### PR TITLE
feat(release): source prerelease notes from RELEASE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@
 ## 发布流程
 
 - 发布前先阅读 `PROJECT-STATUS.md` 和相关 `docs/tasks/**/README.md` / walkthrough，确认本轮改动、验证记录和任务状态。
-- 发布前必须更新 `RELEASE.md`，严格按「面向用户的语言风格」小节写：只留当前版本，历史版本移到 `docs/changelog/` 并同步英文镜像 `docs/en/changelog/`。release 脚本不读 `RELEASE.md`（GitHub prerelease 正文是硬编码模板），所以它纯粹是给人看的，写不好没有任何机器会拦你。
+- 发布前必须更新 `RELEASE.md`，严格按「面向用户的语言风格」小节写：只留当前版本，历史版本移到 `docs/changelog/` 并同步英文镜像 `docs/en/changelog/`。prerelease 的 GitHub Release note 自动读取 `RELEASE.md` 当前版本段落（`## <版本> - <日期>` 起至文末）作为正文，缺失或为空时回退到通用模板并打印警告——写不好会直接出现在每个 canary release 页面上。
 - 提交前用 `git status --short --branch` 确认工作区范围；用户明确要求“提交全部改动”时，才使用 `git add -A` 纳入全部 tracked / untracked 改动。
 - 任何 worktree 或 agent 向远端 `master` 推送或合并后，主工作区必须立刻 `git fetch && git merge --ff-only origin/master`（分支与 worktree 约定见「Git 工作流」）。否则主工作区的 `master` 永远停在旧提交，下次提交就变成分叉；同一份改动也不要在主工作区和 worktree 各提交一次，那会产出 patch-id 相同、SHA 不同的重复提交。
 - 业务提交 message 要覆盖主要任务和用户可见能力。代码改动走分支 + squash PR（见「Git 工作流」）；`git push origin HEAD:master` 仅限文档类例外与 release 提交。如果远端拒绝，停止并报告，不要 force push。

--- a/scripts/release/release-notes.test.ts
+++ b/scripts/release/release-notes.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, it} from "vitest";
+
+import {extractReleaseNotes} from "nbook/scripts/release/release-notes";
+
+describe("extractReleaseNotes", () => {
+    it("提取第一个二级标题之后到文末的内容", () => {
+        const markdown = [
+            "# 更新日志",
+            "",
+            "历史版本见 docs/changelog/。",
+            "",
+            "## 0.9.0-canary - 2026-08-02",
+            "",
+            "本版本聚焦发布链路收口。",
+            "",
+            "### 新功能",
+            "",
+            "- 支持整书导入。",
+        ].join("\n");
+        expect(extractReleaseNotes(markdown)).toBe([
+            "本版本聚焦发布链路收口。",
+            "",
+            "### 新功能",
+            "",
+            "- 支持整书导入。",
+        ].join("\n"));
+    });
+
+    it("没有二级标题时返回空字符串", () => {
+        expect(extractReleaseNotes("# 更新日志\n\n只有引言。")).toBe("");
+    });
+
+    it("二级标题后无正文时返回空字符串", () => {
+        expect(extractReleaseNotes("# 更新日志\n\n## 0.9.0 - 2026-08-02\n\n")).toBe("");
+    });
+
+    it("兼容 CRLF 换行", () => {
+        const markdown = "# 更新日志\r\n\r\n## 0.9.0 - 2026-08-02\r\n\r\n正文。\r\n";
+        expect(extractReleaseNotes(markdown)).toBe("正文。");
+    });
+
+    it("不把三级标题当作版本标题", () => {
+        expect(extractReleaseNotes("# 更新日志\n\n### 不是版本\n\n内容。")).toBe("");
+    });
+});

--- a/scripts/release/release-notes.ts
+++ b/scripts/release/release-notes.ts
@@ -1,0 +1,23 @@
+import {readFile} from "node:fs/promises";
+import {resolve} from "node:path";
+
+/**
+ * 从 RELEASE.md 文本中提取当前版本段落：第一个 `## <版本> - <日期>` 二级标题之后到文末的正文。
+ *
+ * RELEASE.md 只保留当前版本，因此第一个二级标题即当前版本；标题行本身不进入 note
+ * （GitHub Release 标题已含版本号）。无二级标题或正文为空时返回空字符串，由调用方回退。
+ */
+export function extractReleaseNotes(markdown: string): string {
+    const lines = markdown.split(/\r?\n/);
+    const headingIndex = lines.findIndex((line) => /^##\s/u.test(line));
+    if (headingIndex < 0) {
+        return "";
+    }
+    return lines.slice(headingIndex + 1).join("\n").trim();
+}
+
+/** 读取仓库根 RELEASE.md 并提取当前版本段落；文件缺失或读取失败返回空字符串。 */
+export async function readReleaseNotesBody(repoRoot: string): Promise<string> {
+    const markdown = await readFile(resolve(repoRoot, "RELEASE.md"), "utf8").catch(() => "");
+    return extractReleaseNotes(markdown);
+}

--- a/scripts/release/release.ts
+++ b/scripts/release/release.ts
@@ -7,6 +7,7 @@ import {fileURLToPath} from "node:url";
 import {Command} from "commander";
 
 import {createReleaseCandidate} from "nbook/scripts/release/release-candidate";
+import {readReleaseNotesBody} from "nbook/scripts/release/release-notes";
 import {run, runCapture} from "nbook/scripts/utils/process.mjs";
 
 type CommonOptions = {
@@ -797,17 +798,27 @@ async function prereleaseNotes(input: ReleaseNotesInput, repo: string): Promise<
     const compareLine = previousTag
         ? `Compare: https://github.com/${repo}/compare/${previousTag}...${input.tag}`
         : "";
-    return [
-        `${input.channel} prerelease for early validation.`,
+    // 正文优先取 RELEASE.md 当前版本段落；缺失或为空时回退通用模板，不阻塞发布
+    const releaseBody = await readReleaseNotesBody(REPO_ROOT);
+    if (!releaseBody) {
+        console.warn("警告：未能从 RELEASE.md 提取当前版本段落，prerelease notes 回退到通用模板。");
+    }
+    const notes = [
+        releaseBody || `${input.channel} prerelease for early validation.`,
         "",
         `- Tag: ${input.tag}`,
         `- Commit: ${input.target}`,
         `- Package version: ${input.packageVersion}`,
         `- Channel: ${input.channel}`,
-        compareLine ? `- ${compareLine}` : "",
+        ...compareLine ? [`- ${compareLine}`] : [],
         "",
         "Windows portable and container images are produced by the release workflow.",
-    ].filter(Boolean).join("\n");
+    ].join("\n");
+    // Windows 进程命令行上限约 32k 字符，--notes 走命令行传参，留余量防御
+    if (notes.length > 30_000) {
+        throw new Error(`prerelease notes 过长（${notes.length} 字符，上限 30000）：请精简 RELEASE.md 当前版本段落。`);
+    }
+    return notes;
 }
 
 /** 组装正式版 release 命令。 */


### PR DESCRIPTION
## 关联

Closes #42

## 范围

- `scripts/release/release.ts` 的 `prereleaseNotes()`：Release note 正文从硬编码 `canary prerelease for early validation.` 改为读取 `RELEASE.md` 当前版本段落（`## <版本> - <日期>` 起至文末）
- 新增 `scripts/release/release-notes.ts`：`extractReleaseNotes` 纯函数（IO 分离）+ `readReleaseNotesBody`
- 新增 `scripts/release/release-notes.test.ts`：5 个边界测试（正常提取 / 无二级标题 / 空段落 / CRLF / 三级标题不误判）
- `AGENTS.md` 发布流程段同步描述

不在范围：stable 发布路径（`--generate-notes`，不受影响）；release workflow 本身。

## 行为

- `RELEASE.md` 缺失或提取为空：回退原通用模板并打印警告，不阻塞发布
- Tag / Commit / Package version / Channel / Compare metadata 块与尾部说明保留
- 保留 `--notes` 命令行传参：Windows 进程命令行上限约 32k 字符，当前 RELEASE.md 段落约 1-2k 字符，加 30000 字符防御性报错；不引入 `--notes-file` 临时文件机制（与 issue 描述的出入：评估后复杂度不值）
- 拼接保留空行（旧 `filter(Boolean)` 会吞掉分隔空行），markdown 渲染更规范

## 验证

- `bunx vitest run scripts/release/release-notes.test.ts`：5/5 通过（worktree 内需先 `bun run nuxt:prepare` 生成 tsconfig 产物）
- `bun run generate && bun run typecheck`：全绿
- `bun run release -- canary --next patch --dry-run`：dry-run 打印的 gh 命令中 notes 正文为 RELEASE.md 当前版本四个小节全文 + 完整 metadata 块，未触发回退警告
- 未执行真实发布（由维护者决定何时发下一个 canary）