### PR TITLE
feat(agent): establish asset install and skill contracts

### DIFF
--- a/assets/workspace/.nbook/agent/skills/skill-creator/SKILL.md
+++ b/assets/workspace/.nbook/agent/skills/skill-creator/SKILL.md
@@ -7,13 +7,15 @@ description: Create or update a Neuro Book skill under .nbook/agent/skills. Use 
 
 Create and maintain skills for the Neuro Book repository.
 
-This project currently discovers skills by scanning `assets/workspace/.nbook/agent/skills/*/SKILL.md` and `workspace/.nbook/agent/skills/*/SKILL.md` (or legacy `skill.md`) and reading only the frontmatter fields `name`, `description`, and `when_to_use`. The skill body is loaded later with `read` from the catalog location only when the model decides the skill is relevant.
+This project follows the [Agent Skills open standard](https://agentskills.io/specification). A skill is a directory whose name is the stable id, with `SKILL.md` at its root. Skills are discovered from the Install Root (`workspace/.nbook/agent/skills/*/SKILL.md`) and, for project-scoped skills, from the current project root. Built-in skills are installed into the Install Root from the packages that ship with NeuroBook; they are not a separate override layer you edit in place.
 
-Treat this as the ground truth while editing skills. Do not design around external Codex conventions that are not implemented in this repo.
+Only the frontmatter is read up front. The body is loaded with `read` from the catalog location later, and only when the model decides the skill is relevant.
+
+The authoritative contract is `reference/agent/skill-package.md`. Treat it as ground truth while editing skills, and do not design around external conventions that this project does not implement.
 
 ## What A Neuro Book Skill Is
 
-Each skill is a folder under `assets/workspace/.nbook/agent/skills/<folder>` or the user overlay `workspace/.nbook/agent/skills/<folder>`.
+Each skill is a folder under the Install Root `workspace/.nbook/agent/skills/<id>`. The folder name is the skill id and must match the frontmatter `name`.
 
 Required file:
 
@@ -40,7 +42,7 @@ Do not create extra process documentation such as `README.md`, `CHANGELOG.md`, o
 
 ## Frontmatter Rules
 
-The current runtime only needs:
+Minimum:
 
 ```yaml
 ---
@@ -49,13 +51,33 @@ description: Explain what the skill does and when it should be used.
 ---
 ```
 
+With the optional fields this project supports:
+
+```yaml
+---
+name: rp-mode
+description: Runs the roleplay protocol. Use when the user asks to start RP, play a character, or advance a tick.
+when_to_use:
+  - 用户要求进入 RP
+  - 用户要求推进 tick
+metadata:
+    displayName: RP 模式
+    version: "1.2.0"
+    author: your-name
+    minAppVersion: "0.8.0"
+license: AGPL-3.0-only
+compatibility: Requires bun and network access
+---
+```
+
 Rules:
 
-- `name` must be usable as `$name`
-- `name` may be English or Chinese
-- `name` must not contain spaces
-- prefer short names because the user may type them in the editor
-- `description` is the main trigger hint, so include both capability and usage context
+- `name` is the stable **id**, not a display label. It must be 1–64 characters, lowercase letters, digits and hyphens only, must not start or end with a hyphen, must not contain consecutive hyphens, and **must equal the parent directory name**.
+- **Chinese names go in `metadata.displayName`, never in `name`.** The id stays ASCII so it can be used as a directory name, an install identity, and a shell path; the interface still shows the Chinese name.
+- `description` is the main trigger hint, so include both capability and usage context.
+- `when_to_use` optionally adds trigger scenarios, as a scalar or a YAML list. It supplements `description`; it does not replace it.
+- Everything else custom goes under `metadata`, which is a flat string map. Do not invent new top-level keys.
+- Prefer short ids because the user may type them in the editor.
 
 Good `description` fields mention:
 
@@ -132,10 +154,12 @@ These scripts are optional accelerators. Do not block on them if the environment
 
 If you cannot run the validator, check these points manually:
 
-- the skill folder lives under `workspace/.nbook/agent/skills` or `assets/workspace/.nbook/agent/skills`
+- the skill folder lives under `workspace/.nbook/agent/skills`, or under the current project root for a project-scoped skill
 - `SKILL.md` exists
-- frontmatter contains only `name` and `description`
-- `name` can be typed as `$name` without spaces
+- `name` is lowercase letters, digits and hyphens, and equals the folder name
+- any Chinese display name is in `metadata.displayName`, not in `name`
+- no custom top-level frontmatter keys beyond `when_to_use`; everything else is under `metadata`
+- `metadata.version` and `metadata.minAppVersion`, when present, are canonical SemVer
 - `description` clearly states when the skill should be used
 - `SKILL.md` does not mention outdated Codex-specific paths or metadata files
 - optional `references/`, `scripts/`, and `assets/` directories are only present when they are actually useful

--- a/assets/workspace/.nbook/agent/skills/skill-creator/scripts/init_skill.py
+++ b/assets/workspace/.nbook/agent/skills/skill-creator/scripts/init_skill.py
@@ -3,12 +3,16 @@
 Create a Neuro Book skill skeleton.
 
 Usage:
-    init_skill.py <folder-name> [--name <skill-name>] [--description <text>]
+    init_skill.py <skill-id> [--display-name <text>] [--description <text>]
         [--path <skills-root>] [--resources scripts,references,assets]
+
+The directory name is the skill id and is written verbatim into the frontmatter
+`name`. Chinese or otherwise non-ASCII labels go to `--display-name`, which is
+emitted as `metadata.displayName`.
 
 Examples:
     init_skill.py plot-helper
-    init_skill.py shuangwen-style --name 爽文风格
+    init_skill.py shuangwen-style --display-name 爽文风格
     init_skill.py lore-tools --resources scripts,references
 """
 
@@ -20,12 +24,13 @@ from pathlib import Path
 MAX_SKILL_NAME_LENGTH = 64
 ALLOWED_RESOURCES = ("scripts", "references", "assets")
 DEFAULT_SKILL_ROOT = Path(__file__).resolve().parents[2]
-SKILL_NAME_PATTERN = re.compile(r"^[^\s\\/]+$", re.UNICODE)
+# id 规则：小写字母数字与连字符，不以连字符开头结尾，不含连续连字符。
+SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 SKILL_TEMPLATE = """---
 name: {skill_name}
 description: {skill_description}
----
+{metadata_block}---
 
 # {skill_title}
 
@@ -79,23 +84,26 @@ Replace this file with a real template, image, sample file, or delete it.
 
 
 def is_valid_skill_name(value: str) -> bool:
-    """Return True when the skill name can be typed as a single `$name` token."""
+    """Return True when the value is a valid skill id."""
     if not value or len(value) > MAX_SKILL_NAME_LENGTH:
         return False
     return SKILL_NAME_PATTERN.match(value) is not None
 
 
-def is_valid_folder_name(value: str) -> bool:
-    """Return True when the folder name is a single directory segment."""
-    return bool(value) and value not in {".", ".."} and "/" not in value and "\\" not in value
+def build_metadata_block(display_name: str) -> str:
+    """Build the optional frontmatter metadata block."""
+    if not display_name:
+        return ""
+    return f"metadata:\n    displayName: {display_name}\n"
 
 
-def build_skill_title(skill_name: str) -> str:
-    """Build a readable heading from the skill name."""
-    if "-" not in skill_name and "_" not in skill_name:
+def build_skill_title(skill_name: str, display_name: str) -> str:
+    """Build a readable heading, preferring the display name when provided."""
+    if display_name:
+        return display_name
+    if "-" not in skill_name:
         return skill_name
-    parts = re.split(r"[-_]+", skill_name)
-    return " ".join(part.capitalize() for part in parts if part)
+    return " ".join(part.capitalize() for part in skill_name.split("-") if part)
 
 
 def parse_resources(raw_resources: str) -> list[str]:
@@ -124,22 +132,22 @@ def write_file(path: Path, content: str, executable: bool = False) -> None:
         path.chmod(0o755)
 
 
-def init_skill(folder_name: str, skill_name: str, description: str, root_path: Path, resources: list[str]) -> int:
+def init_skill(skill_name: str, display_name: str, description: str, root_path: Path, resources: list[str]) -> int:
     """Create the skill directory and starter files."""
-    skill_dir = root_path / folder_name
+    skill_dir = root_path / skill_name
     if skill_dir.exists():
         print(f"[ERROR] Skill directory already exists: {skill_dir}")
         return 1
 
     skill_dir.mkdir(parents=True, exist_ok=False)
 
-    skill_title = build_skill_title(skill_name)
     write_file(
         skill_dir / "SKILL.md",
         SKILL_TEMPLATE.format(
             skill_name=skill_name,
             skill_description=description,
-            skill_title=skill_title,
+            metadata_block=build_metadata_block(display_name),
+            skill_title=build_skill_title(skill_name, display_name),
         ),
     )
 
@@ -169,8 +177,12 @@ def init_skill(folder_name: str, skill_name: str, description: str, root_path: P
 def main() -> int:
     """Parse CLI arguments and create the skill skeleton."""
     parser = argparse.ArgumentParser(description="Create a Neuro Book skill skeleton.")
-    parser.add_argument("folder_name", help="Directory name under the skill root")
-    parser.add_argument("--name", help="Frontmatter skill name. Defaults to folder_name.")
+    parser.add_argument("skill_name", help="Skill id. Becomes both the directory name and frontmatter `name`.")
+    parser.add_argument(
+        "--display-name",
+        default="",
+        help="Interface label written to metadata.displayName. Use this for Chinese names.",
+    )
     parser.add_argument(
         "--description",
         default="[TODO: Explain what this skill does and when it should be used.]",
@@ -179,7 +191,7 @@ def main() -> int:
     parser.add_argument(
         "--path",
         default=str(DEFAULT_SKILL_ROOT),
-        help="Skill root directory. Defaults to assets/agent/skills in this repo.",
+        help="Skill root directory. Defaults to the skills root containing this script.",
     )
     parser.add_argument(
         "--resources",
@@ -188,23 +200,24 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    folder_name = args.folder_name.strip()
-    skill_name = (args.name or folder_name).strip()
+    skill_name = args.skill_name.strip()
+    display_name = args.display_name.strip()
     description = args.description.strip()
     root_path = Path(args.path).resolve()
     resources = parse_resources(args.resources)
 
-    if not is_valid_folder_name(folder_name):
-        print("[ERROR] folder_name must be a single directory name.")
-        return 1
     if not is_valid_skill_name(skill_name):
-        print("[ERROR] skill name must be a single token without spaces or slashes.")
+        print(
+            "[ERROR] skill id must be lowercase letters, digits and hyphens only, "
+            "without leading, trailing or consecutive hyphens. "
+            "Put Chinese names in --display-name."
+        )
         return 1
     if not description:
         print("[ERROR] description cannot be empty.")
         return 1
 
-    return init_skill(folder_name, skill_name, description, root_path, resources)
+    return init_skill(skill_name, display_name, description, root_path, resources)
 
 
 if __name__ == "__main__":

--- a/assets/workspace/.nbook/agent/skills/skill-creator/scripts/quick_validate.py
+++ b/assets/workspace/.nbook/agent/skills/skill-creator/scripts/quick_validate.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """
 Lightweight validator for Neuro Book skills.
+
+Validates against the Agent Skills open standard (https://agentskills.io/specification)
+plus the Neuro Book conventions layered on top of it. See
+`reference/agent/skill-package.md` for the authoritative contract.
 """
 
 import re
@@ -8,6 +12,31 @@ import sys
 from pathlib import Path
 
 MAX_SKILL_NAME_LENGTH = 64
+MAX_DESCRIPTION_LENGTH = 1024
+MAX_COMPATIBILITY_LENGTH = 500
+
+# 标准允许的顶层字段。metadata 是任意 string map，用于承载标准之外的属性。
+# when_to_use 是标准之外的既有扩展：NeuroBook SkillCatalog 与 Claude Code 都消费它，
+# 现存内置 Skill 也在用，因此容忍在顶层出现。
+ALLOWED_TOP_LEVEL_KEYS = {
+    "name",
+    "description",
+    "when_to_use",
+    "license",
+    "compatibility",
+    "metadata",
+    "allowed-tools",
+}
+
+SEMVER_PATTERN = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+
+# id 规则：小写字母数字与连字符，不以连字符开头结尾，不含连续连字符。
+SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
 FORBIDDEN_TERMS = (
     "CODEX_HOME",
     "~/.codex/skills",
@@ -16,21 +45,56 @@ FORBIDDEN_TERMS = (
 )
 
 
-def parse_frontmatter(content: str) -> tuple[dict[str, str], str] | tuple[None, str]:
-    """Extract a flat YAML-like frontmatter block with string values."""
-    match = re.match(r"^---\n(.*?)\n---\n?(.*)$", content, re.DOTALL)
+def strip_quotes(value: str) -> str:
+    """Remove one matching pair of surrounding quotes."""
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def parse_frontmatter(content: str) -> tuple[dict[str, object], str] | tuple[None, str]:
+    """
+    Extract the YAML frontmatter block.
+
+    Supports flat scalar keys, a single nested `metadata` mapping (the only nested
+    structure the Agent Skills standard defines), and a block list under `when_to_use`.
+    """
+    match = re.match(r"^---\r?\n(.*?)\r?\n---\r?\n?(.*)$", content, re.DOTALL)
     if not match:
         return None, "Missing or invalid YAML frontmatter"
 
-    raw_frontmatter = match.group(1)
-    frontmatter: dict[str, str] = {}
+    frontmatter: dict[str, object] = {}
+    metadata: dict[str, str] = {}
+    when_to_use_items: list[str] = []
+    # 当前正在收集的块：None / "metadata" / "when_to_use"
+    open_block: str | None = None
 
-    for raw_line in raw_frontmatter.splitlines():
-        line = raw_line.strip()
-        if not line:
+    for raw_line in match.group(1).splitlines():
+        if not raw_line.strip():
             continue
-        if raw_line[:1].isspace():
-            return None, "Frontmatter must be flat and must not contain nested keys"
+
+        indented = raw_line[:1].isspace()
+        line = raw_line.strip()
+
+        if line.startswith("- "):
+            if open_block != "when_to_use":
+                return None, f"Unexpected list item outside when_to_use: {line}"
+            when_to_use_items.append(strip_quotes(line[2:].strip()))
+            continue
+
+        if indented:
+            if open_block != "metadata":
+                return None, f"Unexpected indented frontmatter line: {line}"
+            if ":" not in line:
+                return None, f"Invalid metadata line: {line}"
+            key, raw_value = line.split(":", 1)
+            key = key.strip()
+            if not key:
+                return None, f"Invalid metadata line: {line}"
+            metadata[key] = strip_quotes(raw_value.strip())
+            continue
+
+        open_block = None
         if ":" not in line:
             return None, f"Invalid frontmatter line: {line}"
 
@@ -39,27 +103,65 @@ def parse_frontmatter(content: str) -> tuple[dict[str, str], str] | tuple[None, 
         value = raw_value.strip()
         if not key:
             return None, f"Invalid frontmatter line: {line}"
-        if value.startswith(("'", '"')) and value.endswith(("'", '"')) and len(value) >= 2:
-            if value[0] == value[-1]:
-                value = value[1:-1]
-        frontmatter[key] = value
+
+        if key == "metadata":
+            if value:
+                return None, "metadata must be a nested mapping, not an inline value"
+            open_block = "metadata"
+            continue
+
+        if key == "when_to_use" and not value:
+            open_block = "when_to_use"
+            continue
+
+        frontmatter[key] = strip_quotes(value)
+
+    if metadata:
+        frontmatter["metadata"] = metadata
+    if when_to_use_items:
+        frontmatter["when_to_use"] = when_to_use_items
 
     return frontmatter, ""
 
 
-def is_valid_skill_name(name: str) -> bool:
-    """Return True when the name matches the current project token rules."""
-    if not name or len(name) > MAX_SKILL_NAME_LENGTH:
-        return False
+def validate_frontmatter(frontmatter: dict[str, object], directory_name: str) -> str:
+    """Return an error message, or an empty string when the frontmatter is valid."""
+    unexpected_keys = sorted(set(frontmatter.keys()) - ALLOWED_TOP_LEVEL_KEYS)
+    if unexpected_keys:
+        joined_keys = ", ".join(unexpected_keys)
+        return f"Unexpected frontmatter keys: {joined_keys}"
 
-    first_char = name[0]
-    if not (first_char.isalpha() or first_char in {"_", "-"}):
-        return False
+    name = str(frontmatter.get("name", "")).strip()
+    if not name:
+        return "Missing 'name' in frontmatter"
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return f"name must be at most {MAX_SKILL_NAME_LENGTH} characters"
+    if not SKILL_NAME_PATTERN.match(name):
+        return (
+            "name must be lowercase letters, digits and hyphens only, "
+            "without leading, trailing or consecutive hyphens"
+        )
+    if name != directory_name:
+        return f"name '{name}' must match the parent directory name '{directory_name}'"
 
-    for char in name[1:]:
-        if not (char.isalpha() or char.isdigit() or char in {"_", "-"}):
-            return False
-    return True
+    description = str(frontmatter.get("description", "")).strip()
+    if not description:
+        return "Missing 'description' in frontmatter"
+    if len(description) > MAX_DESCRIPTION_LENGTH:
+        return f"description must be at most {MAX_DESCRIPTION_LENGTH} characters"
+
+    compatibility = str(frontmatter.get("compatibility", "")).strip()
+    if len(compatibility) > MAX_COMPATIBILITY_LENGTH:
+        return f"compatibility must be at most {MAX_COMPATIBILITY_LENGTH} characters"
+
+    metadata = frontmatter.get("metadata")
+    if isinstance(metadata, dict):
+        for field in ("version", "minAppVersion"):
+            raw = metadata.get(field, "").strip()
+            if raw and not SEMVER_PATTERN.match(raw):
+                return f"metadata.{field} must be a canonical SemVer string"
+
+    return ""
 
 
 def validate_skill(skill_path: Path) -> tuple[bool, str]:
@@ -73,21 +175,9 @@ def validate_skill(skill_path: Path) -> tuple[bool, str]:
     if parsed_frontmatter is None:
         return False, error
 
-    allowed_keys = {"name", "description"}
-    unexpected_keys = sorted(set(parsed_frontmatter.keys()) - allowed_keys)
-    if unexpected_keys:
-        joined_keys = ", ".join(unexpected_keys)
-        return False, f"Unexpected frontmatter keys: {joined_keys}"
-
-    name = parsed_frontmatter.get("name", "").strip()
-    description = parsed_frontmatter.get("description", "").strip()
-
-    if not name:
-        return False, "Missing 'name' in frontmatter"
-    if not is_valid_skill_name(name):
-        return False, "name must be a single token usable as `$name`"
-    if not description:
-        return False, "Missing 'description' in frontmatter"
+    error = validate_frontmatter(parsed_frontmatter, skill_path.name)
+    if error:
+        return False, error
 
     for forbidden_term in FORBIDDEN_TERMS:
         if forbidden_term in content:

--- a/assets/workspace/.nbook/agent/workflows/llmlint-full-review/workflow.ts
+++ b/assets/workspace/.nbook/agent/workflows/llmlint-full-review/workflow.ts
@@ -1,0 +1,447 @@
+/**
+ * 内置 workflow：llmlint 完整审稿（检测 → 报告 → 计划 → 审批 → 修复 → 复测）。
+ *
+ * 在 llmlint-review 基础上加四步：
+ *   - plan：runner（leader.default）读报告 + 命中 JSON + 原文，注入 guide 约束，按「修 / 留 / 问」生成 plan.md（含激进档决定）
+ *   - 审批：wf.ask（approve）让用户在 workflow 面板批准修复计划；拒绝则提前结束
+ *   - fix：adhoc 修复员（只有 read+report_result，无 write 天然不越权）按 plan+guide 重写，返回全文由 runner 落盘 output/
+ *   - retest：复测 check/detect + round metrics 算 verdict（pass/fail）
+ *
+ * 调用前先 `llmlint round begin <files>` 拿轮号，把轮目录传 roundDir（谱系完整）。
+ */
+
+export default {
+    key: "llmlint-full-review",
+    title: "llmlint 完整审稿",
+    description: "对文件执行 llmlint 检测 + 报告 + 修复计划（注入 guide 约束）+ 人工审批 + adhoc 修复 + 复测闭环，返回修后稿路径与复测 verdict。",
+    whenToUse: "用户要对正文做完整 llmlint 审稿并直接修到轮目录（含计划审批和复测判据）时；只想先看报告不修复（用 llmlint-review）、或正文尚未成稿时不要使用。",
+    argsHint: [
+        {name: "files", label: "待审文件（Project Workspace 相对路径，多个用逗号分隔）", defaultValue: "manuscript/002-volume/001-chapter/index.md"},
+        {name: "skillRoot", label: "llmlint skill 根路径（SkillCatalog 提供）", defaultValue: ""},
+        {name: "roundDir", label: "轮目录（建议先 llmlint round begin 拿到）", defaultValue: ".agent/llmlint/review"},
+        {name: "review", label: "审查受众桶：all（创作类默认）或 agent", defaultValue: "all"},
+        {name: "skipDetect", label: "跳过神经检测（正文不离机时用）", defaultValue: "false"},
+        {name: "concurrency", label: "并行文件数（默认 2）", defaultValue: "2"},
+        {name: "aggressiveness", label: "修复激进档：balanced / aggressive / auto（auto 由 plan 生成器根据报告自主决定）", defaultValue: "auto"},
+    ],
+    phases: [
+        {key: "scan", title: "并行 check + detect"},
+        {key: "report", title: "合成审稿报告"},
+        {key: "plan", title: "生成修复计划"},
+        {key: "approve", title: "人工审批计划"},
+        {key: "fix", title: "按计划修复"},
+        {key: "integrity", title: "原文件完整性校验"},
+        {key: "retest", title: "复测与 verdict"},
+    ],
+    run: async (wf, args) => {
+        const skillRoot = typeof args?.skillRoot === "string" && args.skillRoot.trim()
+            ? args.skillRoot.trim()
+            : "";
+        if (!skillRoot) {
+            throw new Error("缺少 skillRoot：llmlint skill 根路径（SkillCatalog 里 llmlint 的 root 字段）");
+        }
+        const rawFiles = Array.isArray(args?.files)
+            ? args.files.filter((f) => typeof f === "string" && f.trim().length > 0).map((f) => f.trim())
+            : typeof args?.files === "string" && args.files.trim()
+                ? args.files.split(",").map((f) => f.trim()).filter(Boolean)
+                : [];
+        if (rawFiles.length === 0) {
+            throw new Error("缺少 files：至少一个 Project Workspace 相对路径");
+        }
+        const files = [...new Set(rawFiles)];
+        const roundDir = typeof args?.roundDir === "string" && args.roundDir.trim()
+            ? args.roundDir.trim()
+            : ".agent/llmlint/review";
+        const review = args?.review === "agent" ? "agent" : "all";
+        const skipDetect = args?.skipDetect === true || args?.skipDetect === "true";
+        const concurrency = Math.max(1, Math.min(Math.floor(Number(args?.concurrency) || 2), 4));
+        // 修复激进档：auto 时由 plan 生成器读报告自主决定（规则见 plan 步骤）；
+        // balanced 保守只修无功能负担项；aggressive 允许按 guide 重写并给关键规则目标值。
+        const aggressiveness = args?.aggressiveness === "aggressive"
+            ? "aggressive"
+            : args?.aggressiveness === "balanced" ? "balanced" : "auto";
+
+        const baseName = (file: string): string => file.split(/[\\/]/u).filter(Boolean).at(-1) ?? "input.md";
+        // 从轮目录末段提取轮号（.agent/llmlint/rounds/0001 → 1）；非标准轮目录时返回 null
+        const roundMatch = /rounds\/(\d+)\/?$/u.exec(roundDir);
+        const roundNumber = roundMatch ? Number.parseInt(roundMatch[1], 10) : null;
+
+        // 单个 CLI 执行器：leader.default 有 bash（adhoc 只有 read），initial 无字段。
+        const runner = await wf.agents.create("leader.default", {
+            initial: {},
+            ephemeral: true,
+            tags: ["workflow:llmlint-full-review", "role:clirunner"],
+        });
+        const runCommand = (command: string) => runner.invoke({
+            mode: "prompt",
+            message: [
+                "用 bash 执行下面这条命令，只把命令的原始 stdout 回报给我（不要加任何额外解释、不要总结）：",
+                "```bash",
+                command,
+                "```",
+            ].join("\n"),
+        });
+
+        // 1. 并行 check + detect
+        wf.progress({phase: "scan", done: 0, total: files.length});
+        wf.chart.node("scan", "并行 check + detect");
+        wf.chart.enter("scan");
+        const scanResults = await wf.map(files, async (file) => {
+            const base = baseName(file);
+            // 单文件用 llmlint round 标准命名（check-source.json / detect-source.json），
+            // 让 round metrics / contribute 能直接读；多文件才用带 basename 的命名。
+            const single = files.length === 1;
+            const checkPath = single ? `${roundDir}/check-source.json` : `${roundDir}/check-${base}.json`;
+            const detectPath = single ? `${roundDir}/detect-source.json` : `${roundDir}/detect-${base}.json`;
+            const detectPart = skipDetect ? "" : `\nbun "${skillRoot}/bin/llmlint.ts" detect "${file}" --format json > "${detectPath}" 2>&1; ec2=$?; echo "DETECT_EXIT=$ec2";`;
+            const command = [
+                `mkdir -p "${roundDir}"`,
+                `bun "${skillRoot}/bin/llmlint.ts" check "${file}" --review ${review} --format json > "${checkPath}" 2>&1; ec1=$?; echo "CHECK_EXIT=$ec1";`,
+                detectPart,
+                `[ -s "${checkPath}" ] && echo "CHECK_OK" || echo "CHECK_FAIL"`,
+                `[ -s "${detectPath}" ] && echo "DETECT_OK" || echo "DETECT_FAIL"`,
+            ].filter((line) => line !== "").join("\n");
+            const outcome = await runCommand(command);
+            if (outcome.status !== "completed") {
+                throw new Error(`文件 ${file} 的 llmlint 执行未完成：${outcome.result.message}`);
+            }
+            const text = outcome.result.message ?? "";
+            return {
+                file, base, checkPath, detectPath,
+                checkOk: text.includes("CHECK_OK"),
+                detectOk: skipDetect || text.includes("DETECT_OK"),
+            };
+        }, {concurrency});
+        wf.chart.leave("scan");
+        wf.progress({phase: "scan", done: files.length, total: files.length});
+
+        // 2. 合成报告（逐文件；detect 失败或跳过的文件只给静态部分）
+        wf.progress({phase: "report", done: 0, total: files.length});
+        wf.chart.node("report", "合成审稿报告");
+        wf.chart.enter("report");
+        const reports: string[] = [];
+        for (const r of scanResults) {
+            if (!r.checkOk) {
+                reports.push(`## ${r.file}\n\n（check 失败，跳过）`);
+                continue;
+            }
+            const detectArg = r.detectOk ? ` --detect "${r.detectPath}"` : "";
+            const outcome = await runCommand(
+                `bun "${skillRoot}/bin/llmlint.ts" report --check "${r.checkPath}"${detectArg}`,
+            );
+            if (outcome.status !== "completed") {
+                reports.push(`## ${r.file}\n\n（report 失败：${outcome.result.message}）`);
+                continue;
+            }
+            const body = (outcome.result.message ?? "")
+                .replace(/^# llmlint 审稿报告\n/u, "")
+                .replace(/^## /gmu, "### ")
+                .replace(/^```[\s\S]*?```\n?/u, "");
+            reports.push(`## ${r.file}\n\n${body.trim()}`);
+        }
+        const reportText = reports.join("\n\n");
+        wf.chart.leave("report");
+        wf.progress({phase: "report", done: files.length, total: files.length});
+
+        // 3. 生成 plan.md（runner 读报告 + 命中 + 原文，注入 guide 约束，按修/留/问分流）
+        //    先取 guide 摘要：语义规则（静态查不到）必须由模型读过才有执行路径。
+        wf.progress({phase: "plan", done: 1, total: 1});
+        wf.chart.node("plan", "生成修复计划");
+        wf.chart.enter("plan");
+        const guideOutcome = await runCommand(`bun "${skillRoot}/bin/llmlint.ts" guide --tier standard`);
+        const guideRaw = guideOutcome.result.message ?? "";
+        const guideText = guideRaw.includes("# 中文正文写作约束要点")
+            ? guideRaw.slice(guideRaw.indexOf("# 中文正文写作约束要点"))
+            : guideRaw;
+        const firstCheck = scanResults.find((r) => r.checkOk)?.checkPath ?? null;
+        const planOutcome = await runner.invoke({
+            mode: "prompt",
+            message: [
+                "你是 llmlint 审稿流程的修复计划生成器。根据审稿报告、命中 JSON 和原文，生成修复计划文件。",
+                "要求：",
+                "1. 用 read 工具读：审稿报告（见下）、check JSON、detect JSON（若有）、原文文件。",
+                "2. 计划按「修 / 留 / 问」三档分流：修=确认无功能的模板负担（给最小改法）；留=承担剧情/人物声音/节奏功能（给保留理由）；问=证据不足或改作者意图（交用户）。",
+                "3. 每项引用行号、原文片段、修复理由。统计摘要（静态命中分级、密度指纹、docPAi/spread、四象限结论）放最前。",
+                "4. 硬伤必须逐字扫描原文（不要只看规则命中）：错别字（如「我了在原地」→「我愣在原地」）、草稿残留（如「薇洛丝（男）」这类括号注释）、语法错误（如「不觉得那是安全」→「不觉得那是安全的」）。全部单列一组，标「必须修」，给行号和最小改法。",
+                "5. 篇幅预算：删减不超过两成（visibleChars 口径），不要为了清零命中而大删。",
+                `6. 用 write 工具把计划写到：${roundDir}/plan.md`,
+                "",
+                `档位决策（aggressiveness = ${aggressiveness}）：`,
+                "- balanced：保守。只修明确无功能负担的命中；承担角色声音/节奏的判「留」。",
+                "- aggressive：允许按 guide 重写模板化表达（不只删压换）；关键规则给目标值——not-is-comparison 修 ≥50%、开头 150 字内不允许连续否定对比、语义规则全部对照。",
+                `- auto：你根据审稿报告自主决定。触发 aggressive 的条件：confirm 象限 ≥3 处，或 not-is-comparison 命中 ≥30，或开头 600 字内连续否定对比 ≥2 处；否则 balanced。把决定写进 plan.md 头部（「档位：X（理由：…）」）。`,
+                "",
+                "写作约束（guide；判「修/留/问」和给改法时对照，尤其「优先注意：静态工具查不出来的」段与「不是A，是B 对比状态机」条）：",
+                guideText,
+                "",
+                `审稿报告：\n${reportText}`,
+                firstCheck ? `check JSON 路径：${firstCheck}` : "",
+            ].join("\n"),
+        });
+        if (planOutcome.status !== "completed") {
+            throw new Error(`plan.md 生成未完成：${planOutcome.result.message}`);
+        }
+        wf.chart.leave("plan");
+
+        // 4. 人工审批（approve：用户在 workflow 面板批准 / 拒绝）
+        wf.progress({phase: "approve", done: 1, total: 1});
+        wf.chart.node("approve", "审批修复计划");
+        wf.chart.enter("approve");
+        const approved = await wf.ask({
+            kind: "approve",
+            title: "批准 llmlint 修复计划？",
+        });
+        wf.chart.leave("approve");
+        if (approved !== true) {
+            wf.log("用户拒绝修复计划，workflow 提前结束，plan.md 已保留在轮目录");
+            return {
+                status: "rejected",
+                planPath: `${roundDir}/plan.md`,
+                report: reportText,
+                files: scanResults.map((r) => ({file: r.file, checkJson: r.checkPath, detectJson: r.detectPath, detectOk: r.detectOk})),
+            };
+        }
+
+        // 5. 编辑指令修复：runner 读原文 → workflow 按 ## 分块 → 每块 adhoc 生成结构化编辑指令
+        //    （{original→replacement}，flash 模型稳定输出的形式）→ 合并 → runner 脚本精确应用。
+        //    不再要求模型输出完整全文（实测 flash 系统性只出摘要）；脚本应用保证原文其余部分原样保留。
+        wf.progress({phase: "fix", done: 0, total: files.length});
+        wf.chart.node("fix", "编辑指令修复");
+        wf.chart.enter("fix");
+        const EditSchema = Type.Object({
+            edits: Type.Array(Type.Object({
+                original: Type.String({description: "原文片段：必须在所给块原文中恰好出现一次（唯一匹配）；拿不准就多带上下文词"}),
+                replacement: Type.String({description: "替换文本；删除时为空字符串"}),
+                note: Type.String({description: "规则 id 或硬伤类型 + 一句理由"}),
+            }, {additionalProperties: false})),
+            summary: Type.String({description: "改动总览一句话"}),
+        }, {additionalProperties: false});
+        // 应用脚本（runner 用 node 执行）：逐条唯一匹配替换，非唯一/缺失进 failed，不静默错改。
+        const APPLY_SCRIPT = [
+            "const fs = require(\"fs\");",
+            "const [,, src, editsPath, out] = process.argv;",
+            "const edits = JSON.parse(fs.readFileSync(editsPath, \"utf8\")).edits;",
+            "let t = fs.readFileSync(src, \"utf8\");",
+            "const applied = [], failed = [];",
+            "for (const e of edits) {",
+            "  const esc = e.original.replace(/[.*+?^${}()|[\\]\\\\]/g, \"\\\\$&\");",
+            "  const matches = [...t.matchAll(new RegExp(esc, \"g\"))];",
+            "  if (matches.length !== 1) {",
+            "    failed.push((e.note || \"\") + \"|match\" + matches.length + \"|\" + e.original.slice(0, 30));",
+            "    continue;",
+            "  }",
+            "  const i = matches[0].index;",
+            "  t = t.slice(0, i) + e.replacement + t.slice(i + e.original.length);",
+            "  applied.push(e.note || \"\");",
+            "}",
+            "fs.writeFileSync(out, t);",
+            "console.log(\"APPLIED=\" + applied.length + \" FAILED=\" + failed.length);",
+            "if (failed.length) console.log(\"FAILED_DETAIL=\" + JSON.stringify(failed));",
+        ].join("\n");
+        const fixResults = await wf.map(scanResults, async (r) => {
+            if (!r.checkOk) {
+                return {file: r.file, outputPath: null, skipped: true};
+            }
+            const outputPath = `${roundDir}/output/${r.base}`;
+            // runner 用 bash cat 读原文（read 工具会带行号前缀污染分块）
+            const readOutcome = await runCommand(`cat "${r.file}"`);
+            if (readOutcome.status !== "completed") {
+                return {file: r.file, outputPath, skipped: false, error: `读原文失败：${readOutcome.result.message}`};
+            }
+            const fullText = readOutcome.result.message ?? "";
+            if (fullText.trim().length < 5000) {
+                return {file: r.file, outputPath, skipped: false, error: `原文读取不完整（${fullText.trim().length} 字符）`};
+            }
+
+            // 按 "## " 标题分块；frontmatter 与首个标题前内容原样保留（不参与修复）
+            const lines = fullText.split("\n");
+            const titleIdx: number[] = [];
+            lines.forEach((line, index) => {
+                if (/^##\s/u.test(line)) titleIdx.push(index);
+            });
+            const chunks: Array<{title: string; startLine: number; endLine: number; text: string}> = [];
+            if (titleIdx.length === 0) {
+                chunks.push({title: "全文", startLine: 1, endLine: lines.length, text: fullText});
+            } else {
+                for (let k = 0; k < titleIdx.length; k++) {
+                    const start = titleIdx[k]!;
+                    const end = k + 1 < titleIdx.length ? titleIdx[k + 1]! : lines.length;
+                    chunks.push({
+                        title: lines[start]!.replace(/^##\s*/u, "").slice(0, 20),
+                        startLine: start + 1,
+                        endLine: end,
+                        text: lines.slice(start, end).join("\n"),
+                    });
+                }
+            }
+
+            // 逐块生成编辑指令
+            const allEdits: Array<{original: string; replacement: string; note: string}> = [];
+            for (const chunk of chunks) {
+                const fixer = await wf.agents.create("adhoc", {
+                    initial: {
+                        name: "llmlint 编辑指令生成员",
+                        systemPrompt: "你是中文小说正文修复员。按修复计划与写作约束，对指定的一块正文输出结构化编辑指令（原文片段→替换文本）。只改表达，不改剧情、人设、时间线、叙事视角；对白保留角色声音；不新增原文没有的事件。",
+                        outputSchema: EditSchema,
+                    },
+                    ephemeral: true,
+                    tags: ["workflow:llmlint-full-review", "role:fixer", `file:${r.base}`, `chunk:${chunk.title}`],
+                });
+                const outcome = await fixer.invoke({
+                    mode: "prompt",
+                    message: [
+                        `对「${chunk.title}」这一节（对应全文 L${chunk.startLine}-L${chunk.endLine}）生成 llmlint 编辑指令。`,
+                        "",
+                        "步骤：",
+                        `1. 用 read 工具读修复计划：${roundDir}/plan.md（档位写在头部；行号是全文件行号，只处理落在 L${chunk.startLine}-L${chunk.endLine} 范围内的「修」组与「必须修」条目；「留」「问」组一律不动）。`,
+                        "2. 对照下面【本块原文】，逐条生成编辑指令。",
+                        "3. report_result.data 返回 {edits, summary}：",
+                        "   edits 每项：",
+                        "   - original：原文片段。**必须在【本块原文】中恰好出现一次**（唯一匹配）；拿不准就多带前后几个字确保唯一；禁止用「完全」「一种」「频率」这类孤立短词；只改这一块的原文，不要包含本块之外的文字。",
+                        "   - replacement：替换文本；删除时为空字符串。",
+                        "   - note：规则 id（如 story-deslop.not-is-comparison）或硬伤类型 + 一句理由。",
+                        "   summary：改动总览一句话。",
+                        "",
+                        "【本块原文】",
+                        chunk.text,
+                        "",
+                        "修复纪律：",
+                        "- 只改表达，不改剧情、人设、时间线、叙事视角；不新增原文没有的事件。",
+                        "- 按「删 → 压 → 换」处理；篇幅删减不超过两成。",
+                        "- 对白保留角色声音；拿不准的归「问」，不要擅改。",
+                        "",
+                        "写作约束（guide，逐条对照；plan 档位为 aggressive 时允许按它重写模板化表达，不只删压换）：",
+                        guideText,
+                    ].join("\n"),
+                });
+                if (outcome.status !== "completed") {
+                    return {file: r.file, outputPath, skipped: false, error: `块「${chunk.title}」指令生成未完成：${outcome.result.message}`};
+                }
+                const data = outcome.result.data as {edits?: Array<{original?: string; replacement?: string; note?: string}>; summary?: string} | null;
+                if (!data || !Array.isArray(data.edits) || data.edits.length === 0) {
+                    // 空 edits 合法（该块无修组命中），继续下一块
+                    continue;
+                }
+                for (const e of data.edits) {
+                    if (typeof e?.original === "string" && e.original.trim().length > 0 && typeof e.replacement === "string") {
+                        allEdits.push({original: e.original, replacement: e.replacement, note: e.note ?? ""});
+                    }
+                }
+            }
+
+            if (allEdits.length === 0) {
+                return {file: r.file, outputPath, skipped: false, error: "所有块都未生成编辑指令（plan 修组可能为空或生成失败）"};
+            }
+
+            // runner 写 edits JSON + apply 脚本，然后 node 应用
+            const editsPath = `${roundDir}/edits-${r.base}.json`;
+            // .cjs：项目位于 type:module 环境，.js 会被当 ESM（require 不可用）
+            const applyPath = `${roundDir}/apply-edits.cjs`;
+            const editsJson = JSON.stringify({edits: allEdits});
+            const writeEdits = await runner.invoke({
+                mode: "prompt",
+                message: [`用 write 工具把下面这份 JSON 写到 ${editsPath}：\n\n${editsJson}`],
+            });
+            if (writeEdits.status !== "completed") {
+                return {file: r.file, outputPath, skipped: false, error: `写 edits JSON 失败：${writeEdits.result.message}`};
+            }
+            const writeScript = await runner.invoke({
+                mode: "prompt",
+                message: [`用 write 工具把下面这份 Node 脚本写到 ${applyPath}：\n\n${APPLY_SCRIPT}`],
+            });
+            if (writeScript.status !== "completed") {
+                return {file: r.file, outputPath, skipped: false, error: `写 apply 脚本失败：${writeScript.result.message}`};
+            }
+            const applyOutcome = await runCommand(`node "${applyPath}" "${r.file}" "${editsPath}" "${outputPath}"`);
+            if (applyOutcome.status !== "completed") {
+                return {file: r.file, outputPath, skipped: false, error: `应用指令失败：${applyOutcome.result.message}`};
+            }
+            const applyText = applyOutcome.result.message ?? "";
+            const appliedMatch = applyText.match(/APPLIED=(\d+)/u);
+            const failedMatch = applyText.match(/FAILED=(\d+)/u);
+            const applied = appliedMatch ? Number.parseInt(appliedMatch[1], 10) : 0;
+            const failed = failedMatch ? Number.parseInt(failedMatch[1], 10) : -1;
+            if (failed > 0 || applied === 0) {
+                const detail = applyText.match(/FAILED_DETAIL=([\s\S]*)$/u)?.[1] ?? "";
+                return {file: r.file, outputPath, skipped: false, error: `应用指令失败（applied=${applied} failed=${failed}）：${detail.slice(0, 300)}`};
+            }
+            return {file: r.file, outputPath, skipped: false, applied, edits: allEdits.length};
+        }, {concurrency});
+        wf.chart.leave("fix");
+        wf.progress({phase: "fix", done: files.length, total: files.length});
+
+        // 6. 原文件完整性校验：若修复阶段仍意外改到原文件，从快照强制回滚。
+        //    修复员本身无 write 权限（天然不越权），这里只兜底 runner 或外部改动。
+        wf.progress({phase: "integrity", done: 0, total: files.length});
+        wf.chart.node("integrity", "校验原文件未被越权修改");
+        wf.chart.enter("integrity");
+        const integrity = await wf.map(scanResults, async (r) => {
+            const snapshot = `${roundDir}/source/${r.base}`;
+            const outcome = await runCommand(
+                `if cmp -s "${r.file}" "${snapshot}"; then echo "ORIGINAL_INTACT"; else cp "${snapshot}" "${r.file}" && echo "ORIGINAL_RESTORED"; fi`,
+            );
+            const text = outcome.result.message ?? "";
+            const restored = text.includes("ORIGINAL_RESTORED");
+            if (restored) {
+                wf.log(`原文件 ${r.file} 被意外修改，已从快照回滚`);
+            }
+            return {file: r.file, restored};
+        }, {concurrency: 1});
+        wf.chart.leave("integrity");
+        wf.progress({phase: "integrity", done: files.length, total: files.length});
+
+        // 7. 复测 check/detect + round metrics（verdict）
+        wf.progress({phase: "retest", done: 0, total: files.length});
+        wf.chart.node("retest", "复测与 verdict");
+        wf.chart.enter("retest");
+        const retests = await wf.map(fixResults, async (r) => {
+            if (!r.outputPath || r.skipped || r.error) {
+                return {file: r.file, verdict: null, message: r.error ?? "skipped"};
+            }
+            const outBase = baseName(r.outputPath);
+            const checkOut = `${roundDir}/check-output.json`;
+            const detectOut = `${roundDir}/detect-output.json`;
+            const detectPart = skipDetect ? "" : `\nbun "${skillRoot}/bin/llmlint.ts" detect "${r.outputPath}" --format json > "${detectOut}" 2>&1; echo "DETECT_EXIT=$?";`;
+            const command = [
+                `bun "${skillRoot}/bin/llmlint.ts" check "${r.outputPath}" --review ${review} --format json > "${checkOut}" 2>&1; echo "CHECK_EXIT=$?";`,
+                detectPart,
+                `[ -s "${checkOut}" ] && echo "CHECK_OK" || echo "CHECK_FAIL"`,
+            ].filter((line) => line !== "").join("\n");
+            const outcome = await runCommand(command);
+            if (outcome.status !== "completed") {
+                return {file: r.file, verdict: null, message: outcome.result.message};
+            }
+            // verdict：round metrics 需要轮号；非标准轮目录时跳过 verdict，只给 JSON 路径
+            if (roundNumber === null) {
+                return {file: r.file, verdict: null, checkOutput: checkOut, detectOutput: detectOut};
+            }
+            const metricsOutcome = await runCommand(
+                `bun "${skillRoot}/bin/llmlint.ts" round metrics ${roundNumber} --format json`,
+            );
+            const metricsText = metricsOutcome.result.message ?? "";
+            let metrics: {staticIssues?: number; densityIssues?: number; docPAi?: number; spread?: number; verdict?: string} = {};
+            try {
+                // runner 可能夹带代码块围栏或解释文字，只提取第一个 { 到最后一个 } 的子串。
+                const jsonMatch = metricsText.match(/\{[\s\S]*\}/u);
+                if (jsonMatch) {
+                    metrics = JSON.parse(jsonMatch[0]) ?? {};
+                }
+            } catch {
+                metrics = {};
+            }
+            return {file: r.file, verdict: metrics.verdict ?? null, checkOutput: checkOut, detectOutput: detectOut, metrics};
+        }, {concurrency});
+        wf.chart.leave("retest");
+        wf.progress({phase: "retest", done: files.length, total: files.length});
+
+        wf.log(`llmlint 完整审稿完成：${files.length} 个文件${skipDetect ? "（跳过 detect）" : ""}`);
+        return {
+            status: "completed",
+            report: reportText,
+            planPath: `${roundDir}/plan.md`,
+            integrity,
+            fixes: fixResults,
+            retests,
+        };
+    },
+};

--- a/assets/workspace/.nbook/agent/workflows/llmlint-review/workflow.ts
+++ b/assets/workspace/.nbook/agent/workflows/llmlint-review/workflow.ts
@@ -1,0 +1,127 @@
+/**
+ * 内置 workflow：llmlint 审稿（检测 + 报告）。
+ *
+ * 用 leader.default agent 作为 CLI 执行器（workflow 求值环境禁止 import/fs，adhoc 无 bash），
+ * 逐文件并行跑 llmlint check + detect，落盘 JSON 到轮目录，再跑 llmlint report 合成审稿报告。
+ *
+ * 调用前建议先 `llmlint round begin <files>` 拿到轮号，把轮目录传给 roundDir；
+ * 不传时默认落 `.agent/llmlint/review/`（多轮会覆盖，长期谱系请用轮目录）。
+ */
+
+export default {
+    key: "llmlint-review",
+    title: "llmlint 审稿",
+    description: "对文件并行执行 llmlint check + detect（AIGC 热力图），落盘 JSON 并合成审稿报告（静态分级 + 密度指纹 + 四象限交叉）。",
+    whenToUse: "用户要对章节/正文做 llmlint 审稿、想要一次拿到静态规则命中 + 神经检测热区 + 四象限报告时；只想查单条规则、或正文尚未成稿时不要使用。",
+    argsHint: [
+        {name: "files", label: "待审文件（Project Workspace 相对路径，多个用逗号分隔）", defaultValue: "manuscript/002-volume/001-chapter/index.md"},
+        {name: "skillRoot", label: "llmlint skill 根路径（SkillCatalog 提供）", defaultValue: ""},
+        {name: "roundDir", label: "JSON 落盘目录（建议传 llmlint round begin 的轮目录）", defaultValue: ".agent/llmlint/review"},
+        {name: "review", label: "审查受众桶：all（创作类默认）或 agent", defaultValue: "all"},
+        {name: "skipDetect", label: "跳过神经检测（正文不离机时用）", defaultValue: "false"},
+        {name: "concurrency", label: "并行文件数（detect 是外部服务，默认 2）", defaultValue: "2"},
+    ],
+    phases: [
+        {key: "scan", title: "并行 check + detect"},
+        {key: "report", title: "合成审稿报告"},
+    ],
+    run: async (wf, args) => {
+        const skillRoot = typeof args?.skillRoot === "string" && args.skillRoot.trim()
+            ? args.skillRoot.trim()
+            : "";
+        if (!skillRoot) {
+            throw new Error("缺少 skillRoot：llmlint skill 根路径（SkillCatalog 里 llmlint 的 root 字段）");
+        }
+        const rawFiles = Array.isArray(args?.files)
+            ? args.files.filter((f) => typeof f === "string" && f.trim().length > 0).map((f) => f.trim())
+            : typeof args?.files === "string" && args.files.trim()
+                ? args.files.split(",").map((f) => f.trim()).filter(Boolean)
+                : [];
+        if (rawFiles.length === 0) {
+            throw new Error("缺少 files：至少一个 Project Workspace 相对路径");
+        }
+        const files = [...new Set(rawFiles)];
+        const roundDir = typeof args?.roundDir === "string" && args.roundDir.trim()
+            ? args.roundDir.trim()
+            : ".agent/llmlint/review";
+        const review = args?.review === "agent" ? "agent" : "all";
+        const skipDetect = args?.skipDetect === true || args?.skipDetect === "true";
+        const concurrency = Math.max(1, Math.min(Math.floor(Number(args?.concurrency) || 2), 4));
+
+        // basename：与 llmlint round 的快照口径一致（含扩展名），仅用于拼输出文件名。
+        const baseName = (file: string): string => file.split(/[\\/]/u).filter(Boolean).at(-1) ?? "input.md";
+
+        wf.progress({phase: "scan", done: 0, total: files.length});
+        wf.chart.node("scan", "并行 check + detect");
+        wf.chart.enter("scan");
+
+        // 单个 CLI 执行器：leader.default 有 bash（adhoc 只有 read），initial 无字段。
+        const runner = await wf.agents.create("leader.default", {
+            initial: {},
+            ephemeral: true,
+            tags: ["workflow:llmlint-review", "role:clirunner"],
+        });
+
+        const results = await wf.map(files, async (file) => {
+            const base = baseName(file);
+            // 单文件用 llmlint round 标准命名（check-source.json / detect-source.json），
+            // 让 round metrics / contribute 能直接读；多文件才用带 basename 的命名。
+            const single = files.length === 1;
+            const checkPath = single ? `${roundDir}/check-source.json` : `${roundDir}/check-${base}.json`;
+            const detectPath = single ? `${roundDir}/detect-source.json` : `${roundDir}/detect-${base}.json`;
+            const detectPart = skipDetect ? "" : `\nbun "${skillRoot}/bin/llmlint.ts" detect "${file}" --format json > "${detectPath}" 2>&1; ec2=$?; echo "DETECT_EXIT=$ec2";`;
+            const command = [
+                `mkdir -p "${roundDir}"`,
+                `bun "${skillRoot}/bin/llmlint.ts" check "${file}" --review ${review} --format json > "${checkPath}" 2>&1; ec1=$?; echo "CHECK_EXIT=$ec1";`,
+                detectPart,
+                `if [ -s "${checkPath}" ]${skipDetect ? "" : ` && [ -s "${detectPath}" ]`}; then`,
+                `  bun "${skillRoot}/bin/llmlint.ts" report --check "${checkPath}"${skipDetect ? "" : ` --detect "${detectPath}"`};`,
+                "else",
+                `  echo "REPORT_SKIPPED"; cat "${checkPath}" 2>/dev/null | head -c 300;`,
+                "fi",
+            ].filter((line) => line !== "").join("\n");
+            const outcome = await runner.invoke({
+                mode: "prompt",
+                message: [
+                    `用 bash 执行下面这条命令，只把命令的原始 stdout 回报给我（不要总结、不要加任何额外解释，命令本身不用回报）：`,
+                    "```bash",
+                    command,
+                    "```",
+                    "注意事项：命令会依次跑 check、detect（可能因外部服务失败）、report；每个文件的 JSON 已重定向落盘，stdout 里主要是 report 的 markdown 或失败提示。",
+                ].join("\n"),
+            });
+            if (outcome.status !== "completed") {
+                throw new Error(`文件 ${file} 的 llmlint 执行未完成：${outcome.result.message}`);
+            }
+            const reportText = outcome.result.message ?? "";
+            const detectFailed = !skipDetect && !reportText.includes("DETECT_EXIT=0");
+            return {file, checkJson: checkPath, detectJson: skipDetect ? null : detectPath, detectFailed, report: reportText};
+        }, {concurrency});
+
+        wf.chart.leave("scan");
+        wf.progress({phase: "scan", done: files.length, total: files.length});
+
+        wf.progress({phase: "report", done: 1, total: 1});
+        wf.chart.node("report", "汇总报告");
+        wf.chart.enter("report");
+
+        const reports = results.map((r) => {
+            const header = `## ${r.file}${r.detectFailed ? "（detect 失败，仅静态部分）" : ""}\n\n`;
+            const body = r.report.replace(/^# llmlint 审稿报告\n/u, "").replace(/^## /gmu, "### ");
+            return header + body;
+        });
+
+        const failedDetect = results.filter((r) => r.detectFailed).map((r) => r.file);
+        wf.log(`llmlint 审稿完成：${files.length} 个文件${skipDetect ? "（跳过 detect）" : failedDetect.length > 0 ? `，${failedDetect.length} 个 detect 失败` : ""}`);
+
+        wf.chart.leave("report");
+        return {
+            files: results.map((r) => ({file: r.file, checkJson: r.checkJson, detectJson: r.detectJson, detectFailed: r.detectFailed})),
+            failedDetect,
+            report: reports.join("\n\n"),
+            review,
+            skipDetect,
+            roundDir,
+        };
+    },
+};

--- a/docs/adr/0011-agent-asset-install-identity.md
+++ b/docs/adr/0011-agent-asset-install-identity.md
@@ -30,6 +30,16 @@ Profile 的真实 key 已使用 `leader.default`、`world.engine` 等点分形�
 - 客户端安装实现必须在落盘前验证包身份、入口与编译产物身份，并把验证纳入同一可回滚事务。
 - TypeScript AST 检查继续只是发布质量门禁。它不能替代进程隔离、权限约束或代码审查。
 
+## 修订（2026-08-01，Task 135）
+
+[Task 135](../tasks/135-agent-asset-install-protocol/README.md) 决定兼容 [Agent Skills 开放标准](https://agentskills.io/specification)，因此 Skill 的身份读取位置发生变化。本 ADR 的核心原则不变——**仍然只有一个安装身份，不新增 `assetKey`，不用 slug 代替**——变的只是 Skill 从哪里读它：
+
+- 决策 1 对 Skill 修订为：`SKILL.md` frontmatter 的 `name` 是安装身份真相源。根 `package.json` 对 Skill 降级为可选，仅在携带 `bin`、`scripts` 或 Bun 安装输入时必需。Workflow 与 Profile 没有 frontmatter，继续以根 `package.json.name` 为身份。
+- 决策 5 对 Skill 修订为：`package.json` 存在时，其 `name` 必须等于 frontmatter `name`；不存在时不做该项校验。Workflow 的 `key` 必须等于 `package.json.name` 不变。
+- 新增：Skill 的展示名是 `metadata.displayName`，允许中文；它**不是**身份，不参与任何安装、更新或覆盖判断。版本读取顺序为 `metadata.version` → `package.json.version`，两处并存时以前者为准。
+
+决策 2、3、4、6、7、8 不变。站点侧尚未实施本修订，详见 [Agent Asset Package Protocol](../../reference/agent/agent-asset-package.md) 的 Pending Site Changes 小节。
+
 ## 未采用方案
 
 - 新增 `assetKey`：会与 `package.json.name`、Workflow key 和 Profile key 形成重复真相源。

--- a/docs/agent/index.md
+++ b/docs/agent/index.md
@@ -89,7 +89,7 @@ world-engine/schema/index.ts
 ## 继续阅读
 
 - [Agent 工具](./tools.md)：完整工具清单，以及什么时候该用文件工具、世界引擎、剧情工具还是 linked agent。
-- [Skill](./skills.md)：16 个内置 Skill 清单、三层覆盖与白名单。
+- [Skill](./skills.md)：17 个内置 Skill 清单、覆盖规则与白名单。
 - [Agent Workflow 与 Job](./workflow.md)：如何用可重放脚本编排多个 session，并通过后台 Job 运行长任务。
 - [Subject RAG 记忆](./subject-rag-memory.md)：保留的数据、索引和工具合同，以及当前自动集成缺口。
 - [Agent Harness](./advanced.md)：session、runtime hooks、SSE、队列和黑盒行为合同。

--- a/docs/agent/skills.md
+++ b/docs/agent/skills.md
@@ -21,6 +21,7 @@ Skill 是一张**可复用的工作流程卡**：告诉 Agent 某一类任务该
 | Skill | 做什么 |
 | --- | --- |
 | `novel-genre-research` | 题材与竞品分析，接榜单数据 |
+| `novel-data` | 本地小说榜单与书籍详情查询，供题材分析取数 |
 | `novel-technique-character-card-workshop` | 重量级角色塑造与人设整理 |
 | `llmlint` | 文风检查与修复，见 [llmlint](/core/llmlint) |
 | `stop-slop` | 写作时去除 AI 腔 |
@@ -46,15 +47,16 @@ Skill 是一张**可复用的工作流程卡**：告诉 Agent 某一类任务该
 
 ## Skill 放在哪
 
-和 workflow 一样是三层覆盖，按目录名寻址：
+Skill 按目录名寻址，目录名就是它的 id：
 
 | 层 | 位置 |
 | --- | --- |
 | 系统内置 | 随 NeuroBook 分发 |
-| 用户层 | Workspace Root 的 `.nbook/agent/skills/<key>/SKILL.md` |
-| 项目层 | 当前项目根的 `.nbook/agent/skills/<key>/SKILL.md` |
+| 用户层 | Workspace Root 的 `.nbook/agent/skills/<id>/SKILL.md` |
 
-`SKILL.md` 用 frontmatter 声明 `name` 和 `description`——**description 决定 Agent 什么时候会想起用它**，所以要写清适用场景而不只是功能名。
+用户层同名目录会整体覆盖系统内置的同名 Skill，不会逐个文件合并。
+
+`SKILL.md` 用 frontmatter 声明 `name` 和 `description`——**description 决定 Agent 什么时候会想起用它**，所以要写清适用场景而不只是功能名。想让界面显示中文名，把 `name` 保持为英文小写 id，中文写进 `metadata.displayName`。
 
 ## 可执行 Skill
 

--- a/docs/en/agent/index.md
+++ b/docs/en/agent/index.md
@@ -89,7 +89,7 @@ The test is one question: does this change as the story moves? If it changes, it
 ## Keep Reading
 
 - [Agent Tools](./tools.md): the full tool list, and when to reach for file tools, the World Engine, plot tools or a linked agent.
-- [Skills](./skills.md): the 16 built-in Skills, three-layer overrides and allowlists.
+- [Skills](./skills.md): the 17 built-in Skills, override rules and allowlists.
 - [Agent Workflows and Jobs](./workflow.md): how to orchestrate several sessions with a replayable script and run long tasks as background jobs.
 - [Subject RAG Memory](./subject-rag-memory.md): the data, index and tool contracts that are preserved, and the gap in automatic integration today.
 - [Agent Harness](./advanced.md): sessions, runtime hooks, SSE, queues and black-box behavior contracts.

--- a/docs/en/agent/skills.md
+++ b/docs/en/agent/skills.md
@@ -21,6 +21,7 @@ It is not a tool and not a script. An agent sees which Skills are available in t
 | Skill | What it does |
 | --- | --- |
 | `novel-genre-research` | Genre and competitor analysis, wired to ranking data |
+| `novel-data` | Queries locally cached novel rankings and book details for genre analysis |
 | `novel-technique-character-card-workshop` | Heavyweight character building and character sheet curation |
 | `llmlint` | Prose style checking and repair, see [llmlint](/en/core/llmlint) |
 | `stop-slop` | Strip the AI voice while you write |
@@ -46,15 +47,16 @@ It is not a tool and not a script. An agent sees which Skills are available in t
 
 ## Where Skills Live
 
-Like workflows, Skills use three-layer overrides, addressed by directory name:
+Skills are addressed by directory name, and that directory name is the skill id:
 
 | Layer | Location |
 | --- | --- |
 | System built-in | Ships with NeuroBook |
-| User layer | `.nbook/agent/skills/<key>/SKILL.md` under the Workspace Root |
-| Project layer | `.nbook/agent/skills/<key>/SKILL.md` under the current project root |
+| User layer | `.nbook/agent/skills/<id>/SKILL.md` under the Workspace Root |
 
-`SKILL.md` declares `name` and `description` in frontmatter — **the description is what makes an agent think of using it**, so spell out when it applies instead of just naming the feature.
+A user-layer directory replaces the built-in skill of the same name wholesale; the two are never merged file by file.
+
+`SKILL.md` declares `name` and `description` in frontmatter — **the description is what makes an agent think of using it**, so spell out when it applies instead of just naming the feature. To show a Chinese label in the interface, keep `name` as the lowercase English id and put the Chinese name in `metadata.displayName`.
 
 ## Runnable Skills
 

--- a/docs/tasks/135-agent-asset-install-protocol/README.md
+++ b/docs/tasks/135-agent-asset-install-protocol/README.md
@@ -1,0 +1,238 @@
+# Agent 资产安装协议
+
+## User Request / Topic
+
+- 继续开发 NeuroBook 的 Skill / Workflow / Profile 协议，新协议写进 `reference/`。
+- 现有更新途径只有「装新版 NeuroBook」，且用户资产覆盖机制复杂丑陋，需要重做。
+- Skill 需要支持安装依赖。
+- 需要支持从 git remote 和 NeuroBook 创意工坊安装、更新资产。
+- 调研外部 Skill 协议的最新形态，判断需要对齐到什么程度。
+
+## Goal
+
+1. 把「包」而不是「文件」确立为安装、升级、卸载和记账的最小单位。
+2. 内置资产从模板投影层改为「随程序附带、已下载好的包」，与工坊 / git 走同一条安装路径。
+3. 兼容 Agent Skills 开放标准，外部 Skill 零转换可用。
+4. 建立 provenance 账本，让更新、冲突和卸载有据可依。
+5. 支持中文展示名，同时保持 id 为 ASCII kebab-case。
+
+## Research
+
+调研于 2026-08-01 完成，来源为 [agentskills.io 规范](https://agentskills.io/specification)、[agentskills.io 总览](https://agentskills.io) 与 [Claude Code Skills 文档](https://code.claude.com/docs/en/skills)。
+
+- Agent Skills 已从 Anthropic 私有格式变成开放标准，Cursor / Gemini CLI / GitHub Copilot / VS Code / OpenCode / Goose / Codex / JetBrains Junie 等数十家采纳。
+- 标准 frontmatter 只有 6 个字段：`name`（必填，≤64，kebab-case，必须等于父目录名）、`description`（必填，≤1024）、`license`、`compatibility`（≤500）、`metadata`（任意 string map）、`allowed-tools`（标注为实验性）。
+- **标准把 `version` 放在 `metadata` 下**，官方示例即 `metadata: {author, version}`。
+- **标准不覆盖依赖声明、分发、registry 和更新协议**，这些是各家自行扩展的空白区。
+- Claude Code 的分发方案是 plugin + marketplace（git 仓库为单位），不是「每个 skill 一个包」；另外私有扩展了十余个 frontmatter 字段。
+- 官方提供校验器 `skills-ref validate`。
+
+## Prior State
+
+- 内置资产经 `syncSystemAssetsToUserAssets`（`server/workspace-files/novel-workspace.ts:534`）逐文件投影进 Workspace Root `.nbook`，用 `.system-assets-sync-state.json` 记 `{upstreamHash, lastSyncedUserHash}` 做三方比较。
+- 废弃受管文件依赖五份硬编码墓碑名单共约 50 条（`novel-workspace.ts:41-117`），单调增长且永不能删。
+- `package.json.version` 只是 catalog 的只读展示字段（`skill-catalog.ts:127`），不参与任何更新决策。
+- 依赖失效靠 `skillDependencyKey()` 从路径反推包身份，再比对 17 个 install 相关字段。
+- catalog 层「整目录遮蔽」与 sync 层「逐文件三方合并」语义不一致。
+- 冲突只产生 warning 文本，没有可操作出口。
+- 联网更新、git 安装、工坊安装全部为零。工坊站点已实现完整发布与下载 API，客户端一行未接。
+- Passport 设备码 + Bearer 认证通道已在客户端跑通，可直接复用。
+
+## Decisions
+
+用户拍板，不再重议：
+
+1. **兼容外部 Skill。** frontmatter 是真相源，`package.json` 可选；`version` 与 `author` 进 frontmatter，与 `package.json` 尽量同步。
+2. **id 与展示名分离。** 目录名 = `name` = id（ASCII kebab-case），中文展示名走 `metadata.displayName`。
+3. **禁用目录不做。** 不提供「保留目录但不加载」的开关。
+4. **加 provenance。**
+5. **git remote 安装全部信任放行**，信任分级留待后续专门处理。
+6. **frontmatter 是 Skill 的真相源。**
+7. **放弃内置资产投影到用户目录。** 内置资产改为随程序附带的已下载包，只保留用户级与项目级两层。接受由此产生的 user-assets 同步协议不一致。
+8. **删除的内置包记 uninstall 墓碑，不复活，可在设置页手动恢复。**
+9. **新安装模型覆盖 Skill / Workflow / Profile 三类。**
+
+由本协议直接推导、未单独提问的：
+
+- `minAppVersion` 客户端必须消费，安装前与加载前都生效。
+- 安装走「下载 → 校验 → 暂存 → 原子换 → 失败回滚」，账本写入是唯一提交点。
+- 所有安装落点在 State Root 之下，Windows Portable 搬移 `data/` 不丢。
+- Skill 获得项目级层（与 Workflow 对齐）。规划阶段曾建议不做，按决策 7 撤回。
+- Profile 的 Publisher 提交边界优先于本协议的事务回滚规则。
+
+## Implementation Walkthrough
+
+### 2026-08-01 · 协议建档
+
+只写协议文档，未修改任何业务代码。
+
+- 新增 [reference/agent/agent-asset-install.md](../../../reference/agent/agent-asset-install.md)：核心安装协议。定义包模型、三类 root、provenance 账本、七阶段安装事务、种子投放规则、依赖生命周期、兼容性门禁、信任边界、三类资产各自的补充规则和迁移要求。
+- 重写 [reference/agent/skill-package.md](../../../reference/agent/skill-package.md)：以 Agent Skills 开放标准为基线，frontmatter 成为身份 / 展示名 / 版本的真相源，`package.json` 降级为可选，删除已作废的 Override And Sync 小节。
+- 更新 [reference/agent/agent-asset-package.md](../../../reference/agent/agent-asset-package.md)：Client Boundary 改为指向新安装协议；新增 Pending Site Changes 小节，明确标注 Skill 发布身份改读 frontmatter 是**站点尚未实施**的合同变化。
+- 更新 [reference/agent/workflow/README.md](../../../reference/agent/workflow/README.md)：目录与覆盖小节从三层改为 `Install Root → Project Root` 两层，写明 Seed Root 不是 catalog 层。
+- 更新 [reference/agent/profile-compiled-artifacts.md](../../../reference/agent/profile-compiled-artifacts.md)：Sync 小节加取代关系提示块，正文保留对当前生产行为的准确描述。
+- 更新 [docs/adr/0011-agent-asset-install-identity.md](../../adr/0011-agent-asset-install-identity.md)：新增修订块。核心「单一安装身份」原则不变，Skill 的身份读取位置改为 frontmatter，`package.json` 降级为可选；决策 2、3、4、6、7、8 不变。
+- 更新 [reference/workspace/TERMS.md](../../../reference/workspace/TERMS.md)：新增 Seed Root / Install Root 术语，精确化 `.nbook` 覆盖规则的适用范围。
+- 更新 [reference/agent/README.md](../../../reference/agent/README.md) 索引与阅读规则。
+- 更新 `PROJECT-STATUS.md`：新增 Task 135 行。
+
+### 2026-08-01 · 协议自审与修订
+
+建档后对协议做了一轮对抗式检查，查出 8 处实质缺陷并全部修订。**核对手段是读真实内置资产，不是推演。**
+
+**A. 无版本包永久停更（严重，会直接废掉核心需求）**
+
+原 Seeding 规则把升级门槛写成「种子版本更高」，而 Core Model 断言每个包「有稳定 id 和 SemVer 版本」。实测：**17 个内置 Skill 中 0 个在 frontmatter 声明版本，只有 llmlint 与 novel-data 有 `package.json.version`；7 个内置 Workflow 全部没有 `package.json`。** 即 15 个 Skill 和全部 Workflow 无版本，版本门槛对它们永远不成立，首次安装后再也收不到更新——比现状（文件同步每次都更新）是硬回归，且直接废掉「资产需要支持更新」这条核心需求。Workflow 小节原文「缺失时视为无版本包，只能被整体替换，不参与版本比较升级」本身也自相矛盾（既然不参与升级，替换由什么触发）。
+
+修订：新增 Version And Change Detection 小节。版本改为显式可选；双方都有版本走 SemVer 比较，任一方缺版本回退到 `contentHash` 比较。无版本包因此仍能跟随更新，代价是无法表达「内容变了但不算升级」。
+
+**B. `restore` 被版本门槛拦死（严重，与用户决策 8 直接冲突）**
+
+原 Resolve 写「同 id 已存在且版本不高于当前版本时直接结束」，而恢复内置包装的是同一个版本 → 用户拍板的「设置页恢复内置 Skill」永远执行不了。原文还把「安装、升级、恢复共用同一个事务」和这条门槛并列，没意识到二者互斥。
+
+修订：拆出 `install` / `upgrade` / `repair` / `restore` / `takeover` 五种意图，版本门槛只约束 `upgrade`。顺带补上了原本完全缺失的 `repair`（同版本重装修损坏）。
+
+**C. Profile 的 commit unit 套不上目录 rename 模型（严重）**
+
+原事务阶段 5 假设「旧目录 rename 进 `.trash`，staging rename 到目标位」。但 Profile 的固定入口是 profiles root 下的**一个文件** `<name>.profile.tsx`（可带同名资料目录），且 `.compiled/` 与 `manifest.json` 是**整个 root 共享**的。目录 rename 对 Profile 无定义，照抄会破坏共享状态。
+
+修订：新增 Commit Unit 小节，明确 Skill / Workflow 是整目录 rename，Profile 是「入口文件 + 同名资料目录」逐条移动，共享的 `.compiled/` 与 `manifest.json` 不进阶段 5、只能由 Publisher 在阶段 7 改。
+
+**D. 账本无并发控制（中）**
+
+账本是单文件共享可变状态，原文只规定了「临时文件 + 原子 rename」，那只保证写原子，不防读—改—写丢更新。多标签页、Manager、CLI 和后台种子投放都能并发触发安装。
+
+修订：新增 Concurrency 小节，整个事务在 Install Root 排他锁内执行，账本读—改—写在同一持锁窗口内完成；并明确它与 Profile `.publish.lock` 是两把独立的锁、不得反向嵌套（否则与后台编译 Coordinator 死锁）。
+
+**E. 账本丢失导致静默永久停更（中）**
+
+原文「账本里没有记录的包一律视为 `local`」+ 账本放在用户可编辑的 `workspace/.nbook/agent/` 下 = 用户误删一个 JSON 文件，全部内置包降级为 `local`，从此静默不再更新。
+
+修订：新增 Ledger Recovery 小节。账本缺失或损坏时从磁盘重建，逐个与 Seed Root 同 id 包比对 `contentHash` 判定来源，只有比对不中的才记 `local`；并明确重建无法恢复 `removed` 墓碑，必须告知用户而非静默发生。
+
+**F. 跨来源同 id 冲突未定义（中）**
+
+`agent-asset-package.md` 的 Client Boundary 原本明确把「同名冲突」列为待设计项，我在改写时声称由新协议接管，实际只覆盖了 dirty（用户手改）冲突，没覆盖跨来源冲突：工坊的 `novel-guide` 装到已有内置 `novel-guide` 上会发生什么，原文没有答案。
+
+修订：新增「跨来源同 id」小节。一个 id 一个槽位，走 `takeover`，需用户确认，成功后 `origin` 改写并脱离种子投放接管；可通过卸载 + `restore` 回到内置版本。
+
+**G. 墓碑与显式安装的交互未定义（中）**
+
+原文只说种子投放遇 `removed` 跳过，没说用户显式从工坊装同 id 包时墓碑怎么办。
+
+修订：明确任何显式安装动作都清除墓碑，只有自动种子投放会被墓碑拦住。
+
+**H. frontmatter-only Skill 无处声明 `minAppVersion`（中，两份文档互相矛盾）**
+
+协议要求 `minAppVersion` 在安装前和加载前都生效，但 `minAppVersion` 只存在于 `package.json` 的 `neurobook` 字段里，而同一轮我刚把 Skill 的 `package.json` 降级为可选——frontmatter-only 的 Skill 根本没有位置声明它。
+
+修订：`skill-package.md` frontmatter 表新增 `metadata.minAppVersion`；协议 Compatibility 小节改为按类型分列声明位置，并写明未声明即无约束。
+
+Review Checklist 同步从 8 条扩到 14 条，把上述每条都变成可核对项。
+
+### 2026-08-02 · 存量冲突面收口
+
+处理建档轮审计出的三处冲突面。**本轮首次修改业务资产（skill-creator 的两个脚本），并做了真实执行验证。**
+
+**1. `quick_validate.py` 重写（原为阻塞项）**
+
+原实现有两个方向相反的错误：`allowed_keys` 只放行 `name` / `description` 并拒绝其余一切 key，同时 `parse_frontmatter` 明确拒绝任何缩进行——`metadata` 嵌套块与 `license` / `compatibility` 全部会被判不合格；而 `is_valid_skill_name` 用 `char.isalpha()` 判定，Python 的 `isalpha()` 对中文和大写字母都返回 `True`，等于放行了 `RP模式` 这类不合规 id。
+
+重写后按标准校验：顶层字段白名单、`name` 严格 kebab 且必须等于父目录名、`description` ≤1024、`compatibility` ≤500、`metadata.version` 与 `metadata.minAppVersion` 必须是 canonical SemVer，并支持 `metadata` 嵌套映射与 `when_to_use` 块列表两种结构。
+
+**实测发现协议漏字段**：首轮跑全量内置 Skill 时 6 个报 `Unexpected frontmatter keys: when_to_use`。核查 `server/agent/skills/skill-catalog.ts:161` 确认 `when_to_use` 是 **NeuroBook 真实消费的既有字段**（解析后输出 `whenToUse`，且 `:152-158` 专门处理了 YAML 列表形态），4 个 Skill 用标量、2 个用列表，Claude Code 也把它作为私有扩展消费。**我在重写 `skill-package.md` 时把这个生产字段整个丢了**，属于协议缺陷而非校验器缺陷。已在 `skill-package.md` 补回字段表条目与专门小节，说明它是标准之外的容忍扩展。
+
+**2. `init_skill.py` 重写**
+
+原实现的用法示例是 `init_skill.py shuangwen-style --name 爽文风格`，正好教了「目录名 ≠ frontmatter name、且 name 用中文」，与决策 2 完全相反；`SKILL_NAME_PATTERN` 为 `^[^\s\\/]+$`，只要没有空格和斜杠就放行。
+
+重写后 `name` 恒等于目录名，`--name` 改为 `--display-name` 并写入 `metadata.displayName`，模板按需生成 `metadata` 块，标题优先用展示名，中文 id 直接拒绝并提示改用 `--display-name`。
+
+**3. `skill-creator/SKILL.md`**
+
+发现路径描述、`## What A Neuro Book Skill Is` 的目录说明、`## Frontmatter Rules` 全段（含 `name may be English or Chinese`）与手工自检清单四处更新为新契约，并指向 `reference/agent/skill-package.md` 作为真相源。
+
+**4. 文档站**
+
+`docs/agent/skills.md` 与英文镜像原本列了 Skill 的「项目层」，但 `SkillCatalog` 构造函数只接 `(systemRoot, userRoot)`、`list()` 没有 project 参数——**Skill 今天没有项目层，这是与 Task 135 无关的既有文档错误**。已改为如实描述当前两层并说明整目录覆盖语义。顺带发现表格漏掉 Task 124 加入的 `novel-data`，实际内置 Skill 是 17 个而非文档写的 16 个，中英文均已补齐。
+
+`skill-creator-zh` 的归档与 `RP模式` 的改名仍未执行，原因见 Open Items。
+
+## Verification
+
+- [ ] 未运行任何测试。本轮只有文档变更，不涉及业务代码。
+- [ ] 协议尚未实施，因此没有任何行为证据。文档中的所有机制描述都是目标合同，不是当前生产行为。
+- [x] 内置资产版本声明覆盖率已用真实文件核对：17 个 Skill 中 15 个无任何版本（llmlint `3.0.0`、novel-data `1.0.0` 走 `package.json`），7 个 Workflow 全部无 `package.json`。缺陷 A 据此确认，不是推演。
+- [x] 自审后重读全文，确认修订未引入新的自相矛盾：版本门槛只出现在 `upgrade` 分支，Seeding 与 Version And Change Detection 判据一致，Commit Unit 与 Profile 小节互相引用无冲突。
+- [x] `quick_validate.py` 全量跑过 17 个内置 Skill：16 通过，唯一失败的 `RP模式` 报中文 id 不合规，属预期待办而非校验器缺陷。
+- [x] `quick_validate.py` 做过失败注入：name 与目录名不符、大写 id、连续连字符、非 SemVer `metadata.version`、未知顶层 key、空 description、`metadata` 写成内联值 7 个坏用例全部按正确原因拒绝；含 `metadata` / `when_to_use` 列表 / `license` / `minAppVersion` 的合法用例通过。**「全通过」不作为有效性依据。**
+- [x] `init_skill.py` → `quick_validate.py` 端到端自洽：纯 ASCII id、中文 `--display-name`、带资源目录三种生成结果均通过校验；中文 id 被正确拒绝并提示改用 `--display-name`。
+- [x] `bun run docs:build` 通过，无死链。
+- [ ] 未运行仓库单元测试。本轮改动的两个 Python 脚本不在 Vitest 覆盖范围内，其余为文档。
+
+## Plan Differences
+
+- 规划阶段建议 Skill 不做项目级层，理由是复杂度不值。用户决策 7 明确要求「只需要用户、项目级 skill」，因此改为纳入，与 Workflow 现有三层结构中的 project 层对齐。
+- 规划阶段准备就「内置可运行 Skill 的依赖如何在只读 Application Root 上安装」提问并给了三个方案。决策 7 让内置包直接安装进可写的 State Root，该问题连同三个方案一并作废。
+- 规划阶段假设 `agent-asset-package.md` 可以直接改写以支持无 `package.json` 的 Skill。核对后发现该文档描述的是**站点已部署行为**，直接改写会让文档对生产失真，因此改为新增 Pending Site Changes 小节隔离未实施部分。
+
+## Contradicting Surfaces
+
+建档同轮对存量文件做了只读审计，查出三处描述或强制执行已被推翻的旧模型。**三处均已于 2026-08-02 收口**，过程见上方实施记录。
+
+1. ~~`skill-creator/scripts/quick_validate.py:76`~~ —— `allowed_keys` 白名单会直接判定新协议的合法 Skill 不合格，属阻塞项。**已重写**，并顺带暴露出协议漏掉 `when_to_use` 生产字段。
+2. ~~`skill-creator/SKILL.md`~~ —— 发现路径与 frontmatter 规则仍是旧模型。**已更新四处**；同轮发现 `init_skill.py` 的示例在教「目录名 ≠ name 且 name 用中文」，一并重写。
+3. ~~`docs/agent/skills.md:49`~~ —— 声称 Skill 有三层覆盖。**已改为如实描述当前两层**；同轮查实「项目层」在 `SkillCatalog` 里根本不存在，属既有文档错误，且表格漏了 `novel-data`。
+
+审计更正：首轮 grep 模式过窄，曾错误断言「`reference/` 下除本轮改动的三个文件外没有其它文件描述旧覆盖模型」。放宽模式后又查到两处，**已一并修正**：
+
+- `reference/agent/workflow/README.md:37-41` 原文完整描述了 `Bundled system → user-assets → Project Workspace` 三层覆盖。已改为 `Install Root → Project Root` 两层，并写明 Seed Root 不是 catalog 层。
+- `reference/agent/profile-compiled-artifacts.md` 的 Sync 小节描述的是旧投影同步。因该节准确描述当前生产行为，未改写正文，改为加显式提示块标注取代关系，并声明三条不可回滚边界与 Publisher 约束在新模型中原样保留。
+
+同文件的另外三处旧同步引用（`:77` 前端 user-assets sync 翻转 system/user 两个 root 的 Registry、`:129` 发布点不可回滚边界、`:136` 依赖标签按 `assets/workspace/.nbook/agent/profiles` 字符串把 system entry rehome 成 user entry）都准确描述当前实现，实施时会随旧同步路径一起失效，本轮不动。实施时必须逐条核对这三行。
+
+`reference/workspace/TERMS.md` 已同步：新增 **Seed Root** 与 **Install Root** 两个术语；原「用户的 `workspace/.nbook` 可以覆盖系统 `assets/workspace/.nbook`」精确化为只对 `templates/` 与 `variables/` 成立。
+
+- `reference/agent/workflow/README.md:37-41` 原文完整描述了 `Bundled system → user-assets → Project Workspace` 三层覆盖。已改为 `Install Root → Project Root` 两层，并写明 Seed Root 不是 catalog 层。
+- `reference/agent/profile-compiled-artifacts.md` 的 Sync 小节描述的是旧投影同步。因该节准确描述当前生产行为，未改写正文，改为加显式提示块标注取代关系，并声明三条不可回滚边界与 Publisher 约束在新模型中原样保留。
+
+同文件的另外三处旧同步引用（`:77` 前端 user-assets sync 翻转 system/user 两个 root 的 Registry、`:129` 发布点不可回滚边界、`:136` 依赖标签按 `assets/workspace/.nbook/agent/profiles` 字符串把 system entry rehome 成 user entry）都准确描述当前实现，实施时会随旧同步路径一起失效，本轮不动。实施时必须逐条核对这三行。
+
+`reference/workspace/TERMS.md` 已同步：新增 **Seed Root** 与 **Install Root** 两个术语；原「用户的 `workspace/.nbook` 可以覆盖系统 `assets/workspace/.nbook`」精确化为只对 `templates/` 与 `variables/` 成立。
+
+## Open Items
+
+实施前需要确认或决策的：
+
+1. **站点跟进 Skill frontmatter 身份**（`neuro-book-site`）。在站点改造完成前，无 `package.json` 的标准 Skill 只能本地安装和 git 安装，传不上工坊。
+2. **恢复内置资产的入口位置。** 决策 8 要求「设置页可手动恢复」，具体挂在哪个设置分区未定。
+3. **依赖安装由谁触发。** 协议规定依赖安装是可延迟阶段且状态记在账本，但「系统在安装后自动跑」还是「首次使用时由 Agent 按账本状态触发」未定。当前实现是后者且靠提示词约束。
+4. **`RP模式` 改名与 `skill-creator-zh` 归档。** 两项都还没做。建档时以为只是移动目录，核查后发现都有活代码引用，且**在当前同步模型下都必须补墓碑名单条目**（否则存量用户机器上留下孤儿目录），而墓碑名单正是本任务要退役的东西——迁移计划要求名单先执行完再删，所以补条目与退役并不冲突，但需要用户确认这个时机。
+
+   `skill-creator-zh` 归档的完整影响面：
+   - `assets/workspace/.nbook/agent/skills/skill-creator-zh/` 移到 `docs/archived/skills/`
+   - `assets/workspace/.nbook/agent/profiles/builtin/leader.assets.profile.tsx:65` 的 `skills.include` 白名单要摘掉它，`:211` 的提示词也提到它
+   - **改了 builtin profile 就要重新编译 artifact**，不是纯文本改动
+   - `server/agent/skills/skill-catalog.test.ts:175` 断言它在 catalog 里
+   - `docs/agent/skills.md:42` 与英文镜像的表格把它和 `skill-creator` 并列
+   - `novel-workspace.ts` 需加墓碑 `agent/skills/skill-creator-zh/`
+
+   `RP模式` 改名的完整影响面：
+   - 目录改 `rp-mode`，`SKILL.md` 的 `name` 改 `rp-mode` 并加 `metadata.displayName: RP 模式`
+   - `server/agent/skills/skill-catalog.test.ts:173` 断言旧名
+   - `docs/agent/skills.md:46` 与英文镜像的「历史」段
+   - `novel-workspace.ts` 需加墓碑 `agent/skills/RP模式/`
+   - 归档文档与历史任务记录里的引用是历史叙述，不改
+5. **迁移的执行时机。** 存量墓碑名单必须一次性执行完才能从代码删除，需要确定这个迁移挂在哪个 Application State catalog 版本上。
+
+## References
+
+- [Agent Asset Install Protocol](../../../reference/agent/agent-asset-install.md)
+- [Skill package contract](../../../reference/agent/skill-package.md)
+- [Agent Asset Package Protocol](../../../reference/agent/agent-asset-package.md)
+- [Profile compiled artifacts](../../../reference/agent/profile-compiled-artifacts.md)
+- [Workspace terms](../../../reference/workspace/TERMS.md)
+- [ADR 0011：Agent 资产安装身份](../../adr/0011-agent-asset-install-identity.md)
+- [Task 120 Agent Skill Package Contract](../120-agent-skill-package-contract/README.md)
+- [Task 88 Workshop Platform](../88-workshop-platform/README.md)
+- [Agent Skills 规范](https://agentskills.io/specification)

--- a/reference/agent/README.md
+++ b/reference/agent/README.md
@@ -12,7 +12,8 @@
 - [leader-default.md](leader-default.md)：`leader.default` 工具、任务、多 Agent、SQL、Plan Mode 和 Skills 操作协议。
 - [project-workspace-guide.md](project-workspace-guide.md)：Agent 使用 Project Workspace 文件工具的短指南，覆盖路径、基础内容节点和常用目录。
 - [novel-writing-workflow.md](novel-writing-workflow.md)：写作模式标准流程、emulation 使用边界、小说 workflow skill 分层和 runs 产物建议。
-- [skill-package.md](skill-package.md)：Skill package、SemVer、portable root、首次安装与依赖失效合同。
+- [skill-package.md](skill-package.md)：Skill 包结构、frontmatter 真相源、id 与展示名分离、SemVer 与依赖合同。
+- [agent-asset-install.md](agent-asset-install.md)：Skill / Workflow / Profile 的本地安装、更新、卸载、来源记账与安装事务合同。
 - [agent-asset-package.md](agent-asset-package.md)：Workshop 可发布 Skill / Workflow / Profile 的统一根 package、SemVer、固定入口与迁移合同。
 - [rp-tick/](rp-tick/)：RP Tick 完整交互协议。覆盖 Tick 生命周期（5 Phase）、LOD 世界模拟系统、actor-facing packet 标签规范、Writer Brief 剧本格式。各文件可被 profile 按需 Import。
 
@@ -33,8 +34,9 @@
 - 实现或修改 profile：先读 [profile-guide.md](profile-guide.md)，再读 [context.md](context.md)、[profile-import.md](profile-import.md) 和 [profile-compiled-artifacts.md](profile-compiled-artifacts.md)。
 - 处理 profile 职责边界、用户用错 agent 或入口切换建议：读 [profile-routing.md](profile-routing.md)。
 - 处理默认 Leader prompt、工具、writer / retrieval / researcher、Plan Mode 或 Skills：读 [leader-default.md](leader-default.md)。
-- 创建或更新 runnable Skill、版本、依赖、vendored snapshot 或 user-assets 同步：读 [skill-package.md](skill-package.md)。
-- 设计 Workshop 发布、资产更新或 Skill / Workflow / Profile 统一包：先读 [agent-asset-package.md](agent-asset-package.md)，再按类型进入对应运行时参考。
+- 创建或更新 runnable Skill、版本、依赖或 vendored snapshot：读 [skill-package.md](skill-package.md)。
+- 实现或修改资产安装、更新、卸载、种子投放、来源记账或 git / Workshop 安装链路：读 [agent-asset-install.md](agent-asset-install.md)。
+- 设计 Workshop 发布或 Skill / Workflow / Profile 统一发布包：先读 [agent-asset-package.md](agent-asset-package.md)，再按类型进入对应运行时参考。
 - 处理 Project Workspace 文件、内容节点、lorebook、manuscript 或 simulation：先读 [project-workspace-guide.md](project-workspace-guide.md)，需要完整目录协议时读 [../content/project-structure.md](../content/project-structure.md)。
 - 处理 Plot System：读 [../plot/system.md](../plot/system.md) 和 [../plot/agent-spec.md](../plot/agent-spec.md)。
 - 处理小说写作流程、剧情推进、emulation tick 或 workflow skill 命名：读 [novel-writing-workflow.md](novel-writing-workflow.md)。

--- a/reference/agent/agent-asset-install.md
+++ b/reference/agent/agent-asset-install.md
@@ -1,0 +1,280 @@
+# Agent Asset Install Protocol
+
+本文是 NeuroBook 客户端**本地安装、更新、卸载和来源记账**的唯一协议真相源。它取代原先「Bundled Workspace Template 逐文件投影进 Workspace Root `.nbook`」的同步模型。
+
+发布侧（Workshop ZIP 外壳、静态校验、版本递增）仍由 [Agent Asset Package Protocol](agent-asset-package.md) 定义。任务过程记录见 [Task 135](../../docs/tasks/135-agent-asset-install-protocol/README.md)。
+
+## Core Model
+
+一个 Agent 资产是一个**包**：带固定入口的可寻址单元，有稳定 id。版本是可选的——现存内置包大多没有声明版本，外部导入的标准 Skill 也可能没有。包是安装、升级、卸载和记账的最小单位；系统不再以文件为单位比较和合并。
+
+内置资产不是模板层，而是**随程序附带、已经下载好的包**。它和 Workshop、git 装来的包走同一条安装代码路径，唯一区别是来源不需要联网。
+
+| 类型 | 固定入口 | 元数据真相源 | id |
+| --- | --- | --- | --- |
+| Skill | `SKILL.md` | YAML frontmatter | 目录名 |
+| Workflow | `workflow.ts` | default export 对象 | 目录名 |
+| Profile | `<name>.profile.tsx` | 编译后 `profileManifest` | `profileKey` |
+
+## Roots
+
+```text
+Application Root/assets/workspace/.nbook/agent/{skills,workflows,profiles}/   Seed Root（只读）
+State Root/workspace/.nbook/agent/{skills,workflows,profiles}/                Install Root（可写）
+State Root/workspace/{project}/.nbook/agent/{skills,workflows,profiles}/      Project Root（可写）
+```
+
+- **Seed Root 不是 catalog 层。** 它只是随程序发布的包仓库，仅供安装器读取。catalog 不从这里加载任何资产。
+- catalog 层级固定为 **Install Root → Project Root**，同 id 时 Project Root 胜出。三类资产使用同一套层级。
+- 安装落点永远在 State Root 之下。Windows Portable 整体搬移 `data/` 后，已安装资产随之迁移；升级 NeuroBook 程序不触碰 Install Root。
+- Project Root 的包不参与安装事务与账本，视为项目内容，随 Project 备份和下载走。**不支持把包安装到 Project Root**；项目级资产只能由用户或 Agent 手工创建。需要跨项目复用时装到 Install Root。
+
+## Provenance Ledger
+
+Install Root 下的 `agent/installed.json` 是已安装资产的账本。它取代 `.system-assets-sync-state.json` 对这三类资产的记账。
+
+```json
+{
+    "schemaVersion": 1,
+    "assets": [
+        {
+            "type": "skill",
+            "id": "llmlint",
+            "version": "3.0.0",
+            "state": "installed",
+            "origin": {"kind": "bundled"},
+            "installedAt": "2026-08-01T00:00:00.000Z",
+            "contentHash": "9f2c...",
+            "dependencies": {"state": "installed", "lockHash": "4ab1..."}
+        },
+        {
+            "type": "skill",
+            "id": "novel-guide",
+            "version": "1.1.0",
+            "state": "removed",
+            "origin": {"kind": "bundled"},
+            "removedAt": "2026-08-02T10:00:00.000Z"
+        },
+        {
+            "type": "workflow",
+            "id": "book-deconstruct",
+            "version": "2.0.0",
+            "state": "installed",
+            "origin": {"kind": "workshop", "slug": "book-deconstruct", "itemId": "itm_..."},
+            "installedAt": "2026-08-01T00:00:00.000Z",
+            "contentHash": "1d70..."
+        }
+    ]
+}
+```
+
+### origin
+
+| kind | 含义 | 升级源 |
+| --- | --- | --- |
+| `bundled` | 随程序附带的种子包 | 新版程序的 Seed Root |
+| `workshop` | 从创意工坊安装 | Workshop API 同 `itemId` 的更高版本 |
+| `git` | 从 git remote 安装，额外记 `remote` / `ref` / `commit` | 同 remote 重新拉取 |
+| `local` | 用户自己在目录里手写 | 无 |
+
+**账本里没有记录的包一律视为 `local`。** 它对 catalog 完全可见，但不参与任何自动升级，也不产生冲突提示。
+
+### state
+
+- `installed`：正常可用。
+- `removed`：**仅对 `bundled` 有意义的墓碑**。用户删掉内置包后写入，用于阻止下次启动重新种回。工坊和 git 包被删除时直接移除账本条目，不留墓碑。
+
+`removed` 条目不会因为新版程序带来更高版本而复活。清除墓碑只有两条路径：用户在设置页显式「恢复内置资产」（`restore`），或用户显式从另一来源安装同 id 包（`takeover`）。**任何显式安装动作都会清除墓碑**；只有自动种子投放会被墓碑拦住。
+
+### 跨来源同 id
+
+Install Root 每个 id 只有一个槽位。用户显式安装的包与已装同 id 包来源不同时（例如工坊的 `novel-guide` 覆盖内置的 `novel-guide`），走 `takeover`：需要用户确认，成功后账本 `origin` 改写为新来源，该 id 从此跟随新来源升级，不再被种子投放接管。
+
+后续用户可以卸载它并执行 `restore` 回到内置版本。跨来源冲突**不静默解决**，也不并存两份同 id 包。
+
+### contentHash
+
+安装完成时对整包内容计算的稳定指纹，排除 `node_modules`、`.compiled/` 和其它本地派生物。因为包是被逐字安装的，账本里的 `contentHash` 同时代表**安装时的上游内容**和**安装后的本地内容**，两个比较方向都靠它：
+
+- 重算磁盘当前内容，与账本不一致 → **本地已手改**（dirty）。
+- 计算上游候选内容，与账本不一致 → **上游有变化**（有更新可用）。
+
+## Version And Change Detection
+
+**版本是可选的。** 当前 17 个内置 Skill 中有 15 个、7 个内置 Workflow 全部没有声明任何版本；符合 Agent Skills 开放标准的外部 Skill 也可以没有 `metadata.version`。因此升级判定**不能只依赖版本比较**，否则这些包在首次安装后将永远不再更新。
+
+升级触发规则，按顺序判定：
+
+1. **双方都有版本**：上游版本按 SemVer precedence 严格大于账本版本 → 有更新。版本相等或更低 → 无更新（除非是显式 repair/restore，见事务 Resolve）。
+2. **任一方没有版本**：改用 `contentHash` 比较。上游 `contentHash` 与账本不一致 → 有更新。
+3. 两种情况下都要再过一次 dirty 判定：磁盘当前 `contentHash` 与账本不一致时，**跳过升级并产生一条冲突提示**，不覆盖用户改动。
+
+无版本包因此仍然能跟随程序更新，代价是无法表达「内容变了但不算升级」，也无法在界面上展示版本号。**内置包应当逐步补齐 `metadata.version`**；补齐后自动从规则 2 切到规则 1，不需要迁移。
+
+dirty 包的处置出口只有两个：用户接受上游版本（覆盖，旧内容进回收区），或用户保留本地版本（origin 降级为 `local`，从此不再跟随上游）。这一整包判定取代了原来 per-file 的 `lastSyncedUserHash` 三方比较。
+
+## Install Transaction
+
+### Intent
+
+事务先确定意图，不同意图的前置条件不同。**版本比较只约束 `upgrade`**，其余意图不受「版本必须更高」限制：
+
+| intent | 触发 | 前置条件 |
+| --- | --- | --- |
+| `install` | 目标 id 未安装 | 账本无 `installed` 条目 |
+| `upgrade` | 检测到上游更新 | 通过 Version And Change Detection 判定，且未 dirty |
+| `repair` | 用户或启动对账发现安装损坏 | 允许同版本重装，覆盖磁盘内容 |
+| `restore` | 用户在设置页恢复已删除的内置包 | 账本条目为 `removed`；**允许同版本安装** |
+| `takeover` | 用户显式从另一来源安装同 id 包 | 需用户确认，成功后 `origin` 改写为新来源 |
+
+`restore` 与 `repair` 若受「版本不高于当前版本就结束」约束会直接失效，因此该约束只写在 `upgrade` 分支里。
+
+### Concurrency
+
+**整个事务在 Install Root 级别的排他锁内执行**，锁与 Profile 的 `.publish.lock` 独立且不得互相嵌套等待。账本是单文件共享可变状态，读—改—写必须在同一次持锁窗口内完成，否则并发安装会互相丢写。
+
+多标签页、Manager、CLI 与后台种子投放都必须走这把锁。拿不到锁时排队或返回「安装进行中」，不得跳过锁直接写盘。
+
+### Stages
+
+七个阶段：
+
+1. **Resolve**：确定 type、id、intent、来源与落点。按上表校验意图前置条件，不满足即结束。
+2. **Fetch**：`bundled` 从 Seed Root 读；`workshop` 经 official-site transport 下载 ZIP；`git` 执行浅克隆。
+3. **Validate**：路径安全规则继承 [Agent Asset Package Protocol](agent-asset-package.md)；校验固定入口存在、id 合法且等于目录名、版本（若声明）是 canonical SemVer、`minAppVersion` 满足当前程序版本。任何一项失败即终止，不产生半安装状态。
+4. **Stage**：写入 `agent/.staging/<type>/<id>-<nonce>/`。staging 与目标同盘，保证后续 rename 是原子的。
+5. **Commit**：把旧的 commit unit 移进 `agent/.trash/<type>/<id>-<timestamp>/`，再把 staging 内容移到目标位。两次移动都在同盘完成。
+6. **Record**：账本在锁内读取、合并本次条目，经临时文件 + 原子 rename 写回。**账本写入是事务提交点。**
+7. **Post-install**：依赖安装与 Profile 发布（见下），失败不回滚已提交的安装，只把状态标为待修复。
+
+### Commit Unit
+
+阶段 5 移动的单元按类型不同：
+
+- **Skill / Workflow**：包目录 `<install-root>/<type>s/<id>/`，整目录 rename。
+- **Profile**：**不是一个自包含目录**。固定入口是 profiles root 下的 `<name>.profile.tsx` 文件，可能另带一个同名资料目录，而 `.compiled/` 与 `manifest.json` 是**整个 root 共享**的。因此 Profile 的 commit unit 是「入口文件 + 同名资料目录」这一组条目，逐条移动；共享的 `.compiled/` 与 `manifest.json` **不属于 commit unit**，只能由 Publisher 在阶段 7 修改。
+
+### Failure Handling
+
+- 阶段 1–4 失败 → 删除 staging，目标位未被触碰。
+- 阶段 5 中途失败 → 从 `.trash` 把旧 commit unit 移回原位。Profile 的多条目移动必须逐条可逆。
+- 阶段 6 失败 → 磁盘已换但账本未更新。**启动对账以磁盘为准回填账本**，不以账本为准回滚磁盘。
+- `.trash` 与 `.staging` 是可重建的运行产物：不进 user-assets Studio、不进文件历史、不进备份与下载包，由启动时的保守清理回收，保留期内可用于人工恢复。
+
+### Ledger Recovery
+
+账本位于用户可编辑的 Workspace Root `.nbook` 之下，必须假设它会被误删或损坏。**不能把「账本无条目」直接解释成 `local`**，否则一次误删会让全部内置包永久停止更新且无任何提示。
+
+- 账本文件缺失或解析失败 → 从磁盘重建：扫描 Install Root 列出所有包，逐个与 Seed Root 同 id 包比对 `contentHash`。命中且一致的重建为 `origin: bundled` 并回填版本；命中但不一致的重建为 `bundled` 且立即标记 dirty；未命中的才记为 `local`。
+- 重建无法恢复 `removed` 墓碑（信息已丢失），因此重建后被删除过的内置包会重新出现。这一点必须在重建时明确告知用户，不能静默发生。
+- 重建是 best-effort 自愈，不阻塞启动。
+
+## Seeding
+
+内置包的投放规则：
+
+- 启动时遍历 Seed Root。对每个种子包，按 id 查账本：
+  - 账本无条目且 Install Root 无同 id 目录 → 安装（`install`）。
+  - 账本 `state: "removed"` → **跳过**，不重装。
+  - 账本 `state: "installed"` 且 `origin.kind` 不是 `bundled` → **跳过**。该 id 已被 `takeover`，种子不再接管。
+  - 账本 `state: "installed"` 且 `origin.kind` 是 `bundled` → 按 Version And Change Detection 判定是否 `upgrade`。**无版本包走 `contentHash` 比较，不会因为缺版本而永远停更。**
+  - Install Root 有同 id 目录但账本无条目 → 先走 Ledger Recovery 的比对逻辑，不要直接判成 `local`。
+- 种子投放不阻塞启动，且必须在 Install Root 排他锁内执行。失败只影响对应包，不拖垮其它包，也不阻止服务起来。
+
+## Dependencies
+
+只有 Skill 可以声明 Bun 安装输入。依赖安装是安装事务的**可延迟阶段**，账本记录其状态：
+
+- `dependencies.state`：`pending` / `installed` / `failed`。
+- `dependencies.lockHash`：`bun.lock` 与 `package.json` 中影响 Bun 安装结果的字段的联合指纹。
+
+规则：
+
+- 安装或升级后，若包声明了 Bun 安装输入且 `lockHash` 与账本不同，状态置 `pending`。
+- 版本号、`SKILL.md`、`references/`、规则文件等变化**不改变** `lockHash`，因此不重装依赖。
+- `pending` 状态下执行 `bun install --cwd "<install-root>" --frozen-lockfile`；成功置 `installed`，失败置 `failed` 并保留可读诊断。不绕过 frozen lockfile。
+- `node_modules` 是本地派生物，不进包内容指纹、不进包分发、不随 `.trash` 保留。
+
+**不再从文件路径反推包身份。** 包已经是一等单位，`skillDependencyKey` 这类按 `agent/skills/<key>/package.json` 猜测归属的逻辑退役。
+
+## Compatibility
+
+`minAppVersion` 的声明位置按类型不同，**Skill 必须能在没有 `package.json` 的情况下声明它**，否则 frontmatter-only 的 Skill 无法表达兼容性要求：
+
+| 类型 | 声明位置 | 回退 |
+| --- | --- | --- |
+| Skill | `metadata.minAppVersion`（frontmatter） | 存在 `package.json` 时回退到 `neurobook.minAppVersion` |
+| Workflow / Profile | `neurobook.minAppVersion`（`package.json`） | 无 |
+
+规则：
+
+- 未声明即无兼容性约束。声明时必须是 canonical SemVer。
+- 安装前检查，不满足则拒绝安装并报告所需版本。
+- 已安装包在程序**降级**后可能不再满足要求：catalog 将其标记为不兼容且**不加载**，不静默运行。
+- Skill 的 `compatibility` 字段（自然语言环境要求）只做展示，不参与门禁。
+
+## Trust
+
+当前阶段：`bundled`、`workshop`、`git` 三种来源**全部信任放行**，安装后可执行其携带的脚本与依赖。
+
+这是明确的阶段性决定，不是遗漏。前提是当前为 owner-only 私有内测。账本保留 `origin.kind` 正是为了在引入信任分级时有据可依。以下事实同时成立，写入协议以免被当作已解决：
+
+- Workshop 站点的 TypeScript AST 门禁是发布质量检查，**不是安全沙箱**。
+- Workflow 源码在受限求值壳中执行，无 `require`、无 `fs`/`process` 注入，但这不构成对第三方代码的隔离保证。
+- Skill 可携带 `bin`、`scripts` 与依赖，安装即等于允许在用户机器上执行第三方代码。
+
+第三方资产的执行隔离威胁模型仍未完成。公开邀请之前必须重新处理本节。
+
+## Per-type Notes
+
+### Skill
+
+id、展示名与版本的真相源全部在 `SKILL.md` frontmatter，详见 [skill-package.md](skill-package.md)。`package.json` 对本地安装是可选的。
+
+### Workflow
+
+`workflow.ts` 的 default export 提供 `title` / `description` / `whenToUse` / `argsHint`；`key` 以目录名为准，文件内声明不一致时被目录名覆盖。这套形态已经满足「id 与展示名分离」，不需要引入 frontmatter。
+
+版本可选，从同目录 `package.json.version` 读取。当前 7 个内置 Workflow 全部没有 `package.json`，因此都是无版本包，升级判定走 `contentHash` 比较。
+
+### Profile
+
+Profile 的安装比另外两类多一层：源码 `.profile.tsx` 需要编译成内容寻址 artifact 才能运行。
+
+- 包内容同时包含源码与随程序预编译的 artifact。安装时两者一起落地。
+- **Profile 的 commit unit 不是自包含目录**，详见 Install Transaction 的 Commit Unit 小节：入口文件与同名资料目录逐条移动，共享的 `.compiled/` 与 `manifest.json` 不参与阶段 5。
+- 安装事务的 **Post-install** 阶段把 artifact 送进 staging，经 `ProfileReleasePublisher` 在 per-root publish lock 内合并进当前 manifest 并翻转 Registry。安装器**不直接写 `manifest.json`**，也不在锁外删除或覆盖 `.compiled/artifacts/**`。
+- Install Root 排他锁与 Profile 的 `.publish.lock` 是两把独立的锁。事务持有前者进入阶段 7，Publisher 在内部获取后者；**不得反向嵌套**，否则会与后台编译 Coordinator 死锁。
+- 一次安装只发布一个 batch patch release，不得用安装开始时的旧 full manifest 覆盖并发发布。
+- Publisher 提交磁盘 release 之后是不可回滚边界：后续 Registry 翻转失败或账本写入失败都不能回滚 profile source，否则 manifest 会指向不存在的 source hash。这条边界优先于本文的事务回滚规则。
+- 卸载 Profile 包时只删源码与账本条目；`.compiled/artifacts/` 中失去引用的 artifact 由既有 GC 按 orphan 预算回收，安装器不直接删除。
+
+其余编译、artifact、manifest、GC 与依赖门禁契约不变，见 [profile-compiled-artifacts.md](profile-compiled-artifacts.md)。
+
+## Migration
+
+从旧投影模型切到本协议需要一次性迁移：
+
+1. `agent/skills/**`、`agent/workflows/**`、`agent/profiles/**` 整体退出 user-assets 同步协议。`templates/` 与 `variables/` 仍留在旧协议中，**两套机制并存是本次切换的既定代价**。
+2. 首次以新协议启动时，把 `.system-assets-sync-state.json` 中属于这三类的条目转换为账本条目：版本从磁盘包读取，内容指纹重算；与上游不一致的包标记 dirty 并保留用户改动。
+3. 存量用户机器上由旧墓碑名单负责清理的残留文件，必须在迁移中一次性执行完毕，之后从代码中删除对应名单条目。迁移未完成的实例不能删除名单。
+4. 迁移必须可 preflight、幂等，且失败时保持旧状态可用。
+
+## Review Checklist
+
+新增或修改安装链路时检查：
+
+1. 包是最小单位，没有任何按文件比较、合并或投放的新逻辑。
+2. 安装落点在 State Root 之下，Seed Root 保持只读且不作为 catalog 层。
+3. **无版本包能正常收到更新**：升级判定在版本缺失时回退到 `contentHash`，不会静默停更。
+4. 事务在 Install Root 排他锁内执行；账本的读—改—写在同一持锁窗口内完成。
+5. 意图分开：版本必须更高的约束只作用于 `upgrade`，`repair` / `restore` / `takeover` 不受它拦截。
+6. Commit Unit 按类型正确：Profile 不当作自包含目录处理，共享 `.compiled/` 与 `manifest.json` 不进阶段 5。
+7. 事务七阶段完整，失败路径不留半安装状态；账本写入是唯一提交点。
+8. 账本缺失或损坏时走重建比对，**不把「无条目」直接判成 `local`**。
+9. dirty 包不被静默覆盖，冲突有明确出口；跨来源同 id 走 `takeover` 且需用户确认。
+10. `bundled` 删除后不复活，但任何显式安装动作都清除墓碑。
+11. 依赖状态记在账本，不从路径反推包身份。
+12. `minAppVersion` 在安装前和加载前都生效，且 Skill 可在无 `package.json` 时声明它。
+13. Profile 走 Publisher，安装器不直接写 manifest、不锁外动 artifact，两把锁不反向嵌套。
+14. `.staging` 与 `.trash` 不进 Studio、文件历史、备份与下载包。

--- a/reference/agent/agent-asset-package.md
+++ b/reference/agent/agent-asset-package.md
@@ -1,6 +1,8 @@
 # Agent Asset Package Protocol
 
-本文是 NeuroBook 可发布 Agent 资产包的唯一协议真相源。它统一 Skill、Workflow 与 Profile 的发布外壳、版本和固定入口；Workshop 实现、后续客户端安装与更新都必须消费同一合同。现有本地 catalog、运行时覆盖与依赖安装细节继续分别由 [Skill package](skill-package.md)、[Workflow](workflow/README.md) 和 [Profile guide](profile-guide.md) 定义。
+本文是 NeuroBook 可发布 Agent 资产包的唯一协议真相源。它统一 Skill、Workflow 与 Profile 的**发布外壳**、版本和固定入口；Workshop 实现必须消费同一合同。
+
+客户端的**本地安装、更新、卸载与来源记账**由 [Agent Asset Install Protocol](agent-asset-install.md) 定义。包结构与依赖细节继续分别由 [Skill package](skill-package.md)、[Workflow](workflow/README.md) 和 [Profile guide](profile-guide.md) 定义。
 
 ## Scope
 
@@ -76,4 +78,16 @@ ZIP 内路径必须使用 `/` 分隔的相对路径。拒绝绝对路径、盘�
 
 ## Client Boundary
 
-后续 NeuroBook 客户端必须以本协议实现安装和更新，但需要另行设计：安装落点、同名冲突、bundled / user / Workshop 三方所有权、文件级更新冲突、校验失败回滚和旧版本保留。客户端还必须先完成第三方 Workflow 的隔离威胁模型，不能把站点 AST 校验当作执行安全证明。本协议存在不代表这些用户闭环已经完成。
+客户端的安装落点、同名冲突、来源所有权、更新冲突、校验失败回滚和旧版本保留由 [Agent Asset Install Protocol](agent-asset-install.md) 定义，不在本文范围内。
+
+客户端还必须先完成第三方 Workflow 的隔离威胁模型，不能把站点 AST 校验当作执行安全证明。本协议存在不代表用户闭环已经完成。
+
+## Pending Site Changes
+
+以下条目是 NeuroBook 侧已拍板、**站点尚未实施**的合同变化。在站点跟进之前，生产行为仍以本文其余小节为准。
+
+1. **Skill 的发布身份改从 `SKILL.md` frontmatter 读取。** 目标合同：`name` 是 id，`metadata.displayName` 是展示名，`metadata.version` 是版本。站点当前强制要求根 `package.json` 并从中取身份与版本，因此符合 Agent Skills 开放标准但没有 `package.json` 的 Skill 现在传不上去。
+2. **Skill 的 `package.json` 降级为可选。** 仅在携带 `bin`、`scripts` 或 Bun 安装输入时必需。Workflow 与 Profile 没有 frontmatter，继续强制根 `package.json`。
+3. 上述两条不改变 ZIP 门禁、路径安全规则、SemVer 递增规则和 `containsExecutableCode` 的计算方式。
+
+跟进这两条时，站点的 Skill 校验分支需要新增严格 YAML frontmatter 身份解析，并保持对已发布的、带 `package.json` 的存量 Skill 兼容。

--- a/reference/agent/profile-compiled-artifacts.md
+++ b/reference/agent/profile-compiled-artifacts.md
@@ -120,6 +120,8 @@ profile artifact 是宿主实现的**冻结副本**：宿主代码更新后旧 a
 
 ## Sync
 
+> 本节描述**当前生产行为**（system → user 逐文件投影同步）。[Task 135](../../docs/tasks/135-agent-asset-install-protocol/README.md) 已决定把 Profile 改为包安装模型，届时本节的触发入口会被 [agent-asset-install.md](agent-asset-install.md) 的安装事务 Post-install 阶段取代。**下面三条不可回滚边界与 Publisher 约束在新模型中原样保留**，安装器同样不得直接写 manifest 或在锁外动 artifact。
+
 Profile assets sync 不直接写 `manifest.json`。它把 system artifact copy 到 staging，经 Publisher 发布 user manifest。
 
 非 force 情况下，用户源码已手改时不会同步 compiled artifact；force 覆盖源码后才同步系统 artifact。

--- a/reference/agent/skill-package.md
+++ b/reference/agent/skill-package.md
@@ -1,50 +1,99 @@
 # Agent Skill Package Contract
 
-本文定义 NeuroBook Agent Skill 的可移植 package、版本、安装和同步合同。任务过程记录见 [Task 120](../../docs/tasks/120-agent-skill-package-contract/README.md)。
+本文定义 NeuroBook Agent Skill 的包结构、身份、版本和依赖合同。
 
-通过 Workshop 发布的 Skill 还必须遵守 [Agent Asset Package Protocol](agent-asset-package.md)：所有可发布 Skill 都要有根 `package.json` 和 `neurobook` 字段。本文件继续负责本地 catalog、runnable Skill 安装和依赖失效细节。
+- 本地安装、更新、卸载和来源记账见 [Agent Asset Install Protocol](agent-asset-install.md)。
+- 通过 Workshop 发布的外壳与静态校验见 [Agent Asset Package Protocol](agent-asset-package.md)。
+- 任务过程记录见 [Task 120](../../docs/tasks/120-agent-skill-package-contract/README.md) 与 [Task 135](../../docs/tasks/135-agent-asset-install-protocol/README.md)。
 
-## Package Identity
+## Compatibility Baseline
 
-- Skill 目录名是 catalog 稳定 `key`；用户和 Agent 必须原样使用，不翻译或重命名。
-- 固定入口是根目录 `SKILL.md`。新建可移植 Skill 的 key 使用小写字母、数字和连字符。
-- `SkillCatalog.rootPath` 是当前生效 Skill 的绝对根目录，`skillPath` 是其入口绝对路径。
-- Skill 不得假定安装在 `.nbook`、`.claude`、`.codex` 或其它宿主专用目录。命令从 catalog 路径推导根目录。
+NeuroBook Skill 遵循 [Agent Skills 开放标准](https://agentskills.io/specification)。**符合该标准的外部 Skill 可以直接安装使用，不需要任何转换或补齐。**
 
-## SKILL.md
+标准约束在本项目内全部保留：
 
-`SKILL.md` frontmatter 只承载触发发现所需元数据：
+- 一个 Skill 是一个目录，固定入口 `SKILL.md`，由 YAML frontmatter 加 Markdown 正文组成。
+- 可选子目录 `scripts/`、`references/`、`assets/`。
+- 引用其它文件使用相对 Skill 根的路径，保持一层深度。
+- Skill 不得假定安装在 `.nbook`、`.claude`、`.codex` 或其它宿主专用目录，命令从 catalog 提供的绝对根目录推导。
+
+## Frontmatter
+
+**`SKILL.md` frontmatter 是 Skill 身份、展示名和版本的唯一真相源。**
 
 ```yaml
 ---
-name: example-skill
-description: Describe what the skill does and the concrete tasks that should trigger it.
+name: rp-mode
+description: 角色扮演模式的运行协议。用户要求进入 RP、扮演角色或推进 tick 时使用。
+metadata:
+    displayName: RP 模式
+    version: "1.2.0"
+    author: notnotype
 ---
 ```
 
-- `name` 和 `description` 必填；触发条件写进 `description`。
-- 版本、作者、安装状态和运行时配置不写入 frontmatter。
-- 正文只保留 Agent 执行任务所需的流程和资源导航；详细材料放在同级 `references/`。
-- Skill 引用的相对资源必须位于自身目录内，并从 `rootPath` 解析。
+| 字段 | 必填 | 约束 |
+| --- | --- | --- |
+| `name` | 是 | 稳定 id。≤64 字符，仅小写字母、数字和连字符，不以连字符开头结尾，不含连续连字符，**必须等于父目录名**。 |
+| `description` | 是 | ≤1024 字符，写清做什么和什么时候用。触发条件写进这里。 |
+| `when_to_use` | 否 | 补充触发场景，标量或 YAML 列表均可。**标准之外的既有扩展**，详见下。 |
+| `metadata.displayName` | 否 | 界面展示名，允许中文和任意字符。缺省时回退到 `name`。 |
+| `metadata.version` | 否 | canonical SemVer 字符串。缺省时视为无版本包，升级判定改走整包内容指纹比较。 |
+| `metadata.author` | 否 | 作者标识，仅展示。 |
+| `metadata.minAppVersion` | 否 | canonical SemVer。声明本 Skill 要求的最低 NeuroBook 版本，安装前和加载前都生效。**这是 frontmatter-only Skill 声明兼容性要求的唯一位置。** |
+| `license` | 否 | 许可证名或包内许可证文件名。 |
+| `compatibility` | 否 | ≤500 字符，自然语言环境要求。只展示，不参与门禁。 |
 
-## Runnable Skill
+### when_to_use
 
-本地只含提示词和参考资料的 loose Skill 不要求 package manifest；但它不能直接发布到 Workshop。包含 CLI、脚本依赖、独立发布生命周期或需要发布的 Skill 必须包含：
+`when_to_use` **不在 Agent Skills 标准里**，但它是既有事实：NeuroBook 的 `SkillCatalog` 真实解析它并输出 `whenToUse`，当前 6 个内置 Skill 在用（其中 2 个用 YAML 列表形态），Claude Code 也把它作为私有扩展消费。因此本项目在顶层容忍这个字段，不强制迁进 `metadata`。
+
+```yaml
+when_to_use:
+  - 用户要求进入 RP
+  - 用户要求推进 tick
+```
+
+标量与列表两种形态都接受；列表在进入模型可见清单时合并成一行。它是 `description` 的补充，不是替代——**只写 `when_to_use` 而 `description` 含糊，Skill 仍然不会被正确触发**。
+
+严格标准校验器可能会因为这个顶层字段报未知 key。它不影响 Skill 在 NeuroBook 内的安装与运行，也不影响外部标准 Skill 导入。
+
+### id 与展示名分离
+
+`name` 是 id，不是展示名。中文名走 `metadata.displayName`。
+
+这样安装身份、目录名、Workshop slug、下载 URL 和 `bun install --cwd` 路径全部保持 ASCII kebab-case，同时界面上呈现给用户的仍是中文。外部 Skill 没有 `displayName` 时回退到 `name`，因此对标准 Skill 零影响。
+
+catalog 同时输出 `id` 与 `displayName`；模型可见清单和界面都消费 `displayName`。
+
+### version 的读取顺序
+
+1. `metadata.version`
+2. 根 `package.json.version`（存在时）
+3. 都没有 → 无版本包
+
+两处同时存在且不一致时以 `metadata.version` 为准，并产生一条诊断。**新建和更新 Skill 时两处应保持同步**；只有从外部导入的 Skill 允许只有其中一处。
+
+## Optional Root Package
+
+`package.json` 对本地安装是**可选**的。只含提示词和参考资料的 Skill 不需要它。
+
+以下任一情况需要根 `package.json`：
+
+- Skill 携带 CLI、脚本或运行时依赖。
+- Skill 要发布到 Workshop（发布外壳要求见 [agent-asset-package.md](agent-asset-package.md)）。
 
 ```text
-<skill-key>/
+<skill-id>/
 ├── SKILL.md
 ├── package.json
 ├── bun.lock
-├── bin/ or scripts/
-└── references/ and assets/ as needed
+├── bin/ 或 scripts/
+└── references/ 与 assets/ 按需
 ```
 
-- `package.json.name` 与目录 key 一致。
-- `package.json.version` 是唯一 Skill 版本真相源，使用 SemVer；catalog 不从 `SKILL.md` 读取版本。
-- 通过 Workshop 发布时，非空 `bin`、非空 `scripts` 或任一实际 Bun 安装输入都会要求根目录携带非空 `bun.lock`；纯提示词/资料包不为形式统一而生成空锁文件。
-- 需要依赖安装的 Skill 首次运行任何 CLI 前，Agent 必须先执行 `bun install --cwd "<skill-root>" --frozen-lockfile`。安装失败时停止，不绕过 frozen lockfile。
-- 后续运行复用本地安装；只有 `node_modules` 缺失时重新安装。
+- `package.json.name` 必须与目录名和 frontmatter `name` 一致。
+- 非空 `bin`、非空 `scripts` 或任一实际 Bun 安装输入存在时，根目录必须携带非空 `bun.lock`。纯提示词包不为形式统一生成空锁文件。
 
 版本调整口径：
 
@@ -54,32 +103,27 @@ description: Describe what the skill does and the concrete tasks that should tri
 
 ## Dependency Lifecycle
 
-`node_modules` 是当前用户机器上的本地派生物，不是 Skill package 文件：
+依赖安装由安装事务负责，状态记在 provenance 账本中，完整规则见 [agent-asset-install.md](agent-asset-install.md) 的 Dependencies 小节。本文只固定与 Skill 包直接相关的三条：
 
-- sibling/source → Bundled Workspace Template 的 vendored 同步排除 `node_modules`。
-- Bundled Workspace Template → Workspace Root `.nbook` 的受管资产清单排除 `node_modules`。
-- 普通同步、no-op、`force` no-op、版本号变化、`SKILL.md` / `references` / rules 更新不得删除 `node_modules`。
-- 当新的 `bun.lock`，或 `package.json` 中影响 Bun install 的依赖、安装脚本、平台与 package-manager 字段实际发布到用户 Skill 时，只失效该 Skill 的 `node_modules`。
-- 如果用户目录已经自行与新上游文件一致，同步只补齐 sync state，不猜测此前安装动作，也不清理依赖。
-- 用户修改了 package 安装合同且系统更新未覆盖时，不清理用户依赖；强制同步真正覆盖该合同时才清理。
+- `node_modules` 是当前用户机器上的本地派生物，不是包文件。它不进包内容指纹、不进包分发、不随回收区保留。
+- 只有 `bun.lock`，或 `package.json` 中影响 Bun 安装结果的依赖、安装脚本、平台与 package-manager 字段发生变化时，依赖状态才回到 `pending`。版本号、`SKILL.md`、`references/` 与规则文件的变化不触发重装。
+- 需要依赖的 Skill 在依赖状态不是 `installed` 时，任何 CLI 都必须先完成 `bun install --cwd "<skill-root>" --frozen-lockfile`。安装失败时停止，不绕过 frozen lockfile。
 
-`.git`、开发评测、coverage 和已硬切官方目录属于 vendored/runtime 排除项，不与依赖失效机制混用。
+## Catalog Visibility
 
-## Override And Sync
-
-- Bundled system Skill 位于 Bundled Workspace Template 的 `.nbook/agent/skills/<key>/`。
-- 用户 Skill 位于 Workspace Root `.nbook/agent/skills/<key>/`。
-- 用户同 key 目录整体覆盖 system Skill；catalog 不逐文件合并两层。
-- 系统 Skill package 违反 manifest / SemVer 合同属于打包缺陷，catalog 直接失败；损坏的用户 Skill 只隔离该 key 并记录服务端诊断，不拖垮其它 Skill，也不回退执行同 key system Skill。
-- 系统受管文件继续按 sync state 更新；用户已手改文件默认保留并产生冲突提示。
-- runnable Skill 真相源位于独立仓时，先更新独立仓 package，再同步 vendored snapshot，最后同步真实 user-assets runtime。
+- catalog 层级是 Install Root → Project Root，同 id 时 Project Root 胜出。Seed Root 不是 catalog 层。
+- 同 id 的包整体覆盖，catalog 不逐文件合并两层。
+- 损坏的 Skill 包只隔离该 id 并记录服务端诊断，不拖垮其它 Skill。
+- runnable Skill 真相源位于独立仓时，先更新独立仓 package，再同步随程序发布的种子包。
 
 ## Review Checklist
 
-发布或更新 runnable Skill 时检查：
+新增或更新 Skill 时检查：
 
-1. `SKILL.md` 只含 `name` / `description` frontmatter，正文从 catalog 路径推导 `<skill-root>`。
-2. `package.json.version` 已按 SemVer 更新；存在脚本、命令或 Bun 安装输入时，非空 `bun.lock` 与安装声明一致。
-3. 需要依赖安装的新目录先运行 `bun install --cwd "<skill-root>" --frozen-lockfile`，再运行初始化或业务命令。
-4. no-op、版本号、提示词更新保留 `node_modules`；依赖或 lockfile 更新会精确失效对应 Skill。
-5. source、vendored snapshot 与 Workspace Root `.nbook` runtime 的受管文件一致，runtime 不含开发资产。
+1. 目录名、frontmatter `name` 与（若存在）`package.json.name` 三者一致，且是合法 kebab-case id。
+2. 中文名写在 `metadata.displayName`，没有写进 `name`。
+3. `metadata.version` 已按 SemVer 更新；存在 `package.json` 时两处版本同步。
+4. 正文从 catalog 提供的绝对根目录推导 `<skill-root>`，没有硬编码宿主目录名。
+5. 存在脚本、命令或 Bun 安装输入时，非空 `bun.lock` 与安装声明一致。
+6. 该 Skill 能通过随 `skill-creator` 分发的 `scripts/quick_validate.py`。
+7. 除既有扩展 `when_to_use` 外没有引入新的顶层非标准字段；其余自定义属性一律进 `metadata`，以便对标准 Skill 生态保持可移植。

--- a/reference/agent/workflow/README.md
+++ b/reference/agent/workflow/README.md
@@ -34,11 +34,11 @@ agent/workflows/
     └── workflow.ts
 ```
 
-- Bundled Workspace Template 中的系统源：`assets/workspace/.nbook/agent/workflows/<key>/workflow.ts`。
-- 用户覆盖层：Workspace Root `.nbook` 下的 `agent/workflows/<key>/workflow.ts`；默认物理位置是 `workspace/.nbook/agent/workflows/<key>/workflow.ts`。
-- 当前 Project Workspace 覆盖层：当前项目根 `.nbook/agent/workflows/<key>/workflow.ts`。只有调用方显式绑定了该 Project Workspace 时才会读取这一层；未绑定项目时，项目 workflow 不会泄漏到全局或其他项目。
-- `<key>` 是稳定寻址键。用户层出现同名有效目录时，整个 catalog 条目覆盖系统条目；不会合并两份 `workflow.ts`。
-- 覆盖顺序固定为 `Bundled system → Workspace Root user-assets → Project Workspace`；后层同名有效目录覆盖前层。
+- Install Root：Workspace Root `.nbook` 下的 `agent/workflows/<key>/workflow.ts`；默认物理位置是 `workspace/.nbook/agent/workflows/<key>/workflow.ts`。内置 workflow 由安装器从随程序附带的种子包装到这里，装完就是普通的已安装包。
+- Project Root：当前项目根 `.nbook/agent/workflows/<key>/workflow.ts`。只有调用方显式绑定了该 Project Workspace 时才会读取这一层；未绑定项目时，项目 workflow 不会泄漏到全局或其他项目。
+- `assets/workspace/.nbook/agent/workflows/` 是 Seed Root，**不是 catalog 层**。catalog 不从这里加载任何 workflow，它只作为安装器的来源。
+- `<key>` 是稳定寻址键。同 key 时整个 catalog 条目覆盖，不会合并两份 `workflow.ts`。
+- 覆盖顺序固定为 `Install Root → Project Root`；后层同 key 有效目录覆盖前层。安装、升级、卸载与来源记账见 [agent-asset-install.md](../agent-asset-install.md)。
 - 文件内的 `key` 仍应和目录名一致，但 catalog 最终以目录名覆盖文件内 `key`。
 - catalog 只读取固定入口 `workflow.ts`。源码不能 `import` 或 `require`；运行能力来自 `wf`，JSON Schema 构造器来自宿主注入的 typebox `Type`。
 

--- a/reference/workspace/TERMS.md
+++ b/reference/workspace/TERMS.md
@@ -22,13 +22,15 @@
 - **Project Workspace Download Archive**：Project Workspace 的可携带完整备份。普通文件继续遵守 `.gitignore`，`project.yaml`、Project Config、Project SQLite 和已有 History SQLite 强制纳入；两个 SQLite 使用独立在线 snapshot，不复制 live WAL/SHM。History SQLite 可能包含全文、删除内容、acceptance 与 session cursor，分享前必须评估隐私风险。
 - **user-assets**：前端用于编辑 Workspace Root `.nbook` 的入口。它不是独立配置层，而是把当前 Studio 挂载在 `workspace/.nbook/`。
 - **Bundled Workspace Template**：随项目发布的默认 workspace 模板与系统资源，位于 `assets/workspace/`。
+- **Seed Root**：Bundled Workspace Template 中的 `agent/{skills,workflows,profiles}/`，是随程序附带的 Agent 资产种子包仓库。它是只读的，**不是 catalog 层**；catalog 不从这里加载资产，安装器只把它当作来源之一。见 [Agent Asset Install Protocol](../agent/agent-asset-install.md)。
+- **Install Root**：Workspace Root `.nbook` 下的 `agent/{skills,workflows,profiles}/`，是已安装 Agent 资产的落点与 provenance 账本所在位置。它在 State Root 之下，随 Windows Portable 的 `data/` 一起搬移。
 
 ## Path Mapping
 
 - `assets/workspace/.nbook` 是系统模板层，映射到运行时 `workspace/.nbook`。
 - `NEURO_BOOK_STATE_ROOT` 决定 State Root；Workspace Root、Boot Config、Product Env 和日志都从 State Root 解析。
 - Windows Portable 的物理 Workspace Root 是 `data/workspace/`，但 Project API 的 `projectRoot` 仍是同一个单段 root。
-- 用户的 `workspace/.nbook` 可以覆盖系统 `assets/workspace/.nbook`。
+- 用户的 `workspace/.nbook` 可以覆盖系统 `assets/workspace/.nbook`，但**这条只对 `templates/` 与 `variables/` 成立**。`agent/{skills,workflows,profiles}/` 已改为包安装模型：Seed Root 不参与覆盖，资产由安装器装进 Install Root，catalog 层级是 `Install Root → Project Root`。见 [Agent Asset Install Protocol](../agent/agent-asset-install.md)。
 - `assets/workspace/global.config.example.json` 对应运行时 `workspace/.nbook/config.json` 的示例。
 - `assets/workspace/workspace.config.example.json` 对应运行时 `workspace/{project}/.nbook/config.json` 的示例。
 - user-assets 入口直接编辑 `workspace/.nbook`，不再使用 `workspace/.nbook/assets` 作为嵌套资产根。


### PR DESCRIPTION
Closes #35\n\n本 PR 建立 Agent 资产安装协议、Skill frontmatter 身份合同与 skill-creator 校验/生成工具，并加入两条 llmlint 内置 workflow。\n\n明确边界：不包含完整安装器实现，也不把站点 Workshop 适配或资产迁移伪装成已完成。\n\n验证：\n- 16 个内置 Skill 通过 quick_validate；已知 RP模式 中文目录按合同拒绝\n- init_skill -> quick_validate 端到端通过；中文 id 拒绝\n- git diff --check 通过\n- 文档/参考合同与 ADR 0011、双语 Agent 索引同步