### PR TITLE
fix(runtime): separate Source Dev lifecycle and shared shutdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "bun run migration:check && nuxt prepare && bun run generate && bun scripts/build/prepare-system-assets.ts --sync-user-assets --force-sync-user-assets && nuxt dev --no-fork",
+    "dev": "bun scripts/cli/source-dev.ts",
+    "dev:runtime": "bun run migration:check && nuxt prepare && bun run generate && bun scripts/build/prepare-system-assets.ts --sync-user-assets --force-sync-user-assets && nuxt dev --no-fork",
     "dev:warmup": "bun scripts/cli/warmup-dev-server.mjs",
     "nuxt:build": "bun scripts/build/build-product-runtime-image.ts",
     "nuxt:build:raw": "nuxt build --dotenv .env.product --preset node-server",

--- a/packages/neuro-book-manager/src/app-commands.test.ts
+++ b/packages/neuro-book-manager/src/app-commands.test.ts
@@ -501,7 +501,7 @@ describe("Manager Bun运行策略", () => {
 
             expect(ownedProcess.spawn).toHaveBeenCalledWith(expect.objectContaining({
                 command: "bun",
-                args: ["--no-install", "run", "dev"],
+                args: ["--no-install", "run", "dev:runtime"],
                 cwd: root,
                 env: expect.objectContaining({BUN: "bun"}),
             }));

--- a/packages/neuro-book-manager/src/app-commands.ts
+++ b/packages/neuro-book-manager/src/app-commands.ts
@@ -6,11 +6,10 @@ import {spawnOwnedProcess} from "@notnotype/owned-process";
 import {
     PRODUCT_BUN_RUNTIME_ARGS,
     PRODUCT_RUNTIME_COMMAND_BOOTSTRAP,
-    PRODUCT_SHUTDOWN_PATH,
-    PRODUCT_SHUTDOWN_TIMEOUT_MS,
     PRODUCT_SHUTDOWN_TOKEN_ENVIRONMENT,
     type ProductRuntimeCommandId,
 } from "nbook/shared/product-runtime-contract";
+import {shutdownNativeProduct} from "nbook/shared/product-runtime-shutdown";
 
 import {enableAuthentication, ensureWritableRuntimeRoots, loadStateEnv} from "#manager/config";
 import {createProductRuntimeEnvironment} from "nbook/shared/product-runtime-environment";
@@ -183,7 +182,7 @@ export async function launchApplication(
     if (execution.kind === "native-product") delete env.NODE_PATH;
     const command = bun;
     const args = manifest.profile === "source-dev"
-        ? ["--no-install", "run", "dev"]
+        ? ["--no-install", "run", "dev:runtime"]
         : productCommandArgs(root, "start");
     if (manifest.profile !== "source-dev" && !await pathExists(productCommandPath(root))) {
         throw new Error("当前安装缺少 Product 启动入口，请执行 neuro-book update；应用更新始终按Profile原子执行。" );
@@ -222,14 +221,14 @@ export async function launchApplication(
         completion,
         shutdown: () => {
             if (!shutdownPromise) {
-                shutdownPromise = shutdownNativeApplication(
+                shutdownPromise = shutdownNativeProduct({
                     port,
-                    shutdownToken,
+                    token: shutdownToken,
                     completion,
-                    async () => {
+                    forceTerminate: async () => {
                         await lease.terminate("shutdown");
                     },
-                );
+                }).then(() => undefined);
             }
             return shutdownPromise;
         },
@@ -589,53 +588,6 @@ async function waitForApplicationReady(
         await new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
     }
     throw new Error(`Product HTTP 健康检查超时：${lastError}`);
-}
-
-/** 请求 Product 自己关闭；协议失败或 30 秒内未退出时由 Owned Process 强制收口。 */
-async function shutdownNativeApplication(
-    port: number,
-    token: string,
-    completion: Promise<{code: number | null; signal: string | null}>,
-    forceTerminate: () => Promise<void>,
-): Promise<void> {
-    const deadline = Date.now() + PRODUCT_SHUTDOWN_TIMEOUT_MS;
-    try {
-        const response = await fetch(`http://127.0.0.1:${String(port)}${PRODUCT_SHUTDOWN_PATH}`, {
-            method: "POST",
-            headers: {authorization: `Bearer ${token}`},
-            signal: AbortSignal.timeout(PRODUCT_SHUTDOWN_TIMEOUT_MS),
-        });
-        if (response.status !== 202) {
-            throw new Error(`Product shutdown 返回 HTTP ${String(response.status)}`);
-        }
-        const result = await waitWithin(completion, Math.max(0, deadline - Date.now()));
-        if (result.signal !== null || result.code !== 0) {
-            throw new Error(`Product graceful shutdown 异常退出：${result.signal ?? result.code}`);
-        }
-    } catch (error) {
-        console.warn(`Product graceful shutdown 失败，转为强制收口：${error instanceof Error ? error.message : String(error)}`);
-        await forceTerminate();
-    }
-}
-
-/** 在固定剩余窗口内等待 Promise，完成后立即释放 timer。 */
-function waitWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-    return new Promise<T>((resolvePromise, rejectPromise) => {
-        const timer = setTimeout(
-            () => rejectPromise(new Error(`Product shutdown 在 ${String(PRODUCT_SHUTDOWN_TIMEOUT_MS)}ms 内未退出`)),
-            timeoutMs,
-        );
-        void promise.then(
-            (value) => {
-                clearTimeout(timer);
-                resolvePromise(value);
-            },
-            (error: unknown) => {
-                clearTimeout(timer);
-                rejectPromise(error);
-            },
-        );
-    });
 }
 
 export async function runPortableForeground(

--- a/scripts/cli/source-dev.ts
+++ b/scripts/cli/source-dev.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+import {randomBytes} from "node:crypto";
+import {spawnOwnedProcess, type OwnedProcessCompletion} from "@notnotype/owned-process";
+import {shutdownNativeProduct} from "nbook/shared/product-runtime-shutdown";
+import {PRODUCT_SHUTDOWN_TOKEN_ENVIRONMENT} from "nbook/shared/product-runtime-contract";
+
+export type SourceDevOptions = {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+};
+
+/**
+ * 运行公开 Source Dev 入口。
+ *
+ * `dev:runtime` 只负责既有准备和 Nuxt 启动；本函数是唯一直接 CLI owner，负责
+ * graceful shutdown、宿主断连兜底和真实退出码传播。Manager 会直接拥有内部入口。
+ */
+export async function runSourceDev(options: SourceDevOptions = {}): Promise<number> {
+    const cwd = options.cwd ?? process.cwd();
+    const inherited = options.env ?? process.env;
+    const token = randomBytes(32).toString("base64url");
+    const configuredHost = inherited.NITRO_HOST?.trim() || inherited.HOST?.trim();
+    const env = {
+        ...inherited,
+        ...configuredHost ? {} : {HOST: "127.0.0.1", NITRO_HOST: "127.0.0.1"},
+        [PRODUCT_SHUTDOWN_TOKEN_ENVIRONMENT]: token,
+    };
+    const port = sourceDevPort(env);
+    const lease = spawnOwnedProcess({
+        command: process.execPath,
+        args: ["--no-install", "run", "dev:runtime"],
+        cwd,
+        env,
+        stdin: "inherit",
+        stdout: "inherit",
+        stderr: "inherit",
+        windowsHide: false,
+        graceMs: 2_000,
+        hardKillWaitMs: 5_000,
+    });
+    const completion = lease.completion.then(productExit);
+    let signalCount = 0;
+    let shutdownPromise: Promise<"graceful" | "forced"> | null = null;
+    let forcedShutdownPromise: Promise<"forced"> | null = null;
+    let rejectShutdownFailure!: (error: unknown) => void;
+    const shutdownFailure = new Promise<never>((_resolve, reject) => {
+        rejectShutdownFailure = reject;
+    });
+
+    const requestShutdown = (): void => {
+        signalCount += 1;
+        if (signalCount === 1) {
+            shutdownPromise = shutdownNativeProduct({
+                port,
+                token,
+                host: sourceDevLoopbackHost(configuredHost),
+                completion,
+                forceTerminate: async () => {
+                    await lease.terminate("shutdown");
+                },
+            });
+            void shutdownPromise.catch(rejectShutdownFailure);
+            return;
+        }
+        if (!forcedShutdownPromise) {
+            forcedShutdownPromise = lease.terminate("shutdown").then(() => "forced" as const);
+            void forcedShutdownPromise.catch(rejectShutdownFailure);
+        }
+    };
+    process.on("SIGINT", requestShutdown);
+    process.on("SIGTERM", requestShutdown);
+
+    try {
+        const result = await Promise.race([lease.completion, shutdownFailure]);
+        const requestedShutdown = forcedShutdownPromise ?? shutdownPromise;
+        if (requestedShutdown) {
+            await requestedShutdown;
+            return 0;
+        }
+        return ownedProcessExitCode(result);
+    } finally {
+        process.off("SIGINT", requestShutdown);
+        process.off("SIGTERM", requestShutdown);
+    }
+}
+
+/** 将Source Dev监听配置收窄为认证shutdown允许使用的loopback地址。 */
+function sourceDevLoopbackHost(host: string | undefined): "127.0.0.1" | "localhost" | "[::1]" {
+    const normalized = host?.toLocaleLowerCase("en-US").replace(/^\[|\]$/gu, "");
+    if (normalized === "localhost") return "localhost";
+    if (normalized === "::" || normalized === "::1") return "[::1]";
+    return "127.0.0.1";
+}
+
+/** Source Dev 继续沿用 Nuxt 的 NUXT_PORT/PORT/default 解析顺序。 */
+function sourceDevPort(env: NodeJS.ProcessEnv): number {
+    const raw = env.NUXT_PORT?.trim() || env.PORT?.trim() || "3000";
+    const port = Number(raw);
+    if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+        throw new Error(`Source Dev端口无效：${raw}`);
+    }
+    return port;
+}
+
+/** 将 Owned Process 终态投影为共享 Product shutdown 合同。 */
+function productExit(result: OwnedProcessCompletion): {code: number | null; signal: string | null} {
+    return {code: result.exitCode, signal: result.signal};
+}
+
+/** 自然退出保留真实 code；signal/异常空终态使用失败码。 */
+function ownedProcessExitCode(result: OwnedProcessCompletion): number {
+    if (result.signal !== null) return 1;
+    return result.exitCode ?? 1;
+}
+
+if (import.meta.main) {
+    process.exitCode = await runSourceDev();
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -24,6 +24,7 @@
         "build/measure-product-runtime-image.ts",
         "build/product-source-path-contract.ts",
         "build/product-runtime-image-builder.ts",
+        "cli/source-dev.ts",
         "deploy/windows-owned-process-smoke.ts",
         "release/create-interrupted-operation.ts",
         "release/install-dependencies.ts",

--- a/server/agent/session/agent-session-store-lease.test.ts
+++ b/server/agent/session/agent-session-store-lease.test.ts
@@ -1,0 +1,135 @@
+import {mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile} from "node:fs/promises";
+import {tmpdir} from "node:os";
+import {dirname, join} from "node:path";
+import {afterEach, describe, expect, it} from "vitest";
+import {
+    acquireAgentSessionStoreLease,
+    acquireAgentSessionStoreLeaseSync,
+    AGENT_SESSION_STORE_LEASE_OWNER_SCHEMA,
+    AgentSessionStoreLeaseHeldError,
+    agentSessionStoreLeasePath,
+    type AgentSessionStoreLeaseOwner,
+} from "nbook/server/agent/session/agent-session-store-lease";
+
+describe("Agent Session Store runtime lease", () => {
+    const roots: string[] = [];
+
+    afterEach(async () => {
+        await Promise.all(roots.splice(0).map((root) => rm(root, {recursive: true, force: true})));
+    });
+
+    it("async runtime owner写入最小版本化metadata且释放后可重取", async () => {
+        const root = await nextRoot();
+        const path = agentSessionStoreLeasePath(root);
+        const releaseRuntime = await acquireAgentSessionStoreLease(root, "runtime");
+        const runtimeOwner = await readOwner(path);
+
+        expect(runtimeOwner).toMatchObject({
+            schema: AGENT_SESSION_STORE_LEASE_OWNER_SCHEMA,
+            kind: "runtime",
+            pid: process.pid,
+        });
+        expect(Object.keys(runtimeOwner).sort()).toEqual([
+            "acquiredAt",
+            "kind",
+            "leaseId",
+            "pid",
+            "runtime",
+            "runtimeVersion",
+            "schema",
+        ]);
+        expect(JSON.stringify(runtimeOwner)).not.toMatch(/argv|cwd|env|token|password/iu);
+
+        await releaseRuntime();
+        const releaseMigration = await acquireAgentSessionStoreLease(root, "migration");
+        expect(await readOwner(path)).toMatchObject({kind: "migration", pid: process.pid});
+        await releaseMigration();
+    });
+
+    it("sync与async owner共享同一物理lease并返回稳定ELOCKED诊断", async () => {
+        const root = await nextRoot();
+        const path = agentSessionStoreLeasePath(root);
+        const releaseRuntime = acquireAgentSessionStoreLeaseSync(root, "runtime");
+        try {
+            const failure = await acquireAgentSessionStoreLease(root, "migration")
+                .catch((error: unknown) => error);
+
+            expect(failure).toBeInstanceOf(AgentSessionStoreLeaseHeldError);
+            expect(failure).toMatchObject({
+                code: "ELOCKED",
+                leasePath: path,
+                owner: expect.objectContaining({kind: "runtime", pid: process.pid}),
+            });
+            expect((failure as AgentSessionStoreLeaseHeldError).heartbeatAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        } finally {
+            releaseRuntime();
+        }
+
+        const releaseMigration = await acquireAgentSessionStoreLease(root, "migration");
+        try {
+            let failure: unknown;
+            try {
+                acquireAgentSessionStoreLeaseSync(root, "runtime");
+            } catch (error) {
+                failure = error;
+            }
+            expect(failure).toMatchObject({
+                code: "ELOCKED",
+                owner: expect.objectContaining({kind: "migration", pid: process.pid}),
+            });
+        } finally {
+            await releaseMigration();
+        }
+    });
+
+    it.each([
+        ["旧空文件", ""],
+        ["损坏metadata", "{not-json"],
+    ])("%s竞争时owner降级为未知，但保留heartbeat", async (_name, metadata) => {
+        const root = await nextRoot();
+        const path = agentSessionStoreLeasePath(root);
+        const release = await acquireAgentSessionStoreLease(root, "runtime");
+        try {
+            await writeFile(path, metadata, "utf8");
+            const failure = await acquireAgentSessionStoreLease(root, "migration")
+                .catch((error: unknown) => error) as AgentSessionStoreLeaseHeldError;
+
+            expect(failure).toBeInstanceOf(AgentSessionStoreLeaseHeldError);
+            expect(failure.owner).toBeNull();
+            expect(failure.heartbeatAt).not.toBeNull();
+            expect(failure.message).toContain("owner：未知");
+        } finally {
+            await release();
+        }
+    });
+
+    it("超过30秒的遗留lock由proper-lockfile协议接管并覆盖owner", async () => {
+        const root = await nextRoot();
+        const path = agentSessionStoreLeasePath(root);
+        await mkdir(dirname(path), {recursive: true});
+        await writeFile(path, "", "utf8");
+        await mkdir(`${path}.lock`);
+        const staleTime = new Date(Date.now() - 31_000);
+        await utimes(`${path}.lock`, staleTime, staleTime);
+
+        const release = await acquireAgentSessionStoreLease(root, "migration");
+        try {
+            expect(await readOwner(path)).toMatchObject({kind: "migration", pid: process.pid});
+            expect((await stat(`${path}.lock`)).mtimeMs).toBeGreaterThan(staleTime.getTime());
+        } finally {
+            await release();
+        }
+    });
+
+    /** 为每个用例建立仓库外隔离 Workspace Root。 */
+    async function nextRoot(): Promise<string> {
+        const root = await mkdtemp(join(tmpdir(), "nbook-session-store-lease-"));
+        roots.push(root);
+        return root;
+    }
+});
+
+/** 读取当前测试 owner metadata。 */
+async function readOwner(path: string): Promise<AgentSessionStoreLeaseOwner> {
+    return JSON.parse(await readFile(path, "utf8")) as AgentSessionStoreLeaseOwner;
+}

--- a/server/agent/session/agent-session-store-lease.ts
+++ b/server/agent/session/agent-session-store-lease.ts
@@ -1,0 +1,219 @@
+import {randomUUID} from "node:crypto";
+import {
+    closeSync,
+    mkdirSync,
+    openSync,
+    readFileSync,
+    statSync,
+    writeFileSync,
+} from "node:fs";
+import {mkdir, open, readFile, stat, writeFile} from "node:fs/promises";
+import {dirname, resolve} from "node:path";
+import {lock, lockSync} from "proper-lockfile";
+
+export const AGENT_SESSION_STORE_LEASE_RELATIVE_PATH = ".nbook/agent/migrations/runtime.lease";
+export const AGENT_SESSION_STORE_LEASE_OWNER_SCHEMA = "nbook.agent-session-store-lease-owner/v1";
+export const AGENT_SESSION_STORE_LEASE_STALE_MS = 30_000;
+export const AGENT_SESSION_STORE_LEASE_HEARTBEAT_MS = 15_000;
+
+const CANONICAL_UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+
+export type AgentSessionStoreLeaseKind = "runtime" | "migration";
+
+/** `runtime.lease` 中仅供本机排障使用的最小 owner 信息。 */
+export type AgentSessionStoreLeaseOwner = {
+    schema: typeof AGENT_SESSION_STORE_LEASE_OWNER_SCHEMA;
+    leaseId: string;
+    kind: AgentSessionStoreLeaseKind;
+    pid: number;
+    acquiredAt: string;
+    runtime: "bun" | "node";
+    runtimeVersion: string;
+};
+
+/** Session Store 已被另一进程占用；owner 只用于诊断，不授予终止或抢锁权限。 */
+export class AgentSessionStoreLeaseHeldError extends Error {
+    readonly code = "ELOCKED" as const;
+
+    constructor(
+        readonly leasePath: string,
+        readonly heartbeatAt: string | null,
+        readonly owner: AgentSessionStoreLeaseOwner | null,
+        cause: unknown,
+    ) {
+        const ownerText = owner
+            ? `报告 owner：pid=${String(owner.pid)} kind=${owner.kind} acquiredAt=${owner.acquiredAt} runtime=${owner.runtime}@${owner.runtimeVersion}`
+            : "报告 owner：未知（旧版或损坏的诊断 metadata）";
+        const heartbeatText = heartbeatAt ? `；heartbeat=${heartbeatAt}` : "";
+        super(
+            `Agent Session Store 正被另一 NeuroBook 进程使用：${leasePath}；${ownerText}${heartbeatText}。`
+            + "请先正常关闭该实例；owner 仍存活时不要删除 runtime.lease.lock。",
+            {cause},
+        );
+        this.name = "AgentSessionStoreLeaseHeldError";
+    }
+}
+
+/** 返回 Workspace Root 对应的 Session Store lease 绝对路径。 */
+export function agentSessionStoreLeasePath(rootWorkspace: string): string {
+    return resolve(rootWorkspace, AGENT_SESSION_STORE_LEASE_RELATIVE_PATH);
+}
+
+/** 获取带 heartbeat 和 owner metadata 的异步 Session Store lease。 */
+export async function acquireAgentSessionStoreLease(
+    rootWorkspace: string,
+    kind: AgentSessionStoreLeaseKind,
+): Promise<() => Promise<void>> {
+    const path = agentSessionStoreLeasePath(rootWorkspace);
+    await mkdir(dirname(path), {recursive: true});
+    const handle = await open(path, "a");
+    await handle.close();
+
+    let release: () => Promise<void>;
+    try {
+        release = await lock(path, {
+            realpath: false,
+            stale: AGENT_SESSION_STORE_LEASE_STALE_MS,
+            update: AGENT_SESSION_STORE_LEASE_HEARTBEAT_MS,
+        });
+    } catch (error) {
+        if (!isLockContention(error)) throw error;
+        throw await leaseHeldError(path, error);
+    }
+    try {
+        await writeFile(path, `${JSON.stringify(currentOwner(kind), null, 2)}\n`, "utf8");
+    } catch (error) {
+        try {
+            await release();
+        } catch (releaseError) {
+            throw new AggregateError(
+                [asError(error), asError(releaseError)],
+                "Session Store lease owner写入失败且锁未能释放。",
+            );
+        }
+        throw error;
+    }
+    return release;
+}
+
+/** 获取启动构造路径使用的同步 Session Store lease。 */
+export function acquireAgentSessionStoreLeaseSync(
+    rootWorkspace: string,
+    kind: AgentSessionStoreLeaseKind,
+): () => void {
+    const path = agentSessionStoreLeasePath(rootWorkspace);
+    mkdirSync(dirname(path), {recursive: true});
+    const handle = openSync(path, "a");
+    closeSync(handle);
+
+    let release: () => void;
+    try {
+        release = lockSync(path, {
+            realpath: false,
+            stale: AGENT_SESSION_STORE_LEASE_STALE_MS,
+            update: AGENT_SESSION_STORE_LEASE_HEARTBEAT_MS,
+        });
+    } catch (error) {
+        if (!isLockContention(error)) throw error;
+        throw leaseHeldErrorSync(path, error);
+    }
+    try {
+        writeFileSync(path, `${JSON.stringify(currentOwner(kind), null, 2)}\n`, "utf8");
+    } catch (error) {
+        try {
+            release();
+        } catch (releaseError) {
+            throw new AggregateError(
+                [asError(error), asError(releaseError)],
+                "Session Store lease owner写入失败且锁未能释放。",
+            );
+        }
+        throw error;
+    }
+    return release;
+}
+
+/** 构造不含 argv/env/cwd/token 的当前 owner。 */
+function currentOwner(kind: AgentSessionStoreLeaseKind): AgentSessionStoreLeaseOwner {
+    const bunVersion = process.versions.bun;
+    return {
+        schema: AGENT_SESSION_STORE_LEASE_OWNER_SCHEMA,
+        leaseId: randomUUID(),
+        kind,
+        pid: process.pid,
+        acquiredAt: new Date().toISOString(),
+        runtime: bunVersion ? "bun" : "node",
+        runtimeVersion: bunVersion ?? process.versions.node,
+    };
+}
+
+/** 读取活跃 `.lock` 的 heartbeat 与持有者声明；诊断读取失败降级为未知。 */
+async function leaseHeldError(path: string, cause: unknown): Promise<AgentSessionStoreLeaseHeldError> {
+    const [owner, heartbeatAt] = await Promise.all([
+        readFile(path, "utf8").then(parseOwner, () => null),
+        stat(`${path}.lock`).then((value) => value.mtime.toISOString(), () => null),
+    ]);
+    return new AgentSessionStoreLeaseHeldError(path, heartbeatAt, owner, cause);
+}
+
+/** 同步调用方使用相同诊断结构。 */
+function leaseHeldErrorSync(path: string, cause: unknown): AgentSessionStoreLeaseHeldError {
+    let owner: AgentSessionStoreLeaseOwner | null = null;
+    let heartbeatAt: string | null = null;
+    try {
+        owner = parseOwner(readFileSync(path, "utf8"));
+    } catch {
+        owner = null;
+    }
+    try {
+        heartbeatAt = statSync(`${path}.lock`).mtime.toISOString();
+    } catch {
+        heartbeatAt = null;
+    }
+    return new AgentSessionStoreLeaseHeldError(path, heartbeatAt, owner, cause);
+}
+
+/** 严格解析外部持久化 owner；旧空文件和未知字段都只视为未知诊断。 */
+function parseOwner(text: string): AgentSessionStoreLeaseOwner | null {
+    let value: unknown;
+    try {
+        value = JSON.parse(text) as unknown;
+    } catch {
+        return null;
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    // JSON 属于外部持久化输入，必须从 unknown 收窄后再读取字段。
+    const owner = value as Record<string, unknown>;
+    const keys = Object.keys(owner).sort();
+    const expected = ["acquiredAt", "kind", "leaseId", "pid", "runtime", "runtimeVersion", "schema"].sort();
+    if (JSON.stringify(keys) !== JSON.stringify(expected)
+        || owner.schema !== AGENT_SESSION_STORE_LEASE_OWNER_SCHEMA
+        || typeof owner.leaseId !== "string"
+        || !CANONICAL_UUID_PATTERN.test(owner.leaseId)
+        || owner.kind !== "runtime" && owner.kind !== "migration"
+        || typeof owner.pid !== "number" || !Number.isSafeInteger(owner.pid) || owner.pid <= 0
+        || typeof owner.acquiredAt !== "string" || Number.isNaN(Date.parse(owner.acquiredAt))
+        || owner.runtime !== "bun" && owner.runtime !== "node"
+        || typeof owner.runtimeVersion !== "string" || owner.runtimeVersion.length === 0) {
+        return null;
+    }
+    return {
+        schema: AGENT_SESSION_STORE_LEASE_OWNER_SCHEMA,
+        leaseId: owner.leaseId,
+        kind: owner.kind,
+        pid: owner.pid,
+        acquiredAt: owner.acquiredAt,
+        runtime: owner.runtime,
+        runtimeVersion: owner.runtimeVersion,
+    };
+}
+
+/** proper-lockfile 在其他 owner 持有 lease 时使用 ELOCKED。 */
+function isLockContention(error: unknown): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "ELOCKED";
+}
+
+/** 将未知失败收窄为可聚合 Error。 */
+function asError(value: unknown): Error {
+    return value instanceof Error ? value : new Error(String(value));
+}

--- a/server/agent/session/agent-session-store.ts
+++ b/server/agent/session/agent-session-store.ts
@@ -1,8 +1,12 @@
 import {createHash} from "node:crypto";
-import {open, mkdir, readFile} from "node:fs/promises";
-import {dirname, resolve} from "node:path";
-import {lock} from "proper-lockfile";
+import {readFile} from "node:fs/promises";
+import {resolve} from "node:path";
 import {absoluteFsPath, type AbsoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {
+    acquireAgentSessionStoreLease,
+    AGENT_SESSION_STORE_LEASE_RELATIVE_PATH,
+    agentSessionStoreLeasePath,
+} from "nbook/server/agent/session/agent-session-store-lease";
 
 /** 当前Agent Session JSONL持久化schema。 */
 export const AGENT_SESSION_SCHEMA_VERSION = 2 as const;
@@ -11,7 +15,7 @@ export const AGENT_SESSION_SCHEMA_VERSION = 2 as const;
 export const AGENT_SESSION_STORE_SENTINEL_VERSION = 1 as const;
 
 /** Runtime与offline migration唯一互斥锁；物理路径沿用Attachment迁移时期的既有路径。 */
-export const AGENT_SESSION_STORE_LEASE_RELATIVE_PATH = ".nbook/agent/migrations/runtime.lease";
+export {AGENT_SESSION_STORE_LEASE_RELATIVE_PATH};
 
 /** Session schema与崩溃恢复状态的唯一sentinel。 */
 export const AGENT_SESSION_STORE_SENTINEL_RELATIVE_PATH = ".nbook/agent/migrations/session-store.json";
@@ -133,9 +137,7 @@ export function agentSessionStoreKey(rootWorkspace: string): string {
 }
 
 /** 返回Workspace Root对应的runtime lease绝对路径。 */
-export function agentSessionStoreLeasePath(rootWorkspace: string): string {
-    return resolve(rootWorkspace, AGENT_SESSION_STORE_LEASE_RELATIVE_PATH);
-}
+export {agentSessionStoreLeasePath};
 
 /** 返回Workspace Root对应的schema sentinel绝对路径。 */
 export function agentSessionStoreSentinelPath(rootWorkspace: string): string {
@@ -184,7 +186,7 @@ export async function acquireReadyAgentSessionStore(rootWorkspace: string): Prom
  * 此入口不共享进程内runtime引用，也不读取sentinel；调用方必须在锁内完成rescan与状态机推进。
  */
 export async function acquireAgentSessionStoreExclusiveLease(rootWorkspace: string): Promise<() => Promise<void>> {
-    return acquirePhysicalLease(rootWorkspace);
+    return acquirePhysicalLease(rootWorkspace, "migration");
 }
 
 /** 在lease保护下读取并严格解析Session Store sentinel。 */
@@ -360,12 +362,11 @@ async function releaseSharedPhysicalLease(key: string, shared: SharedRuntimeLeas
 }
 
 /** 创建lease文件并取得proper-lockfile物理锁。 */
-async function acquirePhysicalLease(rootWorkspace: string): Promise<() => Promise<void>> {
-    const path = agentSessionStoreLeasePath(rootWorkspace);
-    await mkdir(dirname(path), {recursive: true});
-    const handle = await open(path, "a");
-    await handle.close();
-    return lock(path, {realpath: false, stale: 30_000});
+async function acquirePhysicalLease(
+    rootWorkspace: string,
+    kind: "runtime" | "migration" = "runtime",
+): Promise<() => Promise<void>> {
+    return acquireAgentSessionStoreLease(rootWorkspace, kind);
 }
 
 /** complete sentinel必须绑定真实、未篡改且checkpoint一致的migration manifest。 */

--- a/server/agent/session/attachment-migration-gate.ts
+++ b/server/agent/session/attachment-migration-gate.ts
@@ -1,7 +1,10 @@
-import {access, mkdir, open} from "node:fs/promises";
-import {mkdirSync, openSync, closeSync} from "node:fs";
+import {access} from "node:fs/promises";
 import {dirname, join} from "node:path";
-import {lock, lockSync} from "proper-lockfile";
+import {
+    acquireAgentSessionStoreLease,
+    acquireAgentSessionStoreLeaseSync,
+    AGENT_SESSION_STORE_LEASE_RELATIVE_PATH,
+} from "nbook/server/agent/session/agent-session-store-lease";
 
 /** Attachment 硬切迁移使用的 Workspace Root 级 sentinel 相对路径。 */
 export const ATTACHMENT_MIGRATION_LOCK_RELATIVE_PATH = join(
@@ -10,9 +13,7 @@ export const ATTACHMENT_MIGRATION_LOCK_RELATIVE_PATH = join(
     "migrations",
     "attachment-v1.lock",
 );
-export const ATTACHMENT_RUNTIME_LEASE_RELATIVE_PATH = join(
-    ".nbook", "agent", "migrations", "runtime.lease",
-);
+export const ATTACHMENT_RUNTIME_LEASE_RELATIVE_PATH = AGENT_SESSION_STORE_LEASE_RELATIVE_PATH;
 
 const runtimeSyncLeases = new Map<string, {release: () => void; refs: number}>();
 
@@ -40,8 +41,10 @@ export function isAttachmentMigrationInProgressError(error: unknown): error is A
  */
 export class AttachmentMigrationGate {
     readonly lockPath: string;
+    private readonly rootWorkspace: string;
 
     constructor(rootWorkspace: string) {
+        this.rootWorkspace = rootWorkspace;
         this.lockPath = join(rootWorkspace, ATTACHMENT_MIGRATION_LOCK_RELATIVE_PATH);
     }
 
@@ -60,11 +63,7 @@ export class AttachmentMigrationGate {
      * 迁移脚本无法在 Agent 仍运行时取得同一租约，从根上消除 sentinel TOCTOU。
      */
     async acquireRuntimeLease(): Promise<() => Promise<void>> {
-        await mkdir(dirname(this.runtimeLeasePath), {recursive: true});
-        const handle = await open(this.runtimeLeasePath, "a");
-        await handle.close();
-        const releaseLock = await lock(this.runtimeLeasePath, {realpath: false, stale: 30_000});
-        return releaseLock;
+        return acquireAgentSessionStoreLease(this.rootWorkspace, "migration");
     }
 
     /** 同步获取启动期租约，保证 Harness 构造完成前迁移无法插入。 */
@@ -74,10 +73,7 @@ export class AttachmentMigrationGate {
             existing.refs += 1;
             return () => this.releaseRuntimeLeaseSync(this.runtimeLeasePath);
         }
-        mkdirSync(dirname(this.runtimeLeasePath), {recursive: true});
-        const handle = openSync(this.runtimeLeasePath, "a");
-        closeSync(handle);
-        const release = lockSync(this.runtimeLeasePath, {realpath: false, stale: 30_000});
+        const release = acquireAgentSessionStoreLeaseSync(this.rootWorkspace, "runtime");
         runtimeSyncLeases.set(this.runtimeLeasePath, {release, refs: 1});
         return () => this.releaseRuntimeLeaseSync(this.runtimeLeasePath);
     }

--- a/server/agent/session/source-dev-process.integration.test.ts
+++ b/server/agent/session/source-dev-process.integration.test.ts
@@ -1,0 +1,145 @@
+import {spawn, type ChildProcess} from "node:child_process";
+import {createServer} from "node:http";
+import {mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile} from "node:fs/promises";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterEach, describe, expect, it} from "vitest";
+import {acquireAgentSessionStoreLease} from "nbook/server/agent/session/agent-session-store-lease";
+
+describe("Source Dev launcher process lifecycle", () => {
+    const roots: string[] = [];
+    let launcher: ChildProcess | null = null;
+
+    afterEach(async () => {
+        if (launcher?.exitCode === null && launcher.signalCode === null) launcher.kill("SIGKILL");
+        launcher = null;
+        await Promise.all(roots.splice(0).map((root) => rm(root, {recursive: true, force: true})));
+    });
+
+    it.runIf(process.platform === "win32")(
+        "宿主异常退出会收口持有TCP和Runtime lease的完整后代树",
+        async () => {
+            const root = await mkdtemp(join(tmpdir(), "nbook-source-dev-owner-"));
+            roots.push(root);
+            const sourceRoot = join(root, "source");
+            const rootWorkspace = join(root, "workspace");
+            const statePath = join(root, "state.json");
+            const fixturePath = fileURLToPath(new URL("../test/fixtures/source-dev-runtime.ts", import.meta.url));
+            const launcherPath = fileURLToPath(new URL("../../../scripts/cli/source-dev.ts", import.meta.url));
+            const port = await availablePort();
+            await mkdir(sourceRoot, {recursive: true});
+            await writeFile(join(sourceRoot, "package.json"), `${JSON.stringify({
+                private: true,
+                type: "module",
+                scripts: {"dev:runtime": `bun \"${fixturePath.replaceAll("\\", "/")}\"`},
+            }, null, 2)}\n`, "utf8");
+
+            launcher = spawn(process.platform === "win32" ? "bun.exe" : "bun", [launcherPath], {
+                cwd: sourceRoot,
+                env: {
+                    ...process.env,
+                    PORT: String(port),
+                    SOURCE_DEV_FIXTURE_WORKSPACE_ROOT: rootWorkspace,
+                    SOURCE_DEV_FIXTURE_STATE_PATH: statePath,
+                },
+                stdio: ["ignore", "pipe", "pipe"],
+                windowsHide: true,
+            });
+            const state = await waitForState(statePath, launcher);
+
+            launcher.kill("SIGKILL");
+            await waitForChildExit(launcher);
+            await waitForProcessExit(state.pid);
+            await waitForPortRelease(state.port);
+            const stoppedHeartbeat = (await stat(`${state.leasePath}.lock`)).mtimeMs;
+
+            await new Promise((resolvePromise) => setTimeout(resolvePromise, 16_000));
+
+            expect((await stat(`${state.leasePath}.lock`)).mtimeMs).toBe(stoppedHeartbeat);
+            const staleTime = new Date(Date.now() - 31_000);
+            await utimes(`${state.leasePath}.lock`, staleTime, staleTime);
+            const release = await acquireAgentSessionStoreLease(rootWorkspace, "migration");
+            await release();
+        },
+        30_000,
+    );
+});
+
+type FixtureState = {pid: number; port: number; leasePath: string};
+
+/** 获取当前可用loopback端口。 */
+async function availablePort(): Promise<number> {
+    const server = createServer();
+    await new Promise<void>((resolvePromise, rejectPromise) => {
+        server.once("error", rejectPromise);
+        server.listen(0, "127.0.0.1", resolvePromise);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("无法分配Source Dev测试端口");
+    await new Promise<void>((resolvePromise, rejectPromise) => {
+        server.close((error) => error ? rejectPromise(error) : resolvePromise());
+    });
+    return address.port;
+}
+
+/** 等待fixture完成lease与TCP初始化，失败时附带子进程stderr。 */
+async function waitForState(path: string, child: ChildProcess): Promise<FixtureState> {
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => stderr += chunk.toString());
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+        try {
+            return JSON.parse(await readFile(path, "utf8")) as FixtureState;
+        } catch {
+            if (child.exitCode !== null || child.signalCode !== null) {
+                throw new Error(`Source Dev fixture提前退出：${stderr}`);
+            }
+            await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+        }
+    }
+    throw new Error(`等待Source Dev fixture超时：${stderr}`);
+}
+
+/** 等待launcher进程终态。 */
+async function waitForChildExit(child: ChildProcess): Promise<void> {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    await new Promise<void>((resolvePromise, rejectPromise) => {
+        child.once("error", rejectPromise);
+        child.once("close", () => resolvePromise());
+    });
+}
+
+/** 等待目标进程消失。 */
+async function waitForProcessExit(pid: number): Promise<void> {
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+        try {
+            process.kill(pid, 0);
+        } catch {
+            return;
+        }
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+    }
+    throw new Error(`Source Dev后代进程仍存活：pid=${String(pid)}`);
+}
+
+/** 等待fixture TCP端口可再次绑定。 */
+async function waitForPortRelease(port: number): Promise<void> {
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+        const server = createServer();
+        try {
+            await new Promise<void>((resolvePromise, rejectPromise) => {
+                server.once("error", rejectPromise);
+                server.listen(port, "127.0.0.1", resolvePromise);
+            });
+            await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
+            return;
+        } catch {
+            server.close();
+            await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+        }
+    }
+    throw new Error(`Source Dev端口未释放：${String(port)}`);
+}

--- a/server/agent/test/fixtures/source-dev-runtime.ts
+++ b/server/agent/test/fixtures/source-dev-runtime.ts
@@ -1,0 +1,33 @@
+import {createServer} from "node:http";
+import {writeFile} from "node:fs/promises";
+import {acquireAgentSessionStoreLease, agentSessionStoreLeasePath} from "nbook/server/agent/session/agent-session-store-lease";
+
+const rootWorkspace = requiredEnvironment("SOURCE_DEV_FIXTURE_WORKSPACE_ROOT");
+const statePath = requiredEnvironment("SOURCE_DEV_FIXTURE_STATE_PATH");
+const port = Number(requiredEnvironment("PORT"));
+if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`Source Dev fixture端口无效：${String(port)}`);
+}
+
+// 故障fixture刻意不注册关闭处理：宿主消失时必须由Owned Process收口，留下的lock只由stale协议恢复。
+await acquireAgentSessionStoreLease(rootWorkspace, "runtime");
+const server = createServer((_request, response) => {
+    response.writeHead(200, {"content-type": "text/plain"});
+    response.end("source-dev-fixture");
+});
+await new Promise<void>((resolvePromise, rejectPromise) => {
+    server.once("error", rejectPromise);
+    server.listen(port, "127.0.0.1", resolvePromise);
+});
+await writeFile(statePath, `${JSON.stringify({
+    pid: process.pid,
+    port,
+    leasePath: agentSessionStoreLeasePath(rootWorkspace),
+})}\n`, "utf8");
+
+/** 读取 fixture 必需环境变量。 */
+function requiredEnvironment(name: string): string {
+    const value = process.env[name]?.trim();
+    if (!value) throw new Error(`Source Dev fixture缺少${name}`);
+    return value;
+}

--- a/shared/product-runtime-shutdown.test.ts
+++ b/shared/product-runtime-shutdown.test.ts
@@ -1,0 +1,101 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {PRODUCT_SHUTDOWN_PATH} from "nbook/shared/product-runtime-contract";
+import {shutdownNativeProduct} from "nbook/shared/product-runtime-shutdown";
+
+describe("Product Runtime shutdown client", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it("认证请求返回202且Product正常退出时完成graceful shutdown", async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response(null, {status: 202}));
+        const forceTerminate = vi.fn();
+        vi.stubGlobal("fetch", fetchMock);
+
+        await expect(shutdownNativeProduct({
+            port: 43120,
+            token: "test-token",
+            completion: Promise.resolve({code: 0, signal: null}),
+            forceTerminate,
+        })).resolves.toBe("graceful");
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            `http://127.0.0.1:43120${PRODUCT_SHUTDOWN_PATH}`,
+            expect.objectContaining({
+                method: "POST",
+                headers: {authorization: "Bearer test-token"},
+            }),
+        );
+        expect(forceTerminate).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ["未认证", vi.fn().mockResolvedValue(new Response(null, {status: 401}))],
+        ["连接失败", vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED"))],
+    ])("%s时转为Owned Process强制收口", async (_name, fetchMock) => {
+        const forceTerminate = vi.fn().mockResolvedValue(undefined);
+        vi.stubGlobal("fetch", fetchMock);
+
+        await expect(shutdownNativeProduct({
+            port: 43121,
+            token: "test-token",
+            completion: new Promise(() => undefined),
+            forceTerminate,
+            timeoutMs: 20,
+        })).resolves.toBe("forced");
+        expect(forceTerminate).toHaveBeenCalledOnce();
+    });
+
+    it("202后等待退出超时会强制收口", async () => {
+        vi.useFakeTimers();
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, {status: 202})));
+        const forceTerminate = vi.fn().mockResolvedValue(undefined);
+        const shutdown = shutdownNativeProduct({
+            port: 43122,
+            token: "test-token",
+            completion: new Promise(() => undefined),
+            forceTerminate,
+            timeoutMs: 25,
+        });
+
+        await vi.advanceTimersByTimeAsync(25);
+
+        await expect(shutdown).resolves.toBe("forced");
+        expect(forceTerminate).toHaveBeenCalledOnce();
+    });
+
+    it("graceful非零退出会强制收口", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, {status: 202})));
+        const forceTerminate = vi.fn().mockResolvedValue(undefined);
+
+        await expect(shutdownNativeProduct({
+            port: 43123,
+            token: "test-token",
+            completion: Promise.resolve({code: 2, signal: null}),
+            forceTerminate,
+        })).resolves.toBe("forced");
+        expect(forceTerminate).toHaveBeenCalledOnce();
+    });
+
+    it("graceful与force同时失败时保留两条错误链", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("graceful failed")));
+        const forceFailure = new Error("force failed");
+
+        const failure = await shutdownNativeProduct({
+            port: 43124,
+            token: "test-token",
+            completion: new Promise(() => undefined),
+            forceTerminate: async () => {
+                throw forceFailure;
+            },
+        }).catch((error: unknown) => error);
+
+        expect(failure).toBeInstanceOf(AggregateError);
+        expect((failure as AggregateError).errors).toEqual([
+            expect.objectContaining({message: "graceful failed"}),
+            forceFailure,
+        ]);
+    });
+});

--- a/shared/product-runtime-shutdown.ts
+++ b/shared/product-runtime-shutdown.ts
@@ -1,0 +1,93 @@
+import {
+    PRODUCT_SHUTDOWN_PATH,
+    PRODUCT_SHUTDOWN_TIMEOUT_MS,
+} from "nbook/shared/product-runtime-contract";
+
+export type NativeProductExit = {
+    code: number | null;
+    signal: string | null;
+};
+
+export type NativeProductShutdownOptions = {
+    port: number;
+    token: string;
+    /** 只允许调用方从受限联合中选择loopback地址；Manager默认使用IPv4。 */
+    host?: "127.0.0.1" | "localhost" | "[::1]";
+    completion: Promise<NativeProductExit>;
+    forceTerminate(): Promise<void>;
+    /** 测试可缩短关闭窗口；生产始终使用 Product Runtime Contract。 */
+    timeoutMs?: number;
+};
+
+export type NativeProductShutdownResult = "graceful" | "forced";
+
+/**
+ * 先请求 Product 按领域顺序关闭；协议失败或超时后由 Owned Process 强制收口。
+ * graceful 与 force 同时失败时保留两条错误链，调用方不得继续假定进程已经退出。
+ */
+export async function shutdownNativeProduct(
+    options: NativeProductShutdownOptions,
+): Promise<NativeProductShutdownResult> {
+    const timeoutMs = options.timeoutMs ?? PRODUCT_SHUTDOWN_TIMEOUT_MS;
+    const deadline = Date.now() + timeoutMs;
+    const host = options.host ?? "127.0.0.1";
+    let gracefulFailure: unknown;
+    try {
+        const response = await fetch(`http://${host}:${String(options.port)}${PRODUCT_SHUTDOWN_PATH}`, {
+            method: "POST",
+            headers: {authorization: `Bearer ${options.token}`},
+            signal: AbortSignal.timeout(timeoutMs),
+        });
+        if (response.status !== 202) {
+            throw new Error(`Product shutdown 返回 HTTP ${String(response.status)}`);
+        }
+        const result = await waitWithin(options.completion, Math.max(0, deadline - Date.now()), timeoutMs);
+        if (result.signal !== null || result.code !== 0) {
+            throw new Error(`Product graceful shutdown 异常退出：${result.signal ?? result.code}`);
+        }
+        return "graceful";
+    } catch (error) {
+        gracefulFailure = error;
+        console.warn(`Product graceful shutdown 失败，转为强制收口：${errorMessage(error)}`);
+    }
+
+    try {
+        await options.forceTerminate();
+    } catch (forceFailure) {
+        throw new AggregateError(
+            [asError(gracefulFailure), asError(forceFailure)],
+            "Product graceful shutdown 与强制收口均失败",
+        );
+    }
+    return "forced";
+}
+
+/** 在固定剩余窗口内等待 Product 进程终态。 */
+function waitWithin<T>(promise: Promise<T>, timeoutMs: number, contractTimeoutMs: number): Promise<T> {
+    return new Promise<T>((resolvePromise, rejectPromise) => {
+        const timer = setTimeout(
+            () => rejectPromise(new Error(`Product shutdown 在 ${String(contractTimeoutMs)}ms 内未退出`)),
+            timeoutMs,
+        );
+        void promise.then(
+            (value) => {
+                clearTimeout(timer);
+                resolvePromise(value);
+            },
+            (error: unknown) => {
+                clearTimeout(timer);
+                rejectPromise(error);
+            },
+        );
+    });
+}
+
+/** 将未知失败收窄为可聚合的 Error。 */
+function asError(value: unknown): Error {
+    return value instanceof Error ? value : new Error(String(value));
+}
+
+/** 只输出错误摘要，避免把请求凭据带入日志。 */
+function errorMessage(value: unknown): string {
+    return value instanceof Error ? value.message : String(value);
+}

--- a/shared/source-dev-launcher.test.ts
+++ b/shared/source-dev-launcher.test.ts
@@ -1,0 +1,146 @@
+import type {OwnedProcessCompletion, OwnedProcessLease} from "@notnotype/owned-process";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {PRODUCT_SHUTDOWN_TOKEN_ENVIRONMENT} from "nbook/shared/product-runtime-contract";
+
+const mocks = vi.hoisted(() => ({
+    spawnOwnedProcess: vi.fn(),
+    shutdownNativeProduct: vi.fn(),
+}));
+
+vi.mock("@notnotype/owned-process", () => ({
+    spawnOwnedProcess: mocks.spawnOwnedProcess,
+}));
+vi.mock("nbook/shared/product-runtime-shutdown", () => ({
+    shutdownNativeProduct: mocks.shutdownNativeProduct,
+}));
+
+import {runSourceDev} from "nbook/scripts/cli/source-dev";
+
+describe("Source Dev launcher", () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("公开入口以Owned Process启动内部dev:runtime并传播自然退出码", async () => {
+        mocks.spawnOwnedProcess.mockReturnValue(lease(Promise.resolve({exitCode: 7, signal: null})));
+
+        await expect(runSourceDev({
+            cwd: "C:/source-checkout",
+            env: {PORT: "43130", SOURCE_DEV_MARKER: "kept"},
+        })).resolves.toBe(7);
+
+        expect(mocks.spawnOwnedProcess).toHaveBeenCalledWith(expect.objectContaining({
+            command: process.execPath,
+            args: ["--no-install", "run", "dev:runtime"],
+            cwd: "C:/source-checkout",
+            env: expect.objectContaining({
+                PORT: "43130",
+                SOURCE_DEV_MARKER: "kept",
+                HOST: "127.0.0.1",
+                NITRO_HOST: "127.0.0.1",
+                [PRODUCT_SHUTDOWN_TOKEN_ENVIRONMENT]: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/u),
+            }),
+            stdin: "inherit",
+            stdout: "inherit",
+            stderr: "inherit",
+        }));
+    });
+
+    it("首次信号只请求共享graceful shutdown并等待Product终态", async () => {
+        const terminal = deferred<OwnedProcessCompletion>();
+        const ownedLease = lease(terminal.promise);
+        mocks.spawnOwnedProcess.mockReturnValue(ownedLease);
+        mocks.shutdownNativeProduct.mockResolvedValue("graceful");
+        const before = new Set(process.listeners("SIGINT"));
+        const running = runSourceDev({env: {PORT: "43131"}});
+
+        addedSignalListener("SIGINT", before)();
+        terminal.resolve({exitCode: 0, signal: null});
+
+        await expect(running).resolves.toBe(0);
+        expect(mocks.shutdownNativeProduct).toHaveBeenCalledWith(expect.objectContaining({
+            port: 43131,
+            host: "127.0.0.1",
+            completion: expect.any(Promise),
+            forceTerminate: expect.any(Function),
+        }));
+        expect(ownedLease.terminate).not.toHaveBeenCalled();
+    });
+
+    it("显式localhost监听时graceful shutdown使用同一loopback地址", async () => {
+        const terminal = deferred<OwnedProcessCompletion>();
+        mocks.spawnOwnedProcess.mockReturnValue(lease(terminal.promise));
+        mocks.shutdownNativeProduct.mockResolvedValue("graceful");
+        const before = new Set(process.listeners("SIGINT"));
+        const running = runSourceDev({env: {PORT: "43134", HOST: "localhost"}});
+
+        addedSignalListener("SIGINT", before)();
+        terminal.resolve({exitCode: 0, signal: null});
+
+        await expect(running).resolves.toBe(0);
+        expect(mocks.shutdownNativeProduct).toHaveBeenCalledWith(expect.objectContaining({host: "localhost"}));
+    });
+
+    it("第二次信号幂等地立即强制收口，不等待仍挂起的graceful请求", async () => {
+        const terminal = deferred<OwnedProcessCompletion>();
+        const graceful = deferred<"graceful" | "forced">();
+        const ownedLease = lease(terminal.promise);
+        vi.mocked(ownedLease.terminate).mockResolvedValue({
+            exitCode: null,
+            signal: "SIGTERM",
+            terminationReason: "shutdown",
+        });
+        mocks.spawnOwnedProcess.mockReturnValue(ownedLease);
+        mocks.shutdownNativeProduct.mockReturnValue(graceful.promise);
+        const before = new Set(process.listeners("SIGINT"));
+        const running = runSourceDev({env: {PORT: "43132"}});
+        const signal = addedSignalListener("SIGINT", before);
+
+        signal();
+        signal();
+        signal();
+        terminal.resolve({exitCode: null, signal: "SIGTERM", terminationReason: "shutdown"});
+
+        await expect(running).resolves.toBe(0);
+        expect(ownedLease.terminate).toHaveBeenCalledTimes(1);
+        expect(ownedLease.terminate).toHaveBeenCalledWith("shutdown");
+    });
+
+    it("graceful和force均失败时立即向CLI传播AggregateError", async () => {
+        const terminal = deferred<OwnedProcessCompletion>();
+        const failure = new AggregateError([new Error("graceful"), new Error("force")], "shutdown failed");
+        mocks.spawnOwnedProcess.mockReturnValue(lease(terminal.promise));
+        mocks.shutdownNativeProduct.mockRejectedValue(failure);
+        const before = new Set(process.listeners("SIGTERM"));
+        const running = runSourceDev({env: {PORT: "43133"}});
+
+        addedSignalListener("SIGTERM", before)();
+
+        await expect(running).rejects.toBe(failure);
+    });
+});
+
+/** 构造测试用 Owned Process lease。 */
+function lease(completion: Promise<OwnedProcessCompletion>): OwnedProcessLease & {terminate: ReturnType<typeof vi.fn>} {
+    return {
+        completion,
+        terminate: vi.fn().mockResolvedValue({exitCode: 0, signal: null, terminationReason: "shutdown"}),
+    };
+}
+
+/** 找出本次 runSourceDev 注册的信号监听器，避免向 Vitest 自身广播真实信号。 */
+function addedSignalListener(signal: NodeJS.Signals, before: Set<(...args: never[]) => unknown>): () => void {
+    const listener = process.listeners(signal)
+        .find((candidate) => !before.has(candidate as (...args: never[]) => unknown)) as ((value: NodeJS.Signals) => void) | undefined;
+    if (!listener) throw new Error(`Source Dev未注册${signal}监听器`);
+    return () => listener(signal);
+}
+
+/** 创建可精确推进的 Promise。 */
+function deferred<T>(): {promise: Promise<T>; resolve(value: T): void} {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((resolvePromise) => {
+        resolve = resolvePromise;
+    });
+    return {promise, resolve};
+}


### PR DESCRIPTION
Closes #31\n\n## 变更\n- dev 变为 Source Dev 生命周期外壳，实际 Nuxt 链路移到 dev:runtime。\n- Manager Source Dev 使用内部入口，并复用共享 Product graceful shutdown。\n- Session Store 与附件迁移共用带 owner metadata/heartbeat 的 physical lease。\n- 增加 launcher、shutdown、lease 与 Windows descendant lifecycle focused tests。\n\n## 验证\n- 正式 Vitest focused：4 files / 17 tests\n- Manager focused：2 files / 37 tests\n- unx tsc --noEmit -p scripts/tsconfig.json\n- Manager typecheck\n- git diff --check\n\nIssue: #31