### PR TITLE
fix(build): resolve Product islands from package graph

### DIFF
--- a/scripts/build/product-bundle-plugins.test.ts
+++ b/scripts/build/product-bundle-plugins.test.ts
@@ -1,5 +1,6 @@
 import {execFile} from "node:child_process";
 import {mkdtemp, mkdir, rm, writeFile} from "node:fs/promises";
+import {tmpdir} from "node:os";
 import {join, resolve} from "node:path";
 import {pathToFileURL} from "node:url";
 import {promisify} from "node:util";
@@ -11,6 +12,29 @@ import {productRuntimeCompatibilityPlugin} from "nbook/scripts/build/product-bun
 const execFileAsync = promisify(execFile);
 
 describe("Product bundle plugins", () => {
+    it("在 gaxios 稳定源码路径内投影 node-fetch fallback", async () => {
+        const root = await mkdtemp(join(tmpdir(), "nbook-gaxios-plugin-"));
+        try {
+            const sourcePath = join(root, "gaxios", "build", "cjs", "src", "gaxios.js");
+            await mkdir(join(root, "gaxios", "build", "cjs", "src"), {recursive: true});
+            await writeFile(sourcePath, [
+                "export const fetchImplementation = (await import('node-fetch')).default;",
+            ].join("\n"), "utf8");
+            const result = await build({
+                entryPoints: [sourcePath],
+                bundle: true,
+                format: "esm",
+                platform: "node",
+                write: false,
+                plugins: [productRuntimeCompatibilityPlugin()],
+            });
+            expect(result.outputFiles[0]!.text).toContain("globalThis.fetch.bind(globalThis)");
+            expect(result.outputFiles[0]!.text).not.toContain("node-fetch");
+        } finally {
+            await rm(root, {recursive: true, force: true});
+        }
+    });
+
     it("统一静态化pi-ai已知loader，只保留auth context opaque seam", async () => {
         const probe = await execFileAsync("bun", ["-e", BUN_PLUGIN_PROBE], {
             cwd: process.cwd(),

--- a/scripts/build/product-runtime-bundle.test.ts
+++ b/scripts/build/product-runtime-bundle.test.ts
@@ -61,7 +61,7 @@ describe("Product Runtime bundle", () => {
         const requireFromSource = createRequire(import.meta.url);
         const esbuildEntry = pathToFileURL(requireFromSource.resolve("esbuild")).href;
         const zodEntry = pathToFileURL(requireFromSource.resolve("zod")).href;
-        const gaxiosEntry = pathToFileURL(requireFromSource.resolve("gaxios")).href;
+        const yamlEntry = pathToFileURL(requireFromSource.resolve("yaml")).href;
         const chunkRoot = join(serverRoot, "chunks", "_");
         await Promise.all([
             mkdir(chunkRoot, {recursive: true}),
@@ -82,10 +82,10 @@ describe("Product Runtime bundle", () => {
             `import zod from ${JSON.stringify(zodEntry)};`,
             `import * as zodAgain from ${JSON.stringify(zodEntry)};`,
             'import {JSDOM} from "jsdom";',
-            `import {Gaxios} from ${JSON.stringify(gaxiosEntry)};`,
+            `import YAML from ${JSON.stringify(yamlEntry)};`,
             'const metadata = "../node_modules/.bun/zod@4.3.6/node_modules/zod/index.js";',
             "export {metadata};",
-            "export default [esbuild.transform, zod.string, zodAgain.string, JSDOM, globalThis.__tsVersion, Gaxios];",
+            "export default [esbuild.transform, zod.string, zodAgain.string, JSDOM, globalThis.__tsVersion, YAML.parse];",
         ].join("\n"), "utf8");
         await writeFile(join(chunkRoot, "cfg.mjs"), [
             'import {createRequire} from "node:module";',
@@ -116,7 +116,7 @@ describe("Product Runtime bundle", () => {
         expect(source).toContain("esbuild");
         expect(source).not.toContain(esbuildEntry);
         expect(source).not.toContain(zodEntry);
-        expect(source).not.toContain(gaxiosEntry);
+        expect(source).not.toContain(yamlEntry);
         expect(source).not.toContain("/.bun/");
         expect(source).not.toContain("/.pnpm/");
         expect(source).not.toContain("file:///_entry.js");
@@ -125,7 +125,6 @@ describe("Product Runtime bundle", () => {
         expect(source).toContain("./node_modules/jsdom/lib/api.js");
         expect(source).not.toContain('import("node-fetch")');
         expect(source).not.toContain("import('node-fetch')");
-        expect(source).toContain("globalThis.fetch");
         expect(source).toContain("node_modules/zod/");
         expect(islands.platform).toBe(currentProductPlatform());
         expect(islands.schema).toBe("nbook.product-native-islands/v2");

--- a/scripts/build/product-runtime-islands.test.ts
+++ b/scripts/build/product-runtime-islands.test.ts
@@ -1,0 +1,112 @@
+import {mkdir, mkdtemp, realpath, rm, writeFile} from "node:fs/promises";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, describe, expect, it} from "vitest";
+
+import {
+    productRuntimeIslandDefinitions,
+    productRuntimeIslandPackageNames,
+    productRuntimeIslandSourceRoot,
+} from "nbook/scripts/build/product-runtime-islands";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+    await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, {recursive: true, force: true})));
+});
+
+describe("Product Runtime package island graph", () => {
+    it("从声明 package 内解析未 hoist 的动态与平台依赖", async () => {
+        const root = await createSourceFixture({
+            jsdomDependencies: {"nested-dynamic": "1.0.0"},
+        });
+
+        const definitions = productRuntimeIslandDefinitions();
+        const platformOwner = definitions[1]!.packages[0]!;
+        const nestedPlatformPackage = definitions[1]!.packages[1]!;
+
+        expect(productRuntimeIslandPackageNames(root)).toEqual(expect.arrayContaining([
+            "jsdom",
+            "nested-dynamic",
+            nestedPlatformPackage,
+        ]));
+        await expect(realpath(join(root, "node_modules", "jsdom", "node_modules", "nested-dynamic")))
+            .resolves.toBe(productRuntimeIslandSourceRoot("nested-dynamic", root));
+        await expect(realpath(join(
+            root,
+            "node_modules",
+            ...platformOwner.split("/"),
+            "node_modules",
+            ...nestedPlatformPackage.split("/"),
+        ))).resolves.toBe(productRuntimeIslandSourceRoot(nestedPlatformPackage, root));
+    });
+
+    it("拒绝动态闭包中同名不同版本的 package 实例", async () => {
+        const root = await createSourceFixture({
+            jsdomDependencies: {"parent-a": "1.0.0", "parent-b": "1.0.0"},
+        });
+        for (const [parentName, sharedVersion] of [["parent-a", "1.0.0"], ["parent-b", "2.0.0"]] as const) {
+            const parentRoot = join(root, "node_modules", "jsdom", "node_modules");
+            await writePackage(parentRoot, parentName, "1.0.0", {dependencies: {shared: sharedVersion}});
+            await writePackage(
+                join(parentRoot, parentName, "node_modules"),
+                "shared",
+                sharedVersion,
+            );
+        }
+
+        expect(() => productRuntimeIslandPackageNames(root))
+            .toThrow("Product package island 无法扁平化 shared：1.0.0 != 2.0.0");
+    });
+});
+
+/** 创建具备当前平台静态 islands 的最小 Source Root。 */
+async function createSourceFixture(options: {
+    jsdomDependencies: Record<string, string>;
+}): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "nbook-runtime-islands-"));
+    temporaryRoots.push(root);
+    await writeFile(join(root, "package.json"), `${JSON.stringify({name: "fixture", private: true})}\n`, "utf8");
+    await writePackage(join(root, "node_modules"), "jsdom", "1.0.0", {
+        dependencies: options.jsdomDependencies,
+    });
+    await writePackage(join(root, "node_modules"), "typescript", "1.0.0");
+
+    const staticDefinitions = productRuntimeIslandDefinitions().slice(1);
+    for (const definition of staticDefinitions) {
+        const [owner, ...dependencies] = definition.packages;
+        await writePackage(join(root, "node_modules"), owner, "1.0.0", {
+            optionalDependencies: Object.fromEntries(dependencies.map((packageName) => [packageName, "1.0.0"])),
+        });
+        for (const packageName of dependencies) {
+            await writePackage(
+                join(root, "node_modules", ...owner.split("/"), "node_modules"),
+                packageName,
+                "1.0.0",
+            );
+        }
+    }
+    for (const packageName of options.jsdomDependencies ? Object.keys(options.jsdomDependencies) : []) {
+        await writePackage(join(root, "node_modules", "jsdom", "node_modules"), packageName, "1.0.0");
+    }
+    return root;
+}
+
+/** 写入一个仅用于依赖图解析的最小 package。 */
+async function writePackage(
+    nodeModulesRoot: string,
+    packageName: string,
+    version: string,
+    fields: {
+        dependencies?: Record<string, string>;
+        optionalDependencies?: Record<string, string>;
+    } = {},
+): Promise<void> {
+    const packageRoot = join(nodeModulesRoot, ...packageName.split("/"));
+    await mkdir(packageRoot, {recursive: true});
+    await writeFile(join(packageRoot, "package.json"), `${JSON.stringify({
+        name: packageName,
+        version,
+        ...fields,
+    })}\n`, "utf8");
+}

--- a/scripts/build/product-runtime-islands.ts
+++ b/scripts/build/product-runtime-islands.ts
@@ -1,6 +1,6 @@
-import {readFileSync} from "node:fs";
+import {existsSync, readFileSync, realpathSync} from "node:fs";
 import {createRequire} from "node:module";
-import {dirname, resolve} from "node:path";
+import {dirname, isAbsolute, relative, resolve, sep} from "node:path";
 import {pathToFileURL} from "node:url";
 
 /** Product 中必须保留真实 package 形状的一组运行依赖。 */
@@ -25,10 +25,21 @@ type PackageManifest = {
     name?: string;
     version?: string;
     dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
 };
 
-let cachedDynamicPackages: string[] | undefined;
-let cachedRuntimePackages: string[] | undefined;
+type ResolvedPackage = {
+    name: string;
+    version: string;
+    packageJsonPath: string;
+};
+
+type ProductRuntimeIslandGraph = {
+    definitions: ProductRuntimeIslandDefinition[];
+    packages: Map<string, ResolvedPackage>;
+};
+
+const cachedRuntimeGraphs = new Map<string, ProductRuntimeIslandGraph>();
 
 /**
  * 返回当前平台完整的 package island 登记。
@@ -36,10 +47,18 @@ let cachedRuntimePackages: string[] | undefined;
  * jsdom/undici 会读取 package 相对文件，TypeScript 会读取 `lib/*.d.ts`；它们
  * 不能安全冻结进单文件 bundle。其余纯 JS Provider SDK 仍由 Bun 收入 bundle。
  */
-export function productRuntimeIslandDefinitions(): ProductRuntimeIslandDefinition[] {
+export function productRuntimeIslandDefinitions(sourceRoot = resolve(".")): ProductRuntimeIslandDefinition[] {
+    return runtimeIslandGraph(sourceRoot).definitions.map((definition) => ({
+        ...definition,
+        packages: [...definition.packages],
+    }));
+}
+
+/** 根据已解析的 jsdom 闭包建立当前平台的 package island 合同。 */
+function createRuntimeIslandDefinitions(dynamicPackages: string[]): ProductRuntimeIslandDefinition[] {
     const definitions: ProductRuntimeIslandDefinition[] = [
         {
-            packages: dynamicPackageNames(),
+            packages: dynamicPackages,
             reason: "jsdom/undici 与 TypeScript 在运行时读取 package 相对文件，必须保留真实 package 形状。",
             smoke: "Profile compiler compile/import and Product HTTP startup",
         },
@@ -103,11 +122,8 @@ export function productRuntimeIslandDefinitions(): ProductRuntimeIslandDefinitio
 }
 
 /** 返回供 Bun external 与最终复制共同消费的稳定 package 集合。 */
-export function productRuntimeIslandPackageNames(): string[] {
-    cachedRuntimePackages ??= [...new Set(
-        productRuntimeIslandDefinitions().flatMap((island) => island.packages),
-    )].sort();
-    return [...cachedRuntimePackages];
+export function productRuntimeIslandPackageNames(sourceRoot = resolve(".")): string[] {
+    return [...runtimeIslandGraph(sourceRoot).packages.keys()].sort();
 }
 
 /**
@@ -159,54 +175,149 @@ export function productOpaqueImportDefinitions(): ProductOpaqueImportDefinition[
 }
 
 /**
- * 返回 Source 根中已 hoist 的 package island 目录，并核对 manifest 身份。
- * 不通过 `<package>/package.json` 解析，因为 Sharp 等包会用 exports 隐藏该 subpath。
+ * 返回依赖图中已登记 package island 的真实目录，并核对 manifest 身份。
+ * 该目录可以位于 Bun/pnpm 的嵌套 store，不要求 package 被 hoist 到根 node_modules。
  */
 export function productRuntimeIslandSourceRoot(packageName: string, sourceRoot = resolve(".")): string {
-    const packageRoot = resolve(sourceRoot, "node_modules", ...packageName.split("/"));
-    const manifest = readPackageManifest(resolve(packageRoot, "package.json"));
-    if (manifest.name !== packageName || typeof manifest.version !== "string" || !manifest.version) {
-        throw new Error(`Product package island Source 身份无效：${packageName} (${packageRoot})`);
+    const resolvedPackage = runtimeIslandGraph(sourceRoot).packages.get(packageName);
+    if (!resolvedPackage) {
+        throw new Error(`Product package island 未登记 Source：${packageName}`);
     }
-    return packageRoot;
+    return dirname(resolvedPackage.packageJsonPath);
 }
 
 /**
- * 解析 jsdom 的运行依赖闭包并要求所有实例可安全扁平化到 Product node_modules。
- * 出现同名不同版本时直接失败，不能静默复制错误版本。
+ * 按 Source Root 解析 Product package island 依赖图。
+ *
+ * 传递依赖从声明它的 package 实例解析，不假定它被 hoist 到根 node_modules。
+ * 最终 Product 会把这些实例扁平复制，因此同名不同版本仍然直接失败。
  */
-function dynamicPackageNames(): string[] {
-    if (cachedDynamicPackages) return [...cachedDynamicPackages];
-    const rootRequire = createRequire(pathToFileURL(resolve("package.json")));
-    const queue = [rootRequire.resolve("jsdom/package.json")];
+function runtimeIslandGraph(sourceRoot: string): ProductRuntimeIslandGraph {
+    const canonicalSourceRoot = realpathSync.native(resolve(sourceRoot));
+    const cacheKey = process.platform === "win32"
+        ? canonicalSourceRoot.toLowerCase()
+        : canonicalSourceRoot;
+    const cached = cachedRuntimeGraphs.get(cacheKey);
+    if (cached) return cached;
+
+    const sourceNodeModulesRoot = realpathSync.native(resolve(canonicalSourceRoot, "node_modules"));
+    const packages = new Map<string, ResolvedPackage>();
     const visited = new Set<string>();
-    const packages = new Map<string, {version: string; packageJsonPath: string}>();
+    const queue = [resolveRootPackageManifest(canonicalSourceRoot, "jsdom")];
     while (queue.length > 0) {
-        const packageJsonPath = queue.shift()!;
-        const identityPath = resolve(packageJsonPath).toLowerCase();
+        const packageJsonPath = realpathSync.native(queue.shift()!);
+        assertPackageInsideSource(sourceNodeModulesRoot, packageJsonPath);
+        const identityPath = process.platform === "win32" ? packageJsonPath.toLowerCase() : packageJsonPath;
         if (visited.has(identityPath)) continue;
         visited.add(identityPath);
+        const resolvedPackage = registerResolvedPackage(packages, packageJsonPath);
         const manifest = readPackageManifest(packageJsonPath);
-        const name = manifest.name;
-        const version = manifest.version;
-        if (!name || !version) throw new Error(`Product dynamic island package 缺少 name/version：${packageJsonPath}`);
-        const existing = packages.get(name);
-        if (existing && existing.version !== version) {
-            throw new Error(`Product dynamic island 无法扁平化 ${name}：${existing.version} != ${version}`);
-        }
-        const hoistedPath = resolvePackageManifest(rootRequire, name);
-        const hoisted = readPackageManifest(hoistedPath);
-        if (hoisted.name !== name || hoisted.version !== version) {
-            throw new Error(`Product dynamic island 与 hoisted package 身份不一致：${name}@${version}`);
-        }
-        packages.set(name, {version, packageJsonPath});
-        const requireFromPackage = createRequire(pathToFileURL(packageJsonPath));
         for (const dependency of Object.keys(manifest.dependencies ?? {}).sort()) {
-            queue.push(resolvePackageManifest(requireFromPackage, dependency));
+            queue.push(resolveDependencyManifest(resolvedPackage, dependency));
         }
     }
-    cachedDynamicPackages = ["typescript", ...packages.keys()].sort();
-    return [...cachedDynamicPackages];
+
+    const dynamicPackages = ["typescript", ...packages.keys()].sort();
+    const definitions = createRuntimeIslandDefinitions(dynamicPackages);
+    const registeredNames = new Set(definitions.flatMap((definition) => definition.packages));
+
+    const typescriptManifest = realpathSync.native(resolveRootPackageManifest(canonicalSourceRoot, "typescript"));
+    assertPackageInsideSource(sourceNodeModulesRoot, typescriptManifest);
+    registerResolvedPackage(packages, typescriptManifest);
+
+    for (const definition of definitions.slice(1)) {
+        const ownerName = definition.packages[0]!;
+        const ownerManifest = realpathSync.native(resolveRootPackageManifest(canonicalSourceRoot, ownerName));
+        assertPackageInsideSource(sourceNodeModulesRoot, ownerManifest);
+        const owner = registerResolvedPackage(packages, ownerManifest);
+        for (const packageName of definition.packages.slice(1)) {
+            const packageJsonPath = realpathSync.native(resolveDependencyManifest(owner, packageName));
+            assertPackageInsideSource(sourceNodeModulesRoot, packageJsonPath);
+            registerResolvedPackage(packages, packageJsonPath);
+        }
+    }
+
+    const missingPackages = [...registeredNames].filter((packageName) => !packages.has(packageName)).sort();
+    if (missingPackages.length > 0) {
+        throw new Error(`Product package island 缺少 Source package：${missingPackages.join(", ")}`);
+    }
+
+    const graph = {definitions, packages};
+    cachedRuntimeGraphs.set(cacheKey, graph);
+    return graph;
+}
+
+/** 从 Source 根的直接依赖槽读取 package manifest。 */
+function resolveRootPackageManifest(sourceRoot: string, packageName: string): string {
+    const packageJsonPath = resolve(sourceRoot, "node_modules", ...packageName.split("/"), "package.json");
+    const manifestPath = packageManifestAt(packageJsonPath, packageName);
+    if (manifestPath) return manifestPath;
+    throw new Error(`Product package island 无法解析根依赖：${packageName}`);
+}
+
+/**
+ * 从声明依赖的 package 实例解析目标 manifest。
+ *
+ * 先按标准 nested node_modules 查找，再检查 Bun/pnpm store 的同级依赖槽；最后才
+ * 交给 Node resolver 处理其他标准布局。调用方仍会拒绝 Source Root 外的结果。
+ */
+function resolveDependencyManifest(owner: ResolvedPackage, packageName: string): string {
+    const ownerRoot = dirname(owner.packageJsonPath);
+    const packageParts = packageName.split("/");
+    const candidates = [
+        resolve(ownerRoot, "node_modules", ...packageParts, "package.json"),
+        resolve(ownerNodeModulesRoot(owner), ...packageParts, "package.json"),
+    ];
+    for (const candidate of candidates) {
+        const packageJsonPath = packageManifestAt(candidate, packageName);
+        if (packageJsonPath) return packageJsonPath;
+    }
+    const requireFromOwner = createRequire(pathToFileURL(owner.packageJsonPath));
+    return resolvePackageManifest(requireFromOwner, packageName);
+}
+
+/** 定位当前 package 实例所在的 node_modules 层。 */
+function ownerNodeModulesRoot(owner: ResolvedPackage): string {
+    let directory = dirname(owner.packageJsonPath);
+    for (const _part of owner.name.split("/")) directory = dirname(directory);
+    return directory;
+}
+
+/** 读取一个确定 package 槽；槽存在但身份不符时直接拒绝。 */
+function packageManifestAt(packageJsonPath: string, packageName: string): string | undefined {
+    if (!existsSync(packageJsonPath)) return undefined;
+    const manifest = readPackageManifest(packageJsonPath);
+    if (manifest.name !== packageName) {
+        throw new Error(`Product package island Source 身份无效：${packageName} (${packageJsonPath})`);
+    }
+    return packageJsonPath;
+}
+
+/** 登记一个实际 package 实例，并拒绝扁平复制会冲突的同名多版本。 */
+function registerResolvedPackage(
+    packages: Map<string, ResolvedPackage>,
+    packageJsonPath: string,
+): ResolvedPackage {
+    const manifest = readPackageManifest(packageJsonPath);
+    const name = manifest.name;
+    const version = manifest.version;
+    if (!name || !version) {
+        throw new Error(`Product package island package 缺少 name/version：${packageJsonPath}`);
+    }
+    const resolvedPackage = {name, version, packageJsonPath};
+    const existing = packages.get(name);
+    if (existing && existing.version !== version) {
+        throw new Error(`Product package island 无法扁平化 ${name}：${existing.version} != ${version}`);
+    }
+    if (!existing) packages.set(name, resolvedPackage);
+    return resolvedPackage;
+}
+
+/** 所有 package 实例都必须真实位于当前 Source Root 的 node_modules 内。 */
+function assertPackageInsideSource(sourceNodeModulesRoot: string, packageJsonPath: string): void {
+    const child = relative(sourceNodeModulesRoot, packageJsonPath);
+    if (child !== "" && child !== ".." && !child.startsWith(`..${sep}`) && !isAbsolute(child)) return;
+    throw new Error(`Product package island 逃逸 Source Root：${packageJsonPath}`);
 }
 
 /** 从 package.json 读取构建期受信 manifest。 */


### PR DESCRIPTION
Closes #24\n\nProduct island dependency resolution now follows each package manifest and supports Bun/pnpm nested layouts without requiring transitive hoists. Same-name different versions still fail closed. Adds clean-install fixtures and removes the gaxios test's accidental parent node_modules dependency.