### PR TITLE
fix(release): exclude runtime artifact cache from portable

### DIFF
--- a/scripts/build/portable-file-policy.test.ts
+++ b/scripts/build/portable-file-policy.test.ts
@@ -1,0 +1,17 @@
+import {describe, expect, it} from "vitest";
+
+import {shouldIncludePortableFile} from "nbook/scripts/build/portable-file-policy";
+
+describe("Windows Portable 文件策略", () => {
+    it("排除运行时 artifact cache", () => {
+        expect(shouldIncludePortableFile(".agent/workspace/runtime-artifact-import-cache/profile-compiler/a.mjs")).toBe(false);
+    });
+
+    it("兼容 Windows 路径分隔符", () => {
+        expect(shouldIncludePortableFile(".agent\\workspace\\runtime-artifact-import-cache\\profile-compiler\\a.mjs")).toBe(false);
+    });
+
+    it("保留正常的 tracked 文件", () => {
+        expect(shouldIncludePortableFile("scripts/deploy/windows-portable-manager.ts")).toBe(true);
+    });
+});

--- a/scripts/build/portable-file-policy.ts
+++ b/scripts/build/portable-file-policy.ts
@@ -1,0 +1,7 @@
+const EXCLUDED_PORTABLE_PREFIX = ".agent/workspace/runtime-artifact-import-cache/";
+
+/** 判断文件是否可以进入 Windows Portable staging。 */
+export function shouldIncludePortableFile(path: string): boolean {
+    const normalized = path.replaceAll("\\", "/");
+    return !normalized.startsWith(EXCLUDED_PORTABLE_PREFIX);
+}

--- a/scripts/deploy/windows-portable-manager.ts
+++ b/scripts/deploy/windows-portable-manager.ts
@@ -12,6 +12,7 @@ import {installManagedBun, installManagerExecutable, writeManagerWrapper, writeR
 import {installManagedTool, writeManagedToolWrappers} from "nbook/packages/neuro-book-manager/src/tools";
 import type {InstallationManifest} from "nbook/packages/neuro-book-manager/src/types";
 import {MANAGER_VERSION} from "nbook/packages/neuro-book-manager/src/version-info";
+import {shouldIncludePortableFile} from "nbook/scripts/build/portable-file-policy";
 import {run, runCapture} from "nbook/scripts/utils/process.mjs";
 import {writeZipArchive} from "nbook/scripts/utils/zip";
 
@@ -123,6 +124,7 @@ async function trackedFiles(): Promise<string[]> {
     const indexedFiles = (await runCapture("git", ["ls-files", "-z"], {cwd: ROOT}))
         .split("\0")
         .filter(Boolean)
+        .filter(shouldIncludePortableFile)
         .filter((path) => !path.startsWith("packages/neuro-book-manager/dist/"));
     const existingFiles: string[] = [];
     const skippedFiles: string[] = [];


### PR DESCRIPTION
## Summary

- Exclude `.agent/workspace/runtime-artifact-import-cache/` from Windows Portable staging.
- Add path-policy regression tests for POSIX and Windows separators.

## Why

Runtime artifact import caches are build-time intermediates and must not be copied into the portable package. Keeping them out prevents thousands of small cache files from inflating the Windows archive and slowing extraction.

## Validation

- `node --experimental-strip-types` assertions for the path policy: passed
- TypeScript check for `scripts/build/portable-file-policy.ts`: passed
- Project Vitest command was not runnable in this checkout because Bun and repository dependencies are not installed.

Fixes #5
