### PR TITLE
chore(agent): sync llmlint runtime snapshot

### DIFF
--- a/assets/workspace/.nbook/agent/skills/llmlint/SKILL.md
+++ b/assets/workspace/.nbook/agent/skills/llmlint/SKILL.md
@@ -133,19 +133,23 @@ bun "<skill-root>/bin/llmlint.ts" check <files...> --format json > <轮目录>/c
 
 落盘之后再读这个文件做步骤 3。**不要把命中数字抄进台账**——`contribute` 会直接从这份 JSON 统计命中分布，抄一遍只是多一次抄错的机会。
 
+`check` 的退出码是 eslint 式门禁：有 high 命中时 exit 1、无 high 时 exit 0——JSON 输出不受影响（stdout 照常完整、stderr 保持空）。脚本和 Agent 不要用退出码判断「是否成功」，要看 JSON 是否生成。
+
 为什么创作类要 `--review all`：默认 agent 桶只收「低误杀、可直接交 Agent 处理」的规则，规则整理已把大量语境敏感规则下沉到 human 桶。实测一篇 P(AI) 0.88 的轻小说，agent 桶只给 5 条命中，而这篇最强的 AI 味特征（比喻密度 19 处 / 10.25 每千字）整体在 human 桶——只看 agent 桶会漏掉本篇最该讨论的问题。
 
 两个桶的用法不同，不要混：
 - `agent` 桶是默认**可修**入口。
 - `human` 桶参与四象限判断、密度判断和「问 / 留」分流，但默认不进「修」。要修 human 桶命中，必须先向用户说明理由并取得同意。
 
-JSON 默认是紧凑形态：规则元数据在顶层 `rules`，命中只带 `ruleId`，`context` 裁到命中前后各 24 字。要看规则的 `detector.targets` / `source` / `scope` 才加 `--rule-detail`（体积大 4 倍以上，日常审稿别用）。
+`check --format json` 的紧凑形态字段路径（实测按名猜会踩坑）：顶层 `{kind, filePath, summary, filter, rules, issues, densityIssues?, diagnostics, registry}`。`summary` 含 `total/high/medium/low/visibleChars`（`visibleChars` 是修复前后篇幅对比的同分母口径）；`rules` 是**对象字典**（ruleId → `{namespace,title,level,review,fixability,scope,action,note?}`），不是数组；逐处命中在 **`issues[]`**（每项 `{ruleId,line,column,endLine,endColumn,match,context:{before,current,after}}`，`context` 各裁 24 字）；密度指纹在 `densityIssues[]`（`{ruleId,line,column,hits,perKilo,samples}`）。要看规则的 `detector.targets` / `source` / `scope` 才加 `--rule-detail`（体积大 4 倍以上，日常审稿别用）。
 
 再跑神经检测：
 
 ```bash
 bun "<skill-root>/bin/llmlint.ts" detect <files...> --format json > <轮目录>/detect-source.json
 ```
+
+`detect --format json` 的结构：顶层 `{kind:"detect", files:[...]}`，单文件时结果在 **`files[0]`** 下，字段 `{filePath, docPAi, maxPAi, spread, cached, chunks:[{span,line,pAi,rank,relative,preview?}]}`。`docPAi` 是整篇均值、`spread` 是文内极差（四象限守门用）、`chunks[]` 保持原文顺序、`rank` 是 P(AI) 降序位次、`relative` 是相对整篇均值的偏离、`preview` 是原文前 40–60 字（v3.0.1+，不用再按 `span` 偏移自行切文本）。
 
 `detect` 使用默认 HF Space `yuchuantian-aigc-text-detector.hf.space`，按句界分块并缓存正文哈希。网络失败时报告失败原因和代理设置建议；已完成文件的缓存仍可保留。代理可配置：
 

--- a/assets/workspace/.nbook/agent/skills/llmlint/references/cli-usage.md
+++ b/assets/workspace/.nbook/agent/skills/llmlint/references/cli-usage.md
@@ -242,6 +242,7 @@ filler-word-actually [filler] (无意义填充词)
 handler 命中可能带 `detail`，用于说明动态计数，例如连续短句数量。density 命中在 stylish 输出中以“密度指纹”分段显示，包含命中次数、每千字密度和样本。
 
 `--min-level` 会隐藏低于指定级别的候选，并在 stylish / JSON 输出中记录被隐藏数量。默认值是 `low`，即显示全部级别。
+`check` 的退出码是 eslint 式门禁：有 high 命中时 exit 1、无 high 时 exit 0；JSON 照常完整输出（stdout）、stderr 保持空，脚本不要用退出码判断「是否成功」。
 `--review` 会按审查受众过滤候选，默认 `agent`。`--review` 与 `--min-level` 是两个独立过滤器，被隐藏数量分别统计为“按审查受众隐藏”和“按级别隐藏”。
 `--show-lines` 只影响 stylish 输出。JSON 的 `context` 默认裁到命中前后各 24 个码点；要完整整行前后文用 `--rule-detail`。
 

--- a/assets/workspace/.nbook/agent/skills/llmlint/src/cli.ts
+++ b/assets/workspace/.nbook/agent/skills/llmlint/src/cli.ts
@@ -17,8 +17,9 @@ import {readDetectCache, detectCacheKey, writeDetectCache} from "./detect/cache"
 import {chunkBySentence} from "./detect/chunk";
 import {aggregate, defaultDetectorOptions, HfTransport, type DetectPayload, type DetectorTransport} from "./detect/transport";
 import {loadUserSettings, saveUserSettings, userCacheDir} from "./user-state";
-import {beginRound} from "./round";
+import {beginRound, computeRoundMetrics} from "./round";
 import {contribute, listOutbox, outboxDir} from "./contribute";
+import {buildReport} from "./report";
 import {LLMLINT_VERSION} from "./version";
 import type {ActiveRuleRecord, CheckFileEntry, CheckFilterInfo, DensityIssue, FixFileResult, Issue, LlmlintOutput, MaskedRange, RegexRuleRecord, Review, RuleDetectorKind, RuleLevel} from "./types";
 import type {SharingMode, SharingTier, UserSettings} from "./user-state";
@@ -55,6 +56,8 @@ type DetectChunkReport = DetectPayload["chunks"][number] & {
     rank: number;
     /** 相对文档均值的偏离（pAi − docPAi）。正=比本篇平均更可疑。 */
     relative: number;
+    /** chunk 开头可见字符预览，免去消费者按 span 偏移自行切原文。 */
+    preview?: string;
 };
 type DetectFileReport = {
     filePath: string;
@@ -270,6 +273,38 @@ export async function runCli(argv: string[]): Promise<void> {
             }
         });
 
+    const report = program
+        .command("report")
+        .description("把 check + detect 的 JSON 合成审稿报告（静态分级 + 密度指纹 + 四象限交叉）")
+        .option("--check <path>", "check --format json 的输出文件（必需）")
+        .option("--detect <path>", "detect --format json 的输出文件；缺省只做静态部分")
+        .option("--density-threshold <n>", "四象限「规则密集」的 chunk 内命中下限（默认 3）")
+        .option("--min-level <level>", "只统计不低于该级别的命中：high / medium / low（默认 low）")
+        .action(async (commandOptions: {check?: string; detect?: string; densityThreshold?: string; minLevel?: string}) => {
+            try {
+                const checkPath = commandOptions.check;
+                if (!checkPath) {
+                    throw new Error("report 需要 --check <check.json>（check --format json 的输出文件）");
+                }
+                const checkJson = JSON.parse(readFileSync(checkPath, "utf-8"));
+                const detectJson = commandOptions.detect
+                    ? JSON.parse(readFileSync(commandOptions.detect, "utf-8"))
+                    : null;
+                const threshold = Number(commandOptions.densityThreshold ?? 3);
+                if (!Number.isFinite(threshold) || threshold < 1) {
+                    throw new Error("--density-threshold 必须是 ≥1 的数字");
+                }
+                const minLevel = commandOptions.minLevel ?? "low";
+                if (!LEVELS.has(minLevel as RuleLevel)) {
+                    throw new Error(`--min-level 必须是 ${[...LEVELS].join(" / ")} 之一`);
+                }
+                process.stdout.write(buildReport(checkJson, detectJson, {densityThreshold: threshold, minLevel: minLevel as RuleLevel}) + "\n");
+            } catch (error) {
+                console.error(`错误: ${error instanceof Error ? error.message : String(error)}`);
+                process.exitCode = 1;
+            }
+        });
+
     const round = program
         .command("round")
         .description("多轮修订谱系：把一轮审稿的修前快照、计划、修后稿与检测产物收在同一个目录");
@@ -282,6 +317,39 @@ export async function runCli(argv: string[]): Promise<void> {
         .action(async (files: string[], commandOptions: {parent?: string}) => {
             try {
                 await beginRoundCommand(files, commandOptions.parent);
+            } catch (error) {
+                console.error(`错误: ${error instanceof Error ? error.message : String(error)}`);
+                process.exitCode = 1;
+            }
+        });
+
+    round
+        .command("metrics")
+        .description("读轮目录的 check/detect JSON，输出台账 summary/retest 需要的指标与复测 verdict 建议")
+        .argument("<round>", "轮号")
+        .option("-f, --format <format>", "输出格式：stylish 或 json")
+        .action(async (roundArg: string, commandOptions: {format?: string}) => {
+            try {
+                const options = mergeOptions(program, commandOptions);
+                const parsed = Number.parseInt(roundArg, 10);
+                if (!Number.isInteger(parsed) || parsed < 1) {
+                    throw new Error(`轮号必须是正整数，当前为 ${roundArg}`);
+                }
+                const result = computeRoundMetrics(process.cwd(), parsed);
+                if (resolveOutput("stylish", options.format) === "json") {
+                    console.log(JSON.stringify({kind: "round-metrics", ...result}, null, 2));
+                } else {
+                    console.log([
+                        `round: ${result.round}`,
+                        `dir: ${result.dir}`,
+                        `staticIssues: ${result.staticIssues ?? "—"}`,
+                        `densityIssues: ${result.densityIssues ?? "—"}`,
+                        `docPAi: ${result.docPAi === null ? "—" : result.docPAi.toFixed(3)}`,
+                        `spread: ${result.spread === null ? "—" : result.spread.toFixed(3)}`,
+                        `verdict: ${result.verdict ?? "—（未复测）"}`,
+                        ...(result.message.length > 0 ? [`提示: ${result.message.join("；")}`] : []),
+                    ].join("\n"));
+                }
             } catch (error) {
                 console.error(`错误: ${error instanceof Error ? error.message : String(error)}`);
                 process.exitCode = 1;
@@ -324,6 +392,14 @@ async function beginRoundCommand(files: string[], parent: string | undefined): P
         `dir: ${relative}`,
         `source: ${result.snapshots.map((name) => `${relative}/source/${name}`).join("、")}`,
         `parent: ${parentRound === null ? "null（另起一篇）" : String(parentRound)}`,
+        "",
+        "下一步：",
+        `  1. check --review all --format json > ${relative}/check-source.json`,
+        `  2. detect --format json > ${relative}/detect-source.json`,
+        `  3. report --check ${relative}/check-source.json --detect ${relative}/detect-source.json（合成审稿报告）`,
+        "  4. 生成 plan.md → 用户审批 → 修复到 output/",
+        `  5. 复测：check / detect 落 ${relative}/check-output.json、detect-output.json`,
+        `  6. round metrics ${result.round}（算台账指标与 verdict）→ contribute --auto --round ${result.round}`,
     ].join("\n"));
 }
 
@@ -868,6 +944,16 @@ function chunkSpread(chunks: DetectPayload["chunks"]): number {
     return Math.max(...scores) - Math.min(...scores);
 }
 
+/** preview 最大码点数：足够判断 chunk 主题，又控制 JSON 体积。 */
+const DETECT_PREVIEW_CHARS = 48;
+
+/** 取 chunk 开头可见字符作 preview：折叠空白，按码点裁剪，避免切断代理对。 */
+function chunkPreview(content: string, chunk: {span: [number, number]}): string {
+    const raw = content.slice(chunk.span[0], Math.min(content.length, chunk.span[0] + DETECT_PREVIEW_CHARS * 2));
+    const compact = raw.replace(/\s+/gu, " ");
+    return Array.from(compact).slice(0, DETECT_PREVIEW_CHARS).join("");
+}
+
 function toDetectReport(result: DetectFileResult): DetectFileReport {
     // 派生字段（rank / relative / spread）在报告层算，刻意不写进缓存 payload：
     // 否则每次给报告加字段都要让全部 content-hash 缓存失效。
@@ -884,6 +970,7 @@ function toDetectReport(result: DetectFileResult): DetectFileReport {
             ...chunk,
             rank: rankByChunk.get(chunk) ?? 1,
             relative: chunk.pAi - result.docPAi,
+            preview: chunkPreview(result.content, chunk),
         })),
     };
 }

--- a/assets/workspace/.nbook/agent/skills/llmlint/src/report.ts
+++ b/assets/workspace/.nbook/agent/skills/llmlint/src/report.ts
@@ -1,0 +1,291 @@
+/**
+ * report：把 check + detect 的 JSON 合成一份面向用户的审稿报告。
+ *
+ * 纯函数核心（输入 JSON 对象 → 输出 markdown 字符串），不依赖终端与文件系统，
+ * 供 CLI（skill/src/cli.ts 的 `report` 命令）与 workflow 复用。
+ *
+ * 报告结构：
+ *   1. 统计摘要（静态命中分级 + 密度指纹 + 检测两层结论）
+ *   2. 静态分级表（level × review 桶聚合，带行号样本）
+ *   3. 四象限交叉（规则信号 × 检测热力）
+ *   4. 语义规则提示
+ *
+ * 四象限语义与 SKILL.md 步骤 3 对齐：规则密集 × 文内高位 = 确认疑难；
+ * 规则静默 × 文内高位 = 漏网新规则候选；规则密集 × 文内低位 = 规则与检测器分歧；
+ * 规则静默 × 文内低位 = 不打扰。spread < 0.15 时四象限不适用，改用规则信号密度排序。
+ */
+import type {CheckJsonReport} from "./types";
+
+/** detect JSON 中单个 chunk 的最小投影（与 cli.ts DetectFileReport 对齐，preview 为 v3.0.1+ 可选字段）。 */
+export type ReportDetectChunk = {
+    span: [number, number];
+    line: number;
+    pAi: number;
+    rank: number;
+    relative: number;
+    preview?: string;
+};
+
+/** detect JSON 中单个文件的报告投影。 */
+export type ReportDetectFile = {
+    filePath: string;
+    docPAi: number;
+    maxPAi: number;
+    spread: number;
+    cached: boolean;
+    chunks: ReportDetectChunk[];
+};
+
+/** detect --format json 顶层结构。 */
+export type ReportDetectJson = {
+    kind: "detect";
+    files: ReportDetectFile[];
+};
+
+export type ReportOptions = {
+    /** 四象限「规则密集」的 chunk 内命中数下限。默认 3。 */
+    densityThreshold?: number;
+    /** 只统计不低于该级别的命中。默认 low（全部）。 */
+    minLevel?: "high" | "medium" | "low";
+};
+
+/** 整篇层（绝对）判据：docPAi 达到该值即「这篇整体可疑」。与 cli.ts DETECT_DOC_SUSPICIOUS 同源。 */
+const DOC_SUSPICIOUS = 0.85;
+/** 四象限有效性守门：文内 P(AI) 极差低于该值时不适用。与 cli.ts DETECT_SPREAD_FLOOR 同源。 */
+const SPREAD_FLOOR = 0.15;
+/** 门槛边界带半宽：spread 落在 FLOOR ± 该值内时位次只是弱证据。与 cli.ts DETECT_SPREAD_MARGIN 同源。 */
+const SPREAD_MARGIN = 0.05;
+
+const LEVEL_RANK: Record<string, number> = {high: 3, medium: 2, low: 1};
+
+/** 四象限命中的语义标签。 */
+type Quadrant = "confirm" | "leak" | "dispute" | "quiet";
+
+/** 单个 chunk 的四象限分析结果。 */
+type ChunkQuadrant = {
+    chunk: ReportDetectChunk;
+    hits: number;
+    quadrant: Quadrant;
+};
+
+/** 截取命中文本作为样本：行号 + 前 maxChars 字。 */
+function sampleFor(issue: {line: number; match?: string}, maxChars = 24): string {
+    const match = issue.match ?? "";
+    const trimmed = Array.from(match).slice(0, maxChars).join("");
+    return `L${issue.line}:${trimmed}${Array.from(match).length > maxChars ? "…" : ""}`;
+}
+
+/** 取一行 markdown 表格的转义：竖线与换行替换为空格。 */
+function cell(text: string): string {
+    return text.replace(/\|/gu, "\\|").replace(/\n+/gu, " ");
+}
+
+/**
+ * 按行号把 check 命中归到 detect chunk。
+ *
+ * chunk i 覆盖的行区间取 `[chunk.line, 下一 chunk.line)`，最后一个 chunk 延伸到 Infinity。
+ * 行号落在区间的命中归属该 chunk；没有 detect 时全部命中不参与四象限，只进分级表。
+ */
+export function assignIssuesToChunks(
+    issues: Array<{line: number}>,
+    chunks: ReportDetectChunk[],
+): Map<number, number> {
+    const counts = new Map<number, number>();
+    if (chunks.length === 0) {
+        return counts;
+    }
+    for (const issue of issues) {
+        let index = chunks.length - 1;
+        for (let i = 0; i < chunks.length - 1; i++) {
+            if (issue.line >= chunks[i].line && issue.line < chunks[i + 1].line) {
+                index = i;
+                break;
+            }
+        }
+        counts.set(index, (counts.get(index) ?? 0) + 1);
+    }
+    return counts;
+}
+
+/** 计算单个 chunk 的四象限归属。 */
+function quadrantOf(chunk: ReportDetectChunk, hits: number, chunkCount: number, densityThreshold: number): Quadrant {
+    const tail = Math.ceil(chunkCount / 4);
+    const isHigh = chunk.rank <= tail;
+    const isLow = chunk.rank > chunkCount - tail;
+    const dense = hits >= densityThreshold;
+    const silent = hits === 0;
+    if (dense && isHigh) return "confirm";
+    if (silent && isHigh) return "leak";
+    if (dense && isLow) return "dispute";
+    return "quiet";
+}
+
+/** 组装四象限结果：按 chunk 顺序返回，只保留有信号（confirm/leak/dispute）的项。 */
+function buildQuadrants(check: CheckJsonReport, detect: ReportDetectFile | null, options: ReportOptions): ChunkQuadrant[] {
+    if (!detect || detect.chunks.length === 0) {
+        return [];
+    }
+    const threshold = options.densityThreshold ?? 3;
+    const counts = assignIssuesToChunks(check.issues, detect.chunks);
+    const chunkCount = detect.chunks.length;
+    const results: ChunkQuadrant[] = [];
+    detect.chunks.forEach((chunk, index) => {
+        const hits = counts.get(index) ?? 0;
+        const quadrant = quadrantOf(chunk, hits, chunkCount, threshold);
+        if (quadrant !== "quiet") {
+            results.push({chunk, hits, quadrant});
+        }
+    });
+    return results;
+}
+
+/** 格式化一个四象限 chunk 行：rank、行号、P(AI)、命中数、preview。 */
+function formatQuadrantLine(item: ChunkQuadrant): string {
+    const preview = item.chunk.preview ? `  ${cell(item.chunk.preview)}` : "";
+    return `- rank ${item.chunk.rank} L${item.chunk.line} P(AI)=${item.chunk.pAi.toFixed(3)} 命中 ${item.hits} 处${preview}`;
+}
+
+/**
+ * 把 check + detect JSON 合成 markdown 审稿报告。
+ *
+ * @param check check --format json 的解析结果（紧凑形态）。
+ * @param detect detect --format json 的解析结果；传 null 时只做静态部分。
+ * @param options 密度阈值与级别过滤。
+ * @returns markdown 报告字符串（不以换行结尾）。
+ */
+export function buildReport(check: CheckJsonReport, detect: ReportDetectJson | null, options: ReportOptions = {}): string {
+    const lines: string[] = [];
+    const minLevel = options.minLevel ?? "low";
+    const minLevelRank = LEVEL_RANK[minLevel] ?? 1;
+
+    // 过滤命中（级别过滤；density 命中不参与级别过滤，它们本来就没有 level 语义）
+    const filtered = check.issues.filter((issue) => {
+        const rule = check.rules[issue.ruleId];
+        return rule && (LEVEL_RANK[rule.level] ?? 1) >= minLevelRank;
+    });
+
+    // 单文件 detect 取与 check 匹配的文件；不匹配或缺失时取 files[0]（多文件场景由调用方保证对应）
+    const detectFile: ReportDetectFile | null = detect && detect.files.length > 0
+        ? detect.files.find((f) => f.filePath === check.filePath) ?? detect.files[0]!
+        : null;
+
+    // 1. 统计摘要
+    const s = check.summary;
+    lines.push("# llmlint 审稿报告");
+    lines.push("");
+    lines.push(`文件：\`${check.filePath}\`（${s.visibleChars} 可见字）`);
+    lines.push("");
+    lines.push("## 统计摘要");
+    lines.push("");
+    lines.push(`- 静态检查：**${filtered.length} 处命中**（high ${s.high} / medium ${s.medium} / low ${s.low}）`);
+    if (check.densityIssues && check.densityIssues.length > 0) {
+        for (const d of check.densityIssues) {
+            lines.push(`- 密度指纹：\`${d.ruleId}\` **${d.hits} 处 / ${d.perKilo} 每千字**（样本：${d.samples.slice(0, 3).join("、")}）`);
+        }
+    }
+    if (detectFile) {
+        const docVerdict = detectFile.docPAi >= DOC_SUSPICIOUS ? "整体可疑" : "整体不判可疑";
+        const spreadVerdict = detectFile.spread < SPREAD_FLOOR - SPREAD_MARGIN
+            ? "四象限不适用（文内无高低差，改用规则信号密度）"
+            : detectFile.spread < SPREAD_FLOOR + SPREAD_MARGIN
+                ? "四象限弱适用（spread 贴近门槛，位次仅作弱证据，以规则信号为主）"
+                : "四象限适用";
+        lines.push(`- 神经检测：docPAi **${detectFile.docPAi.toFixed(3)}**（${docVerdict}）；spread **${detectFile.spread.toFixed(3)}**（${spreadVerdict}）`);
+    } else {
+        lines.push("- 神经检测：未提供 detect JSON，只有静态部分");
+    }
+    lines.push("");
+
+    // 2. 静态分级表（level × review 桶聚合）
+    lines.push("## 静态分级表");
+    lines.push("");
+    const buckets = new Map<string, Map<string, {rule: {level: string}; count: number; samples: string[]}>>();
+    for (const issue of filtered) {
+        const rule = check.rules[issue.ruleId];
+        if (!rule) continue;
+        const bucketKey = rule.review ?? "agent";
+        const ruleKey = `${rule.title}（${issue.ruleId}）`;
+        if (!buckets.has(bucketKey)) buckets.set(bucketKey, new Map());
+        const rulesMap = buckets.get(bucketKey)!;
+        if (!rulesMap.has(ruleKey)) rulesMap.set(ruleKey, {rule: {level: rule.level}, count: 0, samples: []});
+        const entry = rulesMap.get(ruleKey)!;
+        entry.count += 1;
+        if (entry.samples.length < 3) entry.samples.push(sampleFor(issue));
+    }
+    if (buckets.size === 0) {
+        lines.push("（无命中）");
+    }
+    for (const [bucket, rulesMap] of buckets) {
+        lines.push(`### ${bucket} 桶`);
+        lines.push("");
+        lines.push("| 规则 | 级别 | 命中 | 样本 |");
+        lines.push("| --- | --- | --- | --- |");
+        const sorted = [...rulesMap.entries()].sort((a, b) => b[1].count - a[1].count);
+        for (const [ruleKey, entry] of sorted) {
+            lines.push(`| ${cell(ruleKey)} | ${entry.rule.level} | ${entry.count} | ${cell(entry.samples.join("；"))} |`);
+        }
+        lines.push("");
+    }
+
+    // 3. 四象限交叉
+    lines.push("## 四象限交叉");
+    lines.push("");
+    if (!detectFile || detectFile.chunks.length === 0) {
+        lines.push("（无 detect 数据，跳过）");
+    } else if (detectFile.spread < SPREAD_FLOOR - SPREAD_MARGIN) {
+        lines.push(`spread ${detectFile.spread.toFixed(3)} < ${SPREAD_FLOOR}：文内 P(AI) 没有可分辨的高低差，四象限不适用。整篇${detectFile.docPAi >= DOC_SUSPICIOUS ? "均匀可疑" : "均匀不疑"}，按规则信号密度排候选优先级（见下方密度排序）。`);
+    } else {
+        const quadrants = buildQuadrants(check, detectFile, options);
+        const groups: Record<Quadrant, ChunkQuadrant[]> = {confirm: [], leak: [], dispute: [], quiet: []};
+        for (const item of quadrants) groups[item.quadrant].push(item);
+        if (groups.confirm.length > 0) {
+            lines.push("### 规则密集 × 文内高位（确认疑难，优先读上下文）");
+            lines.push("");
+            for (const item of groups.confirm) lines.push(formatQuadrantLine(item));
+            lines.push("");
+        }
+        if (groups.leak.length > 0) {
+            lines.push("### 规则静默 × 文内高位（漏网新规则候选，记录观察，不直接大改）");
+            lines.push("");
+            for (const item of groups.leak) lines.push(formatQuadrantLine(item));
+            lines.push("");
+        }
+        if (groups.dispute.length > 0) {
+            lines.push("### 规则密集 × 文内低位（规则与检测器分歧，需人工裁决——低位不等于像人写）");
+            lines.push("");
+            for (const item of groups.dispute) lines.push(formatQuadrantLine(item));
+            lines.push("");
+        }
+        if (groups.confirm.length + groups.leak.length + groups.dispute.length === 0) {
+            lines.push("（无显著象限信号）");
+            lines.push("");
+        }
+    }
+
+    // 4. 密度排序（spread 不适用时的候选优先级；也作为四象限的补充视图）
+    if (detectFile && detectFile.chunks.length > 0) {
+        const counts = assignIssuesToChunks(check.issues, detectFile.chunks);
+        const byDensity = detectFile.chunks
+            .map((chunk, index) => ({chunk, hits: counts.get(index) ?? 0}))
+            .filter((item) => item.hits > 0)
+            .sort((a, b) => b.hits - a.hits || a.chunk.rank - b.chunk.rank)
+            .slice(0, 8);
+        if (byDensity.length > 0) {
+            lines.push("### 规则信号密度排序（候选处理优先级）");
+            lines.push("");
+            for (const item of byDensity) {
+                lines.push(formatQuadrantLine({chunk: item.chunk, hits: item.hits, quadrant: "confirm"}));
+            }
+            lines.push("");
+        }
+    }
+
+    // 5. 语义规则提示
+    lines.push("## 语义规则提示");
+    lines.push("");
+    lines.push("静态检查定位不到语义规则（模板化设问、过度解释、机械升华等）。执行 `llmlint rules --detector semantic` 获取判定说明与对照例，主动读全文审查。");
+    lines.push("");
+    lines.push("> 报告只做候选定位与交叉提示，不是修改命令。每条候选按「修 / 留 / 问」分流，先读命中前后文再动手。");
+
+    return lines.join("\n");
+}

--- a/assets/workspace/.nbook/agent/skills/llmlint/src/round.ts
+++ b/assets/workspace/.nbook/agent/skills/llmlint/src/round.ts
@@ -502,3 +502,88 @@ function snapshotNameKey(name: string): string {
 export function portableBasename(file: string): string {
     return file.replace(/\\/g, "/").split("/").filter(Boolean).at(-1) ?? "";
 }
+
+/** round metrics 的结果：台账 summary/retest 需要的四项指标 + 复测 verdict 建议。 */
+export type RoundMetricsResult = {
+    round: number;
+    dir: string;
+    /** check-source.json 的静态命中总数；缺文件或字段为 null。 */
+    staticIssues: number | null;
+    /** density 命中数；缺文件为 null。 */
+    densityIssues: number | null;
+    /** detect 的 docPAi；缺文件为 null。 */
+    docPAi: number | null;
+    /** detect 的 spread；缺文件为 null。 */
+    spread: number | null;
+    /** 复测判据（有 check-output.json 时）：pass / fail；未复测为 null。 */
+    verdict: "pass" | "fail" | null;
+    /** 缺文件等说明；空数组 = 全部齐备。 */
+    message: string[];
+};
+
+/**
+ * 读轮目录的 check/detect JSON，算出台账 summary/retest 需要的四项指标。
+ *
+ * 有 `check-output.json`（复测产物）时再给 verdict 建议：静态命中减少、
+ * 没有引入新规则命中、篇幅在原文 ±20% 内三条同时成立为 pass。
+ * 检测分数不参与 verdict（SKILL 步骤 4：检测分数只作参考，不作目标）。
+ */
+export function computeRoundMetrics(cwd: string, round: number): RoundMetricsResult {
+    const dir = roundDir(cwd, round);
+    const checkSourcePath = join(dir, "check-source.json");
+    const detectSourcePath = join(dir, "detect-source.json");
+    const checkOutputPath = join(dir, "check-output.json");
+    const message: string[] = [];
+
+    let staticIssues: number | null = null;
+    let densityIssues: number | null = null;
+    let docPAi: number | null = null;
+    let spread: number | null = null;
+    let sourceVisible: number | null = null;
+    const sourceRuleIds = new Set<string>();
+
+    if (existsSync(checkSourcePath)) {
+        const check = JSON.parse(readFileSync(checkSourcePath, "utf-8"));
+        staticIssues = check.summary?.total ?? null;
+        densityIssues = Array.isArray(check.densityIssues) ? check.densityIssues.length : null;
+        sourceVisible = check.summary?.visibleChars ?? null;
+        for (const ruleId of Object.keys(check.rules ?? {})) {
+            sourceRuleIds.add(ruleId);
+        }
+    } else {
+        message.push(`缺 ${checkSourcePath}`);
+    }
+
+    if (existsSync(detectSourcePath)) {
+        const detect = JSON.parse(readFileSync(detectSourcePath, "utf-8"));
+        const file = detect.files?.[0];
+        docPAi = typeof file?.docPAi === "number" ? file.docPAi : null;
+        spread = typeof file?.spread === "number" ? file.spread : null;
+    } else {
+        message.push(`缺 ${detectSourcePath}`);
+    }
+
+    let verdict: "pass" | "fail" | null = null;
+    if (existsSync(checkOutputPath)) {
+        const output = JSON.parse(readFileSync(checkOutputPath, "utf-8"));
+        const outputTotal = output.summary?.total ?? null;
+        const outputVisible = output.summary?.visibleChars ?? null;
+        const outputRuleIds = new Set<string>();
+        for (const issue of output.issues ?? []) {
+            outputRuleIds.add(issue.ruleId);
+        }
+        const reduced = outputTotal !== null && staticIssues !== null && outputTotal < staticIssues;
+        const noNewRules = [...outputRuleIds].every((ruleId) => sourceRuleIds.has(ruleId));
+        const withinBudget = outputVisible !== null && sourceVisible !== null
+            && outputVisible >= sourceVisible * 0.8 && outputVisible <= sourceVisible * 1.2;
+        const checks = [
+            reduced ? "命中减少" : "命中未减少",
+            noNewRules ? "无新规则命中" : "引入新规则命中",
+            withinBudget ? "篇幅 ±20% 内" : "篇幅超出 ±20%",
+        ];
+        verdict = reduced && noNewRules && withinBudget ? "pass" : "fail";
+        message.push(`复测：${checks.join("、")}`);
+    }
+
+    return {round, dir, staticIssues, densityIssues, docPAi, spread, verdict, message};
+}


### PR DESCRIPTION
Closes #37\n\n同步 sibling llmlint master 的可安装 runtime snapshot，包含 report/round/CLI 与对应文档。sibling 已通过 bun run verify；本 PR 不维护第二份源码，不实现安装器。\n\n验证：git diff --check；快照变更来自正式同步路径，新增 report.ts 与 sibling 内容一致。