### PR TITLE
fix(agent): complete cross-root session recovery

### DIFF
--- a/.agents/tasks/legacy-index.json
+++ b/.agents/tasks/legacy-index.json
@@ -399,8 +399,8 @@
     {
       "source": "docs/tasks/118-project-catalog-snapshot-path-integration/README.md",
       "destination": ".agents/tasks/118-project-catalog-snapshot-path-integration/README.md",
-      "sourceSha256": "sha256:2bc2a316175d7bfdc98caa14006be31ef04eb354cbe6d5ad1fb9cc8df4bc4d5d",
-      "destinationSha256": "sha256:2bc2a316175d7bfdc98caa14006be31ef04eb354cbe6d5ad1fb9cc8df4bc4d5d",
+      "sourceSha256": "sha256:3d5658c2ab019d18a3c4d2291ccb587a7ee64cb47b0cbfd95634c6547142ad89",
+      "destinationSha256": "sha256:3d5658c2ab019d18a3c4d2291ccb587a7ee64cb47b0cbfd95634c6547142ad89",
       "kind": "file",
       "linkRewrite": true
     },

--- a/.agents/tasks/ownership.json
+++ b/.agents/tasks/ownership.json
@@ -270,7 +270,7 @@
         {
           "path": "118-project-catalog-snapshot-path-integration/README.md",
           "legacyDestination": ".agents/tasks/118-project-catalog-snapshot-path-integration/README.md",
-          "sha256": "sha256:2bc2a316175d7bfdc98caa14006be31ef04eb354cbe6d5ad1fb9cc8df4bc4d5d"
+          "sha256": "sha256:3d5658c2ab019d18a3c4d2291ccb587a7ee64cb47b0cbfd95634c6547142ad89"
         },
         {
           "path": "118-project-catalog-snapshot-path-integration/SPEC-current-project-root.md",

--- a/packages/neuro-book/.agents/tasks/118-project-catalog-snapshot-path-integration/README.md
+++ b/packages/neuro-book/.agents/tasks/118-project-catalog-snapshot-path-integration/README.md
@@ -6,7 +6,7 @@
 - 主面板与 Inline Editor 的记忆写入继续是非阻断操作：权威 recovery 提交并启动 stream 后才写入；`localStorage` 写入失败只显示一次提示，不回滚已打开对话、不删除旧记忆。Session 丢失恢复只清理 ID 与 identity 同时匹配的记忆。
 - 关联关系读取新增窄的 `projectRelatedSessions()` 投影：目标 JSONL 自身缺失只计入 `unavailableLinkedAgents`，主 Session recovery 和轻量 relations 继续成功；损坏文件、权限错误以及指向其它 ID 的缺失仍原样抛出。前端轻量 relations 刷新也会把不可用数量写回 recovery shell。
 - 本轮新增/复核 focused 合计 **8 个文件 / 284 个测试通过**：`NeuroAgentHarness` 单独运行 `183/183`，其余 7 个状态/草稿/stream/identity/relation 文件分拆运行 `101/101`，包含真实关系目标删除后的 recovery 验收。8 文件并行调用会偶发触发 harness 内既有时间敏感断言；该用例在干净 PR 基线与当前 worktree 单独运行均通过，未用放宽超时掩盖。根 `bun run typecheck` 通过。该数字是本轮补充证据，之前 PR recovery 批次的 14/170 记录保留为历史结果，不合并冒充全量。
-- 详见 [ADR 0018](../../adr/0013-session-identity-and-browser-memory.md)。本轮仍不建立 State Root 实例身份协议、备份恢复、runtime lease 或自动创建 Session；同号 Session 的跨实例隔离另由后续 Issue 承载。
+- 详见 [ADR 0018](../../../docs/adr/0018-session-identity-and-browser-memory.md)。本轮仍不建立 State Root 实例身份协议、备份恢复、runtime lease 或自动创建 Session；同号 Session 的跨实例隔离另由后续 Issue 承载。
 
 > 2026-07-31 CLI 交付路径取代说明：本任务的 Project identity、mutation/Occupancy 与 fail-closed preflight 合同继续有效；CLI implementation/发行所有权由 Task 130 收口。当前同步面是 Product-owned Workspace CLI、`.nbook/agent/bin/workspace(.cmd)` wrapper 与 Product Runtime Contract 的 `workspace` 逻辑命令；下文 `assets/workspace/.nbook/agent/scripts/workspace.ts` 只保留为 hard-cut 时的历史证据，不恢复 asset script 或 `server/scripts` fallback。
 

--- a/packages/neuro-book/.agents/tasks/118-project-catalog-snapshot-path-integration/README.md
+++ b/packages/neuro-book/.agents/tasks/118-project-catalog-snapshot-path-integration/README.md
@@ -1,5 +1,13 @@
 # Task 118：Project 生命周期、文件快照与 Agent 路径合同联合执行计划
 
+## 2026-08-05：Session identity 与关联关系投影补充
+
+- 新 Session 的 header 现在生成 UUID；没有显式身份的旧 header 在读取时由稳定元数据派生 `sha256:` identity，并要求请求数字 ID 同时匹配文件名和 header。Agent summary/recovery/SSE 都携带 identity，浏览器记忆升级为版本化 `{schema: 2, sessionId, sessionIdentity}`；裸数字、损坏记忆和缺 identity 都进入 `unselected`，不会按列表首项猜测。
+- 主面板与 Inline Editor 的记忆写入继续是非阻断操作：权威 recovery 提交并启动 stream 后才写入；`localStorage` 写入失败只显示一次提示，不回滚已打开对话、不删除旧记忆。Session 丢失恢复只清理 ID 与 identity 同时匹配的记忆。
+- 关联关系读取新增窄的 `projectRelatedSessions()` 投影：目标 JSONL 自身缺失只计入 `unavailableLinkedAgents`，主 Session recovery 和轻量 relations 继续成功；损坏文件、权限错误以及指向其它 ID 的缺失仍原样抛出。前端轻量 relations 刷新也会把不可用数量写回 recovery shell。
+- 本轮新增/复核 focused 合计 **8 个文件 / 284 个测试通过**：`NeuroAgentHarness` 单独运行 `183/183`，其余 7 个状态/草稿/stream/identity/relation 文件分拆运行 `101/101`，包含真实关系目标删除后的 recovery 验收。8 文件并行调用会偶发触发 harness 内既有时间敏感断言；该用例在干净 PR 基线与当前 worktree 单独运行均通过，未用放宽超时掩盖。根 `bun run typecheck` 通过。该数字是本轮补充证据，之前 PR recovery 批次的 14/170 记录保留为历史结果，不合并冒充全量。
+- 详见 [ADR 0018](../../adr/0013-session-identity-and-browser-memory.md)。本轮仍不建立 State Root 实例身份协议、备份恢复、runtime lease 或自动创建 Session；同号 Session 的跨实例隔离另由后续 Issue 承载。
+
 > 2026-07-31 CLI 交付路径取代说明：本任务的 Project identity、mutation/Occupancy 与 fail-closed preflight 合同继续有效；CLI implementation/发行所有权由 Task 130 收口。当前同步面是 Product-owned Workspace CLI、`.nbook/agent/bin/workspace(.cmd)` wrapper 与 Product Runtime Contract 的 `workspace` 逻辑命令；下文 `assets/workspace/.nbook/agent/scripts/workspace.ts` 只保留为 hard-cut 时的历史证据，不恢复 asset script 或 `server/scripts` fallback。
 
 > 当前状态：G1–G5 与整体审查结论均已冻结，Phase 0–8 的代码 hard cut 已完成，仍待发布级全量门禁与人工浏览器验收。Session schema v2、Application State catalog v3、runtime fail-closed gate、ProjectSessionController close-then-open、最终 Project HTTP 合同和旧 identity 清理在同一 release train 内落地；真实 State Root 只通过隔离副本演练，正式用户数据不在本任务中再次改写。Project root发布采用portable rename：NeuroBook与`workspace` CLI writer由mutation + Occupancy严格串行，并通过最终同步preflight把非协作外部writer窗口压到最窄；不引入三平台原生atomic no-replace Adapter，接受最终preflight后外部writer创建空同名目录仍可能在POSIX被替换的best-effort边界。
@@ -7,6 +15,22 @@
 > 本任务不是替代 Task 114 或 Task 115，而是它们的协调真相源：Task 114 继续记录文件快照 package 与 NeuroBook adapter 的实现，Task 115 继续记录路径/session hard cut；本 README 冻结二者共享的 Module、Interface、Seam、依赖顺序、发布门禁和跨任务验收。
 >
 > 术语收口：最终合同只称 Project / Project Workspace，不再使用 `managed Project`。下文“旧 managed session”仅指旧 `workspace/<slug>` session 的迁移来源类别。
+
+## 2026-08-05：PR #47 草稿失败与前台 recovery deferred 收口
+
+- `AgentComposerDraftSession` 不再把草稿读取失败降级为空正文。目标 context 只在旧草稿保存和目标草稿读取都成功后激活；`switchContext()`、`clearContext()` 和 acceptance 的持久化失败会保留当前 context、generation 和输入正文，Surface 在解除 Session 绑定前也会先完成草稿保存。
+- Session recovery controller 新增 `started / reused / deferred` 请求结果。SSE 404 在同一界面已有 foreground owner 时记录一次 deferred recovery；前台加载成功会丢弃它，前台失败且旧 Session 仍有完整 recovery 时由 owner 收口并只 replay 一次。主面板与 Inline Editor controller 继续隔离，scope/owner 改变或销毁时会清掉 deferred。
+- `onSessionNotFound` 现在明确返回 `handled / deferred / ignored`：404 的 ignored 不再进入普通错误出口，409 继续按关联资源错误处理。已补回调结果、前台成功/失败、single-flight 和 owner 失效测试。
+- 主面板和 Inline 的 remembered Session ID 在权威状态提交及 stream 启动后才安全写入；`Storage.setItem()` 异常不会回滚已经提交的 Session，只显示一次提示，旧记忆不被误删。
+- 本轮 focused 回归为 **14 files / 170 tests passed**；`bun run nuxt:prepare`、根 `bun run typecheck`、`bun run docs:build` 和 `git diff --check` 均通过。docs build 只有既有 VitePress chunk size warning；浏览器未自动运行，完整 Vitest 和 GitHub Full tests advisory 仍不是全绿证据，Linux `C:/...` fixture、Bun worker 和工具环境失败继续归 Issue #15。
+
+## 2026-08-05：Issue #26 / PR #47 跨 State Root 恢复竞态收口
+
+- 直接请求和 SSE recovery 现在共享同一 Session 生命周期合同：请求 Session 自身缺失返回 `404 / SESSION_NOT_FOUND`；只在读取关联 Session 时缺失返回 `409 / SESSION_DEPENDENCY_NOT_FOUND`。Profile Preview/Compile 的 `sessionId` 仍是字符串 DTO，但路由在进入 worker 或 Profile prepare 前拒绝 `abc`、`NaN`、零、负数和超出安全整数范围的值，统一返回 400；未提供 `sessionId` 的预览请求也不会绕过错误映射。
+- 主 Agent Surface 与 Markdown Studio Inline Editor 都只做一次列表刷新、最多一次 fallback 加载；新增窄的 `AgentSessionLoadController` 后，前台选择会立即使同一界面的旧 recovery 失效，主面板与 Inline Editor 的 owner 互不撤销，旧请求的 `finally`、通知和 fallback 不得清理新选择。右侧 Agent 面板隐藏只失效主面板 owner 并停止主 SSE，保留主 Session、Composer 草稿和后台 Agent；Inline owner、PromptBar、Inline SSE 和模型状态继续运行，重新打开面板时显式重新拉取 recovery。两者均先读取目标 recovery 和目标草稿，读取成功且 owner 仍有效后才停止旧流、切换 ID、清空 shell 和提交新状态。关联 Session 缺失返回 409 时清除 recovery latch、恢复当前连接状态并只走普通错误出口，同时保留稳定的当前对话、草稿、stream 和记忆；普通读取失败在仍有稳定 recovery 时也保持 ready。没有稳定当前对话时进入明确错误/未绑定状态，不 fallback、不删除记忆、不自动创建。主面板空列表会先保存当前 Composer 草稿再解除 context，不隐式创建 Session；Inline 空列表清理状态但不撤销当前请求 owner，保证 loading 的 `finally` 能正常收口。
+- Inline Prompt 打开主 Agent 面板时先确认 Inline 目标仍属于当前 Surface，再建立新的主面板 activation、surface operation 和 foreground load owner；只有目标 Session 已真实提交为当前对话才返回 `current`，被更新操作取代返回 `superseded`，真实加载失败返回 `failed`。主 Session 创建和目标加载失败时保留选择弹窗，只有真实提交成功才关闭；确认 Session 缺失后只删除 storage 中数字 ID 与 identity 仍同时匹配的 remembered value。宽泛 entry/attachment 路由测试通过 `vi.importActual()` 消费生产 HTTP mapper，避免复制映射逻辑继续掩盖回归。
+- Session SSE 的普通 recovery、强制 recovery 和新 event epoch 都在当前 owner 有效时只调用一次专用缺失回调；没有专用回调时保持原错误出口，409 关联缺失会清除 recovery latch、恢复 `connected`/`idle` 状态并只调用一次普通错误处理，不会误走 `SESSION_NOT_FOUND` 专用恢复，owner 已失效时静默丢弃。`stop()` 会失效在途 recovery 并清除旧 latch，重新打开面板只能通过显式 recovery GET 恢复。History/System Prompt 等局部读取继续显示局部错误，不自动替换用户正在查看的上下文；Session 备份目录仍不参与在线枚举。Context Inspector、Profile Preview/Compile、Workflow Preview、current-project 与 Session recovery route 测试现在消费生产 HTTP mapper，而不是复制映射逻辑。
+- 本轮没有引入实例身份协议、备份恢复、lease/heartbeat 变更或数据迁移。浏览器验收未自动执行；使用隔离 State Root 的 focused 测试是本轮 Session 行为证据。最新验证结果：14 files / 160 tests focused、根 `bun run typecheck` 与 `bun run docs:build` 均通过，`git diff --check` 通过；docs build 只有既有 VitePress chunk size warning，换行提示不构成 diff 错误。没有把完整 Vitest 或 GitHub Linux advisory 失败写成全绿；旧的 159/149/140/135 tests 记录保留为历史结果，不再作为本轮证据。
 
 ## 2026-07-28：Project 封面 mutation 与列表性能边界
 
@@ -1008,3 +1032,20 @@ Phase 4B + Phase 7 的实测规模是 **187 个生产文件 + 101 个测试文�
 - Agent HTTP 统一返回 `404` 与 `SESSION_NOT_FOUND`。recovery/history/systemPrompt、relations、mutation 与 Attachment preflight 复用同一映射；宽泛的用户消息和 Attachment 404 路由先保留 Session Not Found，再处理 entry/locator 自身缺失。
 - 主 Agent Surface 遇到该错误时清除精确失效的记忆 ID，在原 activation ownership 下刷新一次列表并最多加载一次 fallback：优先保留仍有效的原 Session，否则选择第一个有效 Session；空列表进入 empty，不自动创建。fallback 再失败不会递归重试，迟到恢复不能覆盖新选择。
 - 验证使用隔离临时 Workspace Root：Repository 28 项、Agent HTTP 22 项、前端错误解析与 Surface 状态 55 项、两个宽泛 entry/attachment 路由 13 项均通过，受共享错误码解析影响的 ProjectSession 另有 9 项通过，合计 9 files / 127 tests；根 `nuxt typecheck` 通过。未执行浏览器验证，未读取、恢复、复制或删除真实 Session 备份。
+
+### 2026-08-03：Issue #26 跨 State Root 恢复补漏
+
+- PR #34 已完成直接 recovery 请求的 `404 / SESSION_NOT_FOUND` 与主 Agent 面板的一次 fallback；后续审查确认 SSE recovery、Inline Editor、Profile/Workflow/Context Inspector 入口以及关联 Session 缺失仍未进入同一合同。本轮只补齐这些缺口，不扩展到 State Root 实例身份、备份恢复、消息分支、`/fork` 或 Runtime lease。
+- Session-bound HTTP 边界现在必须携带请求 Session ID。领域错误中的 ID 与请求 ID 相同返回 `404 / SESSION_NOT_FOUND`；不同返回 `409 / SESSION_DEPENDENCY_NOT_FOUND` 并保留当前选择。Context Inspector、Profile Preview/Compile、Workflow Preview tree/direct-chat 与 entry/attachment 宽泛 catch 均复用该判定，公开错误不包含磁盘路径或 Session 正文。
+- Profile in-process preview 与 compile worker 都保留 Session lifecycle error；worker 只传稳定 code 与 Session ID，主线程重建领域错误。普通编译 issue 与既有 Project lifecycle error 继续走原合同。
+- Session SSE 的 normal、forced 与新 epoch recovery 先识别缺失 Session：当前 owner 只调用一次专用回调，不再同时发布普通错误；过期 owner 静默。主 Agent 面板与 Inline Editor 均刷新一次、最多加载一个 fallback，fallback 关闭递归恢复且不进入自动创建入口。
+- 主面板在列表为空前先持久化当前输入，再解除草稿 context、推进 Composer generation 并清空可见正文；草稿仍可从原 Session context 读取。浏览器记忆只在仍等于失效 ID 时删除，迟到恢复不能清掉用户的新选择。
+- 实施审查额外发现 Inline fallback 会错误使刚完成的列表请求失效，导致 loading 的旧 `finally` 无权收口。本轮让 fallback 复用同一列表请求代次，并把列表 request ID 纳入通知发布权；这属于既有 owner/request-ID 模型内的接线修复，没有增加第二套恢复状态机。
+- 验证只使用 mock 或隔离临时根，不访问真实 `workspace/`、Session 备份或 lease。最终聚焦回归为 12 files / 104 tests，根 `nuxt typecheck` 与 `docs:build` 通过。首轮并行回归有一个 Profile route 用例在 Windows 冷模块转换时越过默认 5 秒，但该文件隔离重跑 2/2 通过；把这个本轮 route 用例的测试预算收窄提高到 10 秒后，原 12 文件命令完整复跑 104/104。按仓库规则未自动执行浏览器验证。
+
+### 2026-08-05：PR #47 恢复生命周期最后收口
+
+- 复核确认右侧面板隐藏会停止主 Session SSE；重开时仅读取 recovery 会留下旧快照而没有实时事件。现在强制 recovery 成功后显式调用现有 `sessionStream.ensure()`；若 409 仍有完整 recovery，则保留 ready 状态并用旧 cursor 恢复 SSE，不重复 recovery。
+- 强制 recovery 的 `SESSION_DEPENDENCY_NOT_FOUND` 不再把稳定当前对话投影为 `load-error`。fallback 二次 404、列表为空或刷新失败均明确收口：旧 Session 有完整 recovery 时保留 ID、shell、stream、Composer 和草稿，否则进入 error/empty；任一确认的主 Session 404 只在浏览器记忆中数字 ID 与 identity 仍同时匹配时才删除对应 remembered ID。
+- 加载完成后的滚动回调改为检查 activation owner，避免 load owner 已正常 finish 后丢失本次 UI 收尾。没有引入新的状态机、Session schema、实例身份或恢复协议。
+- 本轮 focused 回归为 **14 files / 161 tests passed**；根 `bun run typecheck` 与 `bun run docs:build` 均通过，后者只有既有 VitePress chunk size warning；`git diff --check` 通过。浏览器未自动运行，GitHub Full tests 的 Linux `C:/...` fixture 失败继续归 Issue #15。

--- a/packages/neuro-book/app/components/novel-ide/agent/AgentChatFlow.vue
+++ b/packages/neuro-book/app/components/novel-ide/agent/AgentChatFlow.vue
@@ -22,6 +22,8 @@ const props = defineProps<{
     messages: AgentMessage[];
     /** 当前 session ID；变化时认为是整段历史切换，需要立即定位到底部。 */
     sessionId?: number | null;
+    /** 有可用对话但尚未选择时，显示选择提示而不是伪装成空历史。 */
+    unselected?: boolean;
     /** 是否正在执行中。 */
     running: boolean;
     /** 模式区分。main 显示空状态引导，compact 显示简洁空状态。 */
@@ -391,7 +393,17 @@ defineExpose({ scrollToBottom: forceScrollToBottom, scrollRef });
         <!-- 空状态 -->
         <div v-else class="flex h-full flex-col items-center justify-center space-y-6 px-4 text-center">
             <!-- main 模式空状态 -->
-            <template v-if="props.mode === 'main'">
+            <template v-if="props.mode === 'main' && props.unselected">
+                <div class="flex h-12 w-12 items-center justify-center rounded-2xl border border-[var(--status-warning-border)] bg-[var(--status-warning-bg)] shadow-sm">
+                    <span class="i-lucide-messages-square h-6 w-6 text-[var(--status-warning)]"></span>
+                </div>
+                <div class="space-y-2">
+                    <h3 class="text-base font-medium text-[var(--text-main)]">请选择一个对话</h3>
+                    <p class="text-sm leading-relaxed text-[var(--text-muted)]">当前实例还有可用对话，但没有可靠的上次选择。请从对话列表中选择。</p>
+                </div>
+            </template>
+            <!-- main 模式空状态 -->
+            <template v-else-if="props.mode === 'main'">
                 <div class="flex h-12 w-12 items-center justify-center rounded-2xl border border-[var(--border-color)] bg-[var(--bg-input)] shadow-sm">
                     <span class="i-lucide-bot h-6 w-6 text-[var(--text-muted)]"></span>
                 </div>

--- a/packages/neuro-book/app/components/novel-ide/agent/AgentChatSurface.vue
+++ b/packages/neuro-book/app/components/novel-ide/agent/AgentChatSurface.vue
@@ -27,15 +27,31 @@ import AgentSessionAttachmentPanel from "nbook/app/components/novel-ide/agent/Ag
 import {deriveAgentTreeState, resolveBranchSwitchTarget} from "nbook/app/components/novel-ide/agent/session-tree";
 import {AgentSessionListRequestGuard} from "nbook/app/components/novel-ide/agent/session-list-request-guard";
 import {
+    AgentSessionLoadController,
     AgentSurfaceActivationController,
     AgentSurfaceOperationController,
+    adoptInlineEditorRequest,
+    forgetRememberedSession,
+    readRememberedSession,
     isAgentSurfaceSupersededError,
+    projectAgentSessionLoad,
     projectAgentComposerAvailability,
-    recoverMissingSessionSelection,
+    projectInlineEditorSelection,
+    projectReconnectReady,
+    registerReconnectRestoreWatcher,
+    runSessionLoadAttempt,
+    tryWriteRememberedSession,
+    writeRememberedAfterStreamOpen,
     watchAgentSurfaceActivation,
     type AgentComposerAvailability,
     type AgentComposerAvailabilityAction,
+    type AgentSessionLoadResult,
+    type AgentSessionLoadOwner,
+    type AgentSessionOpenResult,
+    type RememberedSession,
     type AgentSurfaceActivationAttempt,
+    type InlineEditorSelectionResult,
+    type AgentSurfaceOperationResult,
 } from "nbook/app/components/novel-ide/agent/agent-chat-surface-state";
 import {assertPublicToolCallId} from "nbook/shared/agent/public-tool-identity";
 import {AGENT_REQUEST_USER_INPUT_CONTEXT_KEY} from "nbook/app/components/novel-ide/agent/request-user-input-context";
@@ -46,15 +62,17 @@ import {resolveApiErrorCode, resolveApiErrorMessage} from "nbook/app/utils/api-e
 import {formatCost, formatCostExact, usingCnyRate} from "nbook/app/utils/cost-format";
 import {promptCacheHitRate, type PromptCacheUsage} from "nbook/app/utils/prompt-cache";
 import type {ConfigBootstrapDto, ConfigModelSettingsDto} from "nbook/shared/dto/config.dto";
-import type {AgentQueuedMessageDto, AgentSessionAttachmentItemDto, AgentSessionAttachmentResolveResultDto, AgentSessionInteractionDto, AgentSessionListPageDto, AgentSessionListQueryDto, AgentSessionRecoveryDto, AgentSessionSummaryDto, AgentMode} from "nbook/shared/dto/agent-session.dto";
+import type {AgentQueuedMessageDto, AgentSessionAttachmentItemDto, AgentSessionAttachmentResolveResultDto, AgentSessionInteractionDto, AgentSessionListPageDto, AgentSessionListQueryDto, AgentSessionRecoveryDto, AgentSessionSummaryDto, AgentMode, AgentSessionIdentity} from "nbook/shared/dto/agent-session.dto";
 import {AgentModeSchema} from "nbook/shared/dto/agent-session.dto";
 import type {AgentCommandResult, InvokeAgentResult} from "nbook/shared/dto/agent-session.dto";
 import type {DropdownItem} from "nbook/app/components/common/dropdown.types";
 import type {ThinkingLevelDto} from "nbook/shared/dto/app-settings.dto";
 import {
     AgentComposerDraftClientStore,
+    AgentComposerDraftBlockedError,
     AgentComposerDraftSession,
     type AgentComposerDraftContext,
+    type AgentComposerDraftPreparedContext,
     type AgentComposerDraftSaveResult,
     type AgentComposerSubmission,
 } from "nbook/app/components/novel-ide/agent/agent-composer-draft";
@@ -126,6 +144,14 @@ const sessionListTotal = ref(0);
 const sessionListHasMore = ref(false);
 const sessionListNextOffset = ref<number | null>(null);
 const activeSessionId = ref<number | null>(null);
+const activeSessionIdentity = ref<AgentSessionIdentity | null>(null);
+const inlineEditorSessions = ref<AgentSessionSummaryDto[]>([]);
+const inlineSessionModelPopoverOpen = ref(false);
+const inlineSessionModelSaving = ref(false);
+const inlineEditorSessionId = ref<number | null>(null);
+const inlineEditorSessionIdentity = ref<AgentSessionIdentity | null>(null);
+const inlineEditorSessionLoading = ref(false);
+const inlineEditorResultText = ref("");
 const linkedAgentPanelOpen = ref(false);
 const loadingSession = ref(false);
 const sessionListLoading = ref(false);
@@ -163,6 +189,7 @@ const pendingResolutionDraft = ref<AgentPendingResolutionDraft>(createAgentPendi
 const pendingSubmissionIssue = ref<AgentPendingSubmissionIssue | null>(null);
 let pendingSubmissionIssueBatchKey: string | null = null;
 let defaultProfileResolveRequest = 0;
+let inlineEditorSessionRequestId = 0;
 let sessionAttachmentRequestId = 0;
 let sessionAttachmentGeneration = 0;
 let historyAttachmentInsertRequestId = 0;
@@ -173,6 +200,11 @@ const composerContextGeneration = ref(0);
 const sessionListRequestGuard = new AgentSessionListRequestGuard();
 const surfaceActivation = new AgentSurfaceActivationController();
 const surfaceOperations = new AgentSurfaceOperationController();
+const inlineSurfaceOperations = new AgentSurfaceOperationController();
+const mainSessionLoads = new AgentSessionLoadController();
+const inlineSessionLoads = new AgentSessionLoadController();
+const surfaceOperationRevision = ref(0);
+const inlineOperationRevision = ref(0);
 const hiddenWritingModeProfileKeys = new Set(["rp.leader", "simulator.leader"]);
 
 /**
@@ -202,6 +234,7 @@ function applySessionListPage(page: AgentSessionListPageDto, append: boolean): A
 
 const sanitizeHtml = ref<((html: string) => string) | null>(null);
 const session = useAgentSession();
+const inlineEditorSession = useAgentSession();
 const agentApi = useAgentSessionApi();
 const configApi = useConfigApi();
 const themeManager = useThemeManager();
@@ -365,6 +398,8 @@ const canChooseCreateProfile = computed(() => createProfileOptions.value.length 
 const sessionMemoryScopeKey = computed(() => agentSessionScopeKey(ideStore.workspaceKind, ideStore.currentProjectRoot));
 /** 数据面 scope 包含 ready revision；同 root reconnect 后旧请求也会立即失去发布权。 */
 const sessionScopeKey = computed(() => `${sessionMemoryScopeKey.value}@ready:${String(props.projectReadyRevision ?? 0)}`);
+const surfaceOperationKey = computed(() => `${sessionScopeKey.value}@activation:${String(surfaceOperationRevision.value)}`);
+const inlineOperationKey = computed(() => `${sessionScopeKey.value}@inline:${String(inlineOperationRevision.value)}`);
 const sessionScope = computed<Pick<AgentSessionListQueryDto, "scope" | "projectRoot">>(() => (
     ideStore.workspaceKind === "novel" && ideStore.currentProjectRoot
         ? {scope: "project", projectRoot: ideStore.currentProjectRoot}
@@ -386,10 +421,188 @@ function invalidateSurfaceOperations(): void {
     surfaceOperations.invalidate();
 }
 
-/** 捕获当前 Project generation 的操作 owner。 */
-function captureSurfaceOperation(): AgentSurfaceActivationAttempt | null {
+/** 开启 Inline PromptBar 自己的 Project 代次，不受右侧面板显隐影响。 */
+function beginInlineSurfaceOperations(scopeKey: string): AgentSurfaceActivationAttempt {
+    const owner = inlineSurfaceOperations.begin(scopeKey);
+    inlineOperationRevision.value = owner.revision;
+    return owner;
+}
+
+/** Project scope 或组件销毁时才使 Inline 操作失效。 */
+function invalidateInlineSurfaceOperations(): void {
+    inlineSurfaceOperations.invalidate();
+    inlineOperationRevision.value += 1;
+}
+
+/** 捕获当前 Project generation 的操作 owner；页面传入旧 scope 时直接拒绝。 */
+function captureSurfaceOperation(expectedOperationKey?: string): AgentSurfaceActivationAttempt | null {
+    if (expectedOperationKey !== undefined && expectedOperationKey !== surfaceOperationKey.value) {
+        return null;
+    }
     return surfaceOperations.capture(sessionScopeKey.value);
 }
+
+/** 主面板请求只校验主面板 Project generation。 */
+function acceptsSurfaceOperation(owner: AgentSurfaceActivationAttempt): boolean {
+    return surfaceOperations.accepts(owner, sessionScopeKey.value);
+}
+
+/** 捕获 Inline PromptBar 当前 Project 代次；右侧面板隐藏时仍可用。 */
+function captureInlineSurfaceOperation(expectedOperationKey?: string): AgentSurfaceActivationAttempt | null {
+    if (expectedOperationKey !== undefined && expectedOperationKey !== inlineOperationKey.value) {
+        return null;
+    }
+    return inlineSurfaceOperations.capture(sessionScopeKey.value);
+}
+
+/** Inline 请求只校验 Inline owner 与目标 Session 身份。 */
+function acceptsInlineSurfaceOperation(owner: AgentSurfaceActivationAttempt, expectedSessionId?: number): boolean {
+    return inlineSurfaceOperations.accepts(owner, sessionScopeKey.value)
+        && (expectedSessionId === undefined || inlineEditorSessionId.value === expectedSessionId);
+}
+
+/** 清空 Inline Editor 当前状态；expectedSessionId 用于拒绝迟到请求清理新选择。 */
+function clearInlineEditorSession(
+    expectedSessionId?: number,
+    invalidateRecovery = true,
+    expectedSessionIdentity?: AgentSessionIdentity,
+): boolean {
+    if (import.meta.client && expectedSessionId !== undefined && expectedSessionIdentity !== undefined) {
+        forgetRememberedSession(
+            localStorage,
+            `agent:inline-editor-session:${sessionMemoryScopeKey.value}`,
+            {sessionId: expectedSessionId, sessionIdentity: expectedSessionIdentity},
+        );
+    }
+    if (expectedSessionId !== undefined && inlineEditorSessionId.value !== expectedSessionId) {
+        return false;
+    }
+    if (invalidateRecovery) {
+        inlineSessionLoads.invalidate();
+    }
+    inlineEditorStream.stop();
+    inlineEditorSessionId.value = null;
+    inlineEditorSessionIdentity.value = null;
+    inlineEditorSession.reset();
+    inlineEditorResultText.value = "";
+    inlineSessionModelPopoverOpen.value = false;
+    inlineSessionModelSaving.value = false;
+    syncInlineSessionModelState();
+    return true;
+}
+
+const INLINE_EDITOR_PROFILE_KEY = "inline.editor";
+
+
+const inlineSessionModelDraft = ref<AgentSessionModelDraft>({
+    modelKey: null,
+    reasoningEffort: null,
+});
+
+const inlineEditorMessages = inlineEditorSession.messages;
+
+const inlineEditorRunning = inlineEditorSession.running;
+
+const inlineEditorCurrentTurnMessages = computed<AgentMessage[]>(() => {
+    const latestUserIndex = inlineEditorMessages.value.findLastIndex((message) => message.type === "user");
+    return latestUserIndex >= 0
+        ? inlineEditorMessages.value.slice(latestUserIndex + 1)
+        : inlineEditorMessages.value;
+});
+
+const inlineEditPreview = computed(() => {
+    const toolCall = inlineEditorCurrentTurnMessages.value
+        .flatMap((message) => message.toolCalls ?? [])
+        .filter((item) => (item.name === "edit" || item.name === "write") && (item.status === "streaming" || item.status === "running"))
+        .at(-1);
+    if (!toolCall) {
+        return "";
+    }
+    const path = readToolPath(toolCall);
+    const status = t("agent.chatSurface.inlineRunning");
+    const result = toolCall.error || toolCall.result || "";
+    return [`${status}${path ? `：${path}` : ""}`, result].filter(Boolean).join("\n");
+});
+
+const inlineEditorLiveView = computed(() => {
+    const latestAssistant = inlineEditorCurrentTurnMessages.value
+        .filter((message) => message.type === "ai")
+        .at(-1);
+    return {
+        thinking: latestAssistant?.thinking ?? "",
+        content: latestAssistant?.content ?? "",
+        status: latestAssistant?.status ?? null,
+        editPreview: inlineEditPreview.value,
+        resultText: inlineEditorResultText.value,
+    };
+});
+
+const inlineEditorSessionLabel = computed(() => {
+    const selected = inlineEditorSessions.value.find((item) => item.sessionId === inlineEditorSessionId.value)
+        ?? inlineEditorSession.recoveryShell.value?.summary
+        ?? null;
+    if (!selected) {
+        return t("agent.chatSurface.inlineSessionLabel");
+    }
+    return selected.title || `Inline AI #${String(selected.sessionId)}`;
+});
+
+function inlineEditPayloadToJson(payload: InlineEditPayload): JsonValue {
+    return {
+        version: payload.version,
+        task: payload.task,
+        targetPath: payload.targetPath,
+        instruction: payload.instruction,
+        references: payload.references.map((reference) => {
+            const output: {[key: string]: JsonValue} = {
+                ref: reference.ref,
+                path: reference.path,
+                match: reference.match,
+                text: reference.text,
+            };
+            if (reference.range) {
+                output.range = {
+                    startLine: reference.range.startLine,
+                    endLine: reference.range.endLine,
+                };
+            }
+            return output;
+        }),
+    };
+}
+
+function readToolPath(toolCall: AgentToolCall): string {
+    const argsText = toolCall.argsJson || toolCall.argsText;
+    if (!argsText.trim()) {
+        return "";
+    }
+    try {
+        const parsed = JSON.parse(argsText) as {path?: string};
+        return typeof parsed.path === "string" ? parsed.path : "";
+    } catch {
+        return "";
+    }
+}
+
+const inlineSessionModelSelectionValue = computed(() => inlineSessionModelDraft.value.modelKey);
+
+const inlineSessionThinkingResolvedLabel = computed(() => {
+    const requested = inlineEditorSession.recoveryShell.value?.thinkingLevel ?? null;
+    const effective = inlineEditorSession.recoveryShell.value?.effectiveThinkingLevel ?? "off";
+    if (requested === null) {
+        return t("agent.chatSurface.followProfileCurrent", {level: thinkingLevelLabel(effective)});
+    }
+    if (requested === effective) {
+        return thinkingLevelLabel(effective);
+    }
+    return t("agent.chatSurface.requestedEffective", {requested: thinkingLevelLabel(requested), effective: thinkingLevelLabel(effective)});
+});
+
+let lastUnavailableRelationWarningKey = "";
+
+const ensureInlineEditorEvents = async (): Promise<void> => {
+    await inlineEditorStream.ensure();
+};
 
 /**
  * 把 Agent 面板内 API 异常统一转换为 notification 文案。
@@ -795,6 +1008,8 @@ const ensureSessionReady = async (
             surfaceActivation.markReady(attempt, sessionScopeKey.value);
         } else if (list.length === 0) {
             surfaceActivation.markEmpty(attempt, sessionScopeKey.value);
+        } else {
+            surfaceActivation.markUnselected(attempt, sessionScopeKey.value);
         }
     }
     return list;
@@ -812,26 +1027,63 @@ const ensureSessionReadyInternal = async (
     }
     if (activeSessionId.value) {
         if (options.forceRecovery) {
-            const recovered = await sessionStream.refreshRecovery("manual_refresh");
+            let recovered = false;
+            try {
+                recovered = await sessionStream.refreshRecovery("manual_refresh");
+            } catch (error) {
+                const hasStableSession = session.recoveryShell.value?.summary.sessionId === activeSessionId.value;
+                if (resolveApiErrorCode(error) === "SESSION_DEPENDENCY_NOT_FOUND"
+                    && hasStableSession
+                    && acceptsActivation(attempt)) {
+                    surfaceActivation.markReady(attempt, sessionScopeKey.value);
+                    notifyAgentError(error, "关联对话不可用，当前对话未切换", "对话未切换");
+                    void sessionStream.ensure().catch(() => {});
+                    return sessions.value;
+                }
+                throw error;
+            }
             if (!recovered && acceptsActivation(attempt)) {
                 throw new Error(t("agent.chatSurface.syncSessionFailed"));
             }
+            if (recovered && acceptsActivation(attempt) && activeSessionId.value) {
+                // 面板隐藏时 stop() 会清掉 controller；恢复快照后显式恢复实时事件流。
+                void sessionStream.ensure().catch(() => {});
+            }
         }
         return sessions.value;
+    }
+    if (activeSessionId.value) {
+        return sessions.value;
+    }
+    const remembered = readLastSession();
+    if (remembered) {
+        const loaded = await loadSession(remembered.sessionId, {
+            attempt,
+            expectedIdentity: remembered.sessionIdentity,
+            recoverMissing: false,
+        });
+        if (loaded.status === "loaded") {
+            return sessions.value;
+        }
+        if (loaded.status === "superseded") {
+            return sessions.value;
+        }
+        if (loaded.status === "primary_missing" && import.meta.client) {
+            forgetRememberedSession(
+                localStorage,
+                `agent:last-session:${sessionMemoryScopeKey.value}`,
+                remembered,
+            );
+        }
     }
     const list = await refreshSessions(attempt);
     if (!acceptsActivation(attempt)) {
         return sessions.value;
     }
-    if (activeSessionId.value) {
-        return list;
-    }
-    const rememberedId = readLastSessionId();
-    const rememberedSession = rememberedId ? list.find((item) => item.sessionId === rememberedId) : undefined;
-    const target = rememberedSession ?? list[0];
-    if (target) {
-        await loadSession(target.sessionId, {attempt});
-        return list;
+    if (sessionListTotal.value === 0) {
+        surfaceActivation.markEmpty(attempt, sessionScopeKey.value);
+    } else {
+        surfaceActivation.markUnselected(attempt, sessionScopeKey.value);
     }
     return list;
 };
@@ -839,13 +1091,16 @@ const ensureSessionReadyInternal = async (
 /**
  * 显式创建一个新的 session。只能由按钮、弹窗或 /new 这类用户命令调用。
  */
-const createSession = async (profileKey?: string): Promise<AgentSessionSummaryDto[]> => {
+const createSession = async (profileKey?: string): Promise<AgentSessionOpenResult<AgentSessionSummaryDto[]>> => {
     const attempt = surfaceActivation.begin(sessionScopeKey.value);
     beginSurfaceOperations(sessionScopeKey.value);
+    const loadOwner = mainSessionLoads.beginForeground(attempt.scopeKey);
+    clearMainReconnectWatchers();
+    let replayDeferred = false;
     try {
         await loadSurfaceBootstrap(attempt);
         if (!acceptsActivation(attempt)) {
-            return sessions.value;
+            return {status: "superseded"};
         }
         const created = await agentApi.createSession({
             profileKey: profileKey || leaderProfileKey.value,
@@ -853,21 +1108,51 @@ const createSession = async (profileKey?: string): Promise<AgentSessionSummaryDt
             currentProjectRoot: ideStore.workspaceKind === "novel" ? ideStore.currentProjectRoot || undefined : undefined,
         });
         if (!acceptsActivation(attempt)) {
-            return sessions.value;
+            return {status: "superseded"};
         }
         await refreshSessions(attempt);
         if (!acceptsActivation(attempt)) {
-            return sessions.value;
+            return {status: "superseded"};
         }
-        await loadSession(created.sessionId, {attempt});
-        return sessions.value;
+        const loaded = await loadSession(created.sessionId, {attempt, loadOwner});
+        if (loaded.status === "loaded") {
+            return {status: "current", value: sessions.value};
+        }
+        if (loaded.status === "superseded") {
+            return loaded;
+        }
+        replayDeferred = activeSessionId.value !== null
+            && session.recoveryShell.value?.summary.sessionId === activeSessionId.value;
+        const message = loaded.status === "dependency_missing"
+            ? resolveApiErrorMessage(loaded.error, "关联对话不可用，无法打开新对话")
+            : loaded.status === "failed"
+                ? resolveApiErrorMessage(loaded.error, t("agent.chatSurface.createSessionFailed"))
+                : "当前没有可用对话";
+        return {status: "failed", message};
     } catch (error) {
         if (!acceptsActivation(attempt) || isAgentSurfaceSupersededError(error)) {
-            return sessions.value;
+            return {status: "superseded"};
         }
         const message = notifyAgentError(error, t("agent.chatSurface.createSessionFailed"));
-        surfaceActivation.markError(attempt, sessionScopeKey.value, message);
-        return sessions.value;
+        const hasStableSession = activeSessionId.value !== null
+            && session.recoveryShell.value?.summary.sessionId === activeSessionId.value;
+        if (hasStableSession) {
+            replayDeferred = true;
+            surfaceActivation.markReady(attempt, sessionScopeKey.value);
+        } else {
+            if (!await clearComposerContextForNoSession(() => acceptsActivation(attempt)
+                && mainSessionLoads.accepts(loadOwner, sessionScopeKey.value))) {
+                if (!acceptsActivation(attempt)) {
+                    return {status: "superseded"};
+                }
+                return {status: "failed", message};
+            }
+            clearActiveAgentSession();
+            surfaceActivation.markError(attempt, sessionScopeKey.value, message);
+        }
+        return {status: "failed", message};
+    } finally {
+        await mainSessionLoads.finish(loadOwner, replayDeferred);
     }
 };
 
@@ -879,7 +1164,7 @@ function handleComposerDraftSave(result: AgentComposerDraftSaveResult, context: 
     }
     if (result === "unsafe" && composerDraftWarning !== `${context.scopeKey}:${String(context.sessionId)}:unsafe`) {
         composerDraftWarning = `${context.scopeKey}:${String(context.sessionId)}:unsafe`;
-        notification.warning("草稿包含 data/blob 图片地址，已按安全规则丢弃。", {title: "草稿未保存"});
+        notification.warning("草稿包含不安全图片地址，仍保留当前正文；请返回编辑或明确放弃。", {title: "草稿未保存"});
     }
 }
 
@@ -900,25 +1185,42 @@ async function saveComposerDraftNow(): Promise<void> {
     const drafts = ensureComposerDraftSession();
     if (!drafts) return;
     drafts.update(inputText.value);
-    await drafts.flush();
+    const result = await drafts.flush();
+    if (result === "oversize" || result === "unsafe") {
+        throw new AgentComposerDraftBlockedError(result);
+    }
 }
 
-/** 原子切换草稿 context，并返回用于 remount Composer 的 generation。 */
-async function switchComposerDraftContext(sessionId: number): Promise<void> {
+/** 用户确认放弃无法保存的草稿后解除 context；普通路径不能调用。 */
+function discardComposerDraft(): void {
     const drafts = ensureComposerDraftSession();
     if (!drafts) {
+        composerContextGeneration.value += 1;
+    } else {
+        composerContextGeneration.value = drafts.discardContext();
+    }
+    inputText.value = "";
+}
+
+/** 只读取目标草稿；Session owner 通过后才允许激活这个快照。 */
+async function prepareComposerDraftContext(sessionId: number): Promise<AgentComposerDraftPreparedContext | null> {
+    const drafts = ensureComposerDraftSession();
+    if (!drafts) {
+        return null;
+    }
+    return await drafts.prepareContext(sessionMemoryScopeKey.value, sessionId);
+}
+
+/** 在主 Session 的同步提交段激活已读取的草稿 context。 */
+function activateComposerDraftContext(prepared: AgentComposerDraftPreparedContext | null): void {
+    const drafts = ensureComposerDraftSession();
+    if (!drafts || !prepared) {
         composerContextGeneration.value += 1;
         inputText.value = "";
         return;
     }
-    const scopeKey = sessionMemoryScopeKey.value;
-    inputText.value = "";
-    const result = await drafts.switchContext(scopeKey, sessionId);
-    if (!result.active
-        || activeSessionId.value !== sessionId
-        || sessionMemoryScopeKey.value !== scopeKey) return;
-    composerContextGeneration.value = result.generation;
-    inputText.value = result.text;
+    composerContextGeneration.value = drafts.activateContext(prepared);
+    inputText.value = prepared.text;
 }
 
 /** 捕获本次提交的 context/revision，供迟到 acceptance compare-and-clear。 */
@@ -937,7 +1239,13 @@ async function clearComposerAfterAccepted(
     if (!submission) {
         return;
     }
-    const result = await ensureComposerDraftSession()?.accept(submission);
+    let result: {clearEditor: boolean} | undefined;
+    try {
+        result = await ensureComposerDraftSession()?.accept(submission);
+    } catch (error) {
+        notifyAgentError(error, "消息已发送，但 Composer 草稿未清除", "草稿未清除");
+        return;
+    }
     if (result?.clearEditor && activeSessionId.value === sessionId && inputText.value === acceptedText) {
         inputText.value = "";
     }
@@ -1074,101 +1382,372 @@ function insertSessionAttachment(item: AgentSessionAttachmentItemDto): void {
     attachmentPanelOpen.value = false;
 }
 
+/** 清空主 Agent Session；只有确认没有可保留的稳定 recovery 时调用。 */
+function clearActiveAgentSession(): void {
+    sessionStream.stop();
+    resetSessionAttachments();
+    linkedAgentRelationsRequestId += 1;
+    linkedAgentsLoading.value = false;
+    linkedAgentPanelOpen.value = false;
+    systemPromptPanelOpen.value = false;
+    sessionTreeDialogOpen.value = false;
+    contextInspectorOpen.value = false;
+    sessionModelPopoverOpen.value = false;
+    sessionModelSaving.value = false;
+    sessionActionId.value = null;
+    cancelEditingMessage();
+    historyAttachmentInsertRequest.value = null;
+    messageActionId.value = null;
+    fileChangedSinceLastSend.value = false;
+    pendingResolutionDraft.value = createAgentPendingResolutionDraft([]);
+    pendingSubmissionIssue.value = null;
+    pendingSubmissionIssueBatchKey = null;
+    submittingUserInputKey.value = null;
+    activeSessionId.value = null;
+    activeSessionIdentity.value = null;
+    session.reset();
+    syncSessionModelState(null);
+}
+
+/** 在解除 Session 绑定前保存并解除 Composer context；保存失败时保留当前输入。 */
+async function clearComposerContextForNoSession(accepts: () => boolean): Promise<boolean> {
+    const drafts = ensureComposerDraftSession();
+    if (!drafts) {
+        if (!accepts()) return false;
+        composerContextGeneration.value += 1;
+        inputText.value = "";
+        return true;
+    }
+    drafts.update(inputText.value);
+    let generation: number;
+    try {
+        generation = await drafts.clearContext();
+    } catch (error) {
+        if (accepts()) {
+            notifyAgentError(error, "保存 Composer 草稿失败，当前对话未切换", "对话未切换");
+        }
+        return false;
+    }
+    if (!accepts()) return false;
+    composerContextGeneration.value = generation;
+    inputText.value = "";
+    return true;
+}
+
+/** Session 消失后只刷新当前实例列表，不猜测另一个同号 Session。 */
+async function recoverMissingAgentSession(
+    failedSessionId: number,
+    previousSessionId: number | null,
+    attempt: AgentSurfaceActivationAttempt,
+    loadOwner: AgentSessionLoadOwner,
+): Promise<AgentSessionLoadResult<void>> {
+    const acceptsLoad = (): boolean => acceptsActivation(attempt)
+        && mainSessionLoads.accepts(loadOwner, sessionScopeKey.value);
+    if (!acceptsLoad()) {
+        return {status: "superseded"};
+    }
+    const stablePreviousSession = previousSessionId !== null
+        && activeSessionId.value === previousSessionId
+        && session.recoveryShell.value?.summary.sessionId === previousSessionId
+        && activeSessionIdentity.value === session.recoveryShell.value.summary.sessionIdentity;
+    const failedIdentity = activeSessionId.value === failedSessionId ? activeSessionIdentity.value : null;
+    try {
+        await refreshSessions(attempt);
+        if (!acceptsLoad()) return {status: "superseded"};
+        if (stablePreviousSession) {
+            surfaceActivation.markReady(attempt, sessionScopeKey.value);
+            notification.warning("目标对话不可用，当前对话未切换。", {title: "对话未切换"});
+            return {status: "failed", error: new Error("目标对话已失效")};
+        }
+        if (failedIdentity && import.meta.client) {
+            const remembered = readLastSession();
+            if (remembered?.sessionId === failedSessionId && remembered.sessionIdentity === failedIdentity) {
+                forgetRememberedSession(
+                    localStorage,
+                    `agent:last-session:${sessionMemoryScopeKey.value}`,
+                    remembered,
+                );
+            }
+        }
+        if (!await clearComposerContextForNoSession(acceptsLoad)) {
+            if (acceptsLoad()) {
+                const error = new Error("保存 Composer 草稿失败");
+                surfaceActivation.markError(attempt, sessionScopeKey.value, error.message);
+                return {status: "failed", error};
+            }
+            return {status: "superseded"};
+        }
+        clearActiveAgentSession();
+        if (sessionListTotal.value === 0) {
+            surfaceActivation.markEmpty(attempt, sessionScopeKey.value);
+            return {status: "empty"};
+        }
+        surfaceActivation.markUnselected(attempt, sessionScopeKey.value);
+        notification.warning("目标对话不在当前打开的 NeuroBook 中，请重新选择对话。", {title: "对话已失效"});
+        return {status: "failed", error: new Error("目标对话已失效")};
+    } catch (refreshError) {
+        if (!acceptsLoad()) {
+            return {status: "superseded"};
+        }
+        console.error("失效 Session 的列表恢复失败", refreshError);
+        if (stablePreviousSession) {
+            surfaceActivation.markReady(attempt, sessionScopeKey.value);
+            notifyAgentError(refreshError, "目标对话不可用，当前对话未切换", "对话未切换");
+            return {status: "failed", error: refreshError};
+        }
+        const message = notifyAgentError(refreshError, "目标对话已失效，刷新对话列表失败");
+        surfaceActivation.markError(attempt, sessionScopeKey.value, message);
+        return {status: "failed", error: refreshError};
+    }
+}
+
 /**
  * 切换到指定 session，并拉取 recovery。
  */
 const loadSession = async (
     sessionId: number,
-    options: {attempt?: AgentSurfaceActivationAttempt; recoverMissing?: boolean} = {},
-): Promise<boolean> => {
+    options: {
+        attempt?: AgentSurfaceActivationAttempt;
+        loadOwner?: AgentSessionLoadOwner;
+        recoverMissing?: boolean;
+        expectedIdentity?: AgentSessionIdentity;
+        acceptsAdditional?: () => boolean;
+    } = {},
+): Promise<AgentSessionLoadResult<void>> => {
     const attempt = options.attempt ?? surfaceActivation.begin(sessionScopeKey.value);
     const previousSessionId = activeSessionId.value;
     if (!options.attempt) {
         beginSurfaceOperations(attempt.scopeKey);
     }
     const targetScopeKey = attempt.scopeKey;
-    await saveComposerDraftNow();
-    if (!acceptsActivation(attempt)) {
-        return false;
-    }
-    sessionStream.stop();
-    resetSessionAttachments();
-    activeSessionId.value = sessionId;
-    await switchComposerDraftContext(sessionId);
-    if (!acceptsActivation(attempt) || activeSessionId.value !== sessionId || sessionScopeKey.value !== targetScopeKey) {
-        return false;
-    }
-    session.reset();
-    cancelEditingMessage();
-    messageActionId.value = null;
-    linkedAgentPanelOpen.value = false;
-    systemPromptPanelOpen.value = false;
-
+    const loadOwner = options.loadOwner ?? mainSessionLoads.beginForeground(targetScopeKey);
+    const ownsLoadOwner = options.loadOwner === undefined;
+    // 无论 owner 由谁创建（外层 createSession/Inline handoff 传 loadOwner），
+    // 前台加载开始即取代旧代次：旧重连 watcher 立即失效，不依赖下一次 status 变化。
+    clearMainReconnectWatchers();
+    let replayDeferred = false;
+    let committedSessionIdentity: AgentSessionIdentity | null = null;
+    const acceptsLoad = (): boolean => acceptsActivation(attempt)
+        && mainSessionLoads.accepts(loadOwner, sessionScopeKey.value)
+        && sessionScopeKey.value === targetScopeKey
+        && (options.acceptsAdditional?.() ?? true);
     try {
-        const recovery = await agentApi.getSessionRecovery(sessionId);
-        if (!acceptsActivation(attempt)
-            || activeSessionId.value !== sessionId
-            || sessionScopeKey.value !== targetScopeKey
-            || recovery.summary.sessionId !== sessionId) {
-            return false;
-        }
-        session.applyRecovery(recovery);
-        saveLastSessionId(sessionId);
-        syncSessionModelState(recovery.summary);
-        void loadSessionAttachments(true);
-        void sessionStream.start(sessionId).catch(() => {});
-        fileChangedSinceLastSend.value = false;
-        await nextTick();
-        if (!acceptsActivation(attempt) || activeSessionId.value !== sessionId) {
-            return false;
-        }
-        scrollToBottom();
-        surfaceActivation.markReady(attempt, sessionScopeKey.value);
-        return true;
-    } catch (error) {
-        if (!acceptsActivation(attempt) || activeSessionId.value !== sessionId) {
-            return false;
-        }
-        sessionStream.stop();
-        activeSessionId.value = null;
-        session.reset();
-        syncSessionModelState(null);
-        if (resolveApiErrorCode(error) === "SESSION_NOT_FOUND" && options.recoverMissing !== false) {
-            if (readLastSessionId() === sessionId) {
-                localStorage.removeItem(`agent:last-session:${sessionMemoryScopeKey.value}`);
+        try {
+            await saveComposerDraftNow();
+        } catch (error) {
+            if (!acceptsLoad()) {
+                return {status: "superseded"};
             }
-            try {
-                const recovery = await recoverMissingSessionSelection({
-                    failedSessionId: sessionId,
-                    previousSessionId,
-                    accepts: () => acceptsActivation(attempt),
-                    refresh: () => refreshSessions(attempt),
-                    load: (fallbackSessionId) => loadSession(fallbackSessionId, {attempt, recoverMissing: false}),
-                });
-                if (recovery.status === "superseded" || recovery.status === "load_failed") {
-                    return false;
+            if (error instanceof AgentComposerDraftBlockedError) {
+                const discard = await confirm(
+                    "当前草稿无法安全保存。返回编辑会保留正文；放弃草稿后才继续切换对话。",
+                    "草稿未保存",
+                );
+                if (!discard || !acceptsLoad()) {
+                    const hasStableSession = previousSessionId !== null
+                        && activeSessionId.value === previousSessionId
+                        && session.recoveryShell.value?.summary.sessionId === previousSessionId;
+                    if (hasStableSession) {
+                        replayDeferred = true;
+                        surfaceActivation.markReady(attempt, sessionScopeKey.value);
+                    } else {
+                        surfaceActivation.markError(attempt, sessionScopeKey.value, error.message);
+                    }
+                    return {status: "failed", error};
                 }
-                if (recovery.status === "empty") {
-                    surfaceActivation.markEmpty(attempt, sessionScopeKey.value);
-                    notification.warning("目标对话不在当前打开的 NeuroBook 中，当前没有可用对话。", {title: "对话已失效"});
-                    return false;
-                }
-                notification.warning("目标对话不在当前打开的 NeuroBook 中，已切换到可用对话。", {title: "对话已切换"});
-                return true;
-            } catch (refreshError) {
-                if (!acceptsActivation(attempt)) {
-                    return false;
-                }
-                console.error("失效 Session 的列表恢复失败", refreshError);
-                const message = notifyAgentError(refreshError, "目标对话已失效，刷新对话列表失败");
+                discardComposerDraft();
+            } else {
+            const hasStablePreviousSession = previousSessionId !== null
+                && activeSessionId.value === previousSessionId
+                && session.recoveryShell.value?.summary.sessionId === previousSessionId;
+            if (hasStablePreviousSession) {
+                replayDeferred = true;
+                surfaceActivation.markReady(attempt, sessionScopeKey.value);
+                notifyAgentError(error, "保存 Composer 草稿失败，当前对话未切换", "对话未切换");
+            } else {
+                const message = notifyAgentError(error, "保存 Composer 草稿失败，无法切换对话", "对话未切换");
                 surfaceActivation.markError(attempt, sessionScopeKey.value, message);
-                return false;
+            }
+                return {status: "failed", error};
             }
         }
+        if (!acceptsLoad()) {
+            return {status: "superseded"};
+        }
+        const result = await runSessionLoadAttempt({
+            read: () => agentApi.getSessionRecovery(sessionId),
+            accepts: acceptsLoad,
+            errorCode: resolveApiErrorCode,
+            commit: async (recovery) => {
+                if (recovery.summary.sessionId !== sessionId) {
+                    throw new Error(`加载 session 身份不匹配：期望 ${String(sessionId)}，收到 ${String(recovery.summary.sessionId)}`);
+                }
+                if (options.expectedIdentity !== undefined
+                    && recovery.summary.sessionIdentity !== options.expectedIdentity) {
+                    throw new Error("加载的对话身份与浏览器记忆不一致。请从当前对话列表重新选择。");
+                }
+                const preparedDraft = await prepareComposerDraftContext(sessionId);
+                if (!acceptsLoad()) {
+                    return;
+                }
+
+                // 下面是同步提交段：owner 通过后立即发布状态；open 成功、记忆写入与 markReady 在提交之后进行。
+                clearActiveAgentSession();
+                activeSessionId.value = sessionId;
+                activeSessionIdentity.value = recovery.summary.sessionIdentity;
+                committedSessionIdentity = recovery.summary.sessionIdentity;
+                activateComposerDraftContext(preparedDraft);
+                session.applyRecovery(recovery);
+                syncSessionModelState(recovery.summary);
+                void loadSessionAttachments(true);
+                fileChangedSinceLastSend.value = false;
+            },
+        });
+        if (result.status === "loaded") {
+            void nextTick().then(() => {
+                if (acceptsActivation(attempt)
+                    && sessionScopeKey.value === targetScopeKey
+                    && activeSessionId.value === sessionId) {
+                    scrollToBottom();
+                }
+            });
+            // 记忆只在事件流 open 成功且 owner 仍有效时写入（ADR 0018）；失败保留已提交 Session，不回滚。
+            const streamOutcome = await writeRememberedAfterStreamOpen({
+                start: () => sessionStream.start(sessionId),
+                accepts: acceptsLoad,
+                remember: () => {
+                    if (committedSessionIdentity) {
+                        saveLastSession(sessionId, committedSessionIdentity);
+                    }
+                },
+            });
+            if (streamOutcome.status === "connect_failed") {
+                console.error(`连接 session ${String(sessionId)} 实时事件流失败，本次不写入对话记忆`, streamOutcome.error);
+                const message = notifyAgentError(streamOutcome.error, "对话已切换，但实时事件流连接失败，恢复连接前不会更新对话记忆。", "连接失败");
+                surfaceActivation.markError(attempt, sessionScopeKey.value, message);
+                // 后台重连成功后解除 load-error；不能用 acceptsLoad() 守卫：loadSession 的 finally
+                // 会立刻 finish loadOwner，重连通常在稍后才 connected；改用 activation 仍是同一
+                // attempt 且目标 Session 仍是当前会话，防跨代次误标。
+                // watch 在多次 await 后的异步 continuation 中创建，没有 active effect scope；
+                // 登记到 setup 同步注册的重连 watcher 清理表，组件卸载时统一 stop。
+                if (surfaceUnmounted) {
+                    return {status: "superseded"};
+                }
+                registerReconnectRestoreWatcher({
+                    connectionStatus: session.connectionStatus,
+                    stops: mainReconnectWatcherStops,
+                    // 新代次接管、会话切换或身份不符时立即自停，防止反复握手失败后闭包累积。
+                    shouldRestore: () => {
+                        const state = surfaceActivation.state.value;
+                        if (state.status !== "error") {
+                            return false;
+                        }
+                        return projectReconnectReady({
+                            activationStatus: state.status,
+                            attemptScopeKey: state.attempt.scopeKey,
+                            attemptRevision: state.attempt.revision,
+                            expectedScopeKey: attempt.scopeKey,
+                            expectedRevision: attempt.revision,
+                            activeSessionId: activeSessionId.value,
+                            expectedSessionId: sessionId,
+                        }) === "restore_ready"
+                            && activeSessionIdentity.value === committedSessionIdentity;
+                    },
+                    onRestored: () => {
+                        surfaceActivation.markReady(attempt, sessionScopeKey.value);
+                        if (committedSessionIdentity) {
+                            // 握手失败时未写记忆；后台重连 open 成功后补写，避免下次启动仍恢复旧记忆。
+                            saveLastSession(sessionId, committedSessionIdentity);
+                        }
+                    },
+                });
+            } else if (streamOutcome.status === "connected") {
+                surfaceActivation.markReady(attempt, sessionScopeKey.value);
+            } else if (streamOutcome.status === "superseded") {
+                // 提交后等待 open 期间被新 owner 取代：新 owner 已发布自己的状态，
+                // 本代次不写记忆、不标记任何 activation；结果按 superseded 转发给调用方。
+                return {status: "superseded"};
+            }
+            return {status: "loaded", value: undefined};
+        }
+        if (result.status === "superseded") {
+            return result;
+        }
+        if (result.status === "primary_missing" && options.recoverMissing !== false) {
+            const recovered = await recoverMissingAgentSession(sessionId, previousSessionId, attempt, loadOwner);
+            if (recovered.status === "failed" || recovered.status === "empty") {
+                replayDeferred = previousSessionId !== null
+                    && activeSessionId.value === previousSessionId
+                    && session.recoveryShell.value?.summary.sessionId === previousSessionId;
+            }
+            return recovered;
+        }
+        if (result.status === "primary_missing") {
+            return {status: "primary_missing"};
+        }
+        const hasStablePreviousSession = previousSessionId !== null
+            && activeSessionId.value === previousSessionId
+            && Boolean(session.recoveryShell.value);
+        const projection = projectAgentSessionLoad(result.status, hasStablePreviousSession);
+        if (projection.status === "preserve") {
+            replayDeferred = hasStablePreviousSession;
+            surfaceActivation.markReady(attempt, sessionScopeKey.value);
+            const error = result.status === "dependency_missing" || result.status === "failed"
+                ? result.error
+                : new Error("Session 不存在或已不可用");
+            console.error(`加载 session ${String(sessionId)} 失败，保留当前 Session`, error);
+            notifyAgentError(
+                error,
+                result.status === "dependency_missing"
+                    ? "关联对话不可用，当前对话未切换"
+                    : t("agent.chatSurface.loadSessionFailed"),
+                result.status === "dependency_missing" ? "对话未切换" : t("agent.chatSurface.loadSessionFailed"),
+            );
+            return result.status === "dependency_missing"
+                ? result
+                : {status: "failed", error};
+        }
+        const error = result.status === "dependency_missing" || result.status === "failed"
+            ? result.error
+            : new Error("Session 不存在或已不可用");
+        if (!await clearComposerContextForNoSession(acceptsLoad)) {
+            if (acceptsLoad()) {
+                const draftError = new Error("保存 Composer 草稿失败");
+                surfaceActivation.markError(attempt, sessionScopeKey.value, draftError.message);
+                return {status: "failed", error: draftError};
+            }
+            return {status: "superseded"};
+        }
+        clearActiveAgentSession();
         console.error(`加载 session ${String(sessionId)} 失败`, error);
+        const message = notifyAgentError(
+            error,
+            result.status === "dependency_missing"
+                ? "关联对话不可用，无法加载目标对话"
+                : t("agent.chatSurface.loadSessionFailed"),
+        );
+        surfaceActivation.markError(attempt, sessionScopeKey.value, message);
+        return {status: "failed", error};
+    } catch (error) {
+        if (!acceptsLoad()) {
+            return {status: "superseded"};
+        }
+        const hasStablePreviousSession = previousSessionId !== null
+            && activeSessionId.value === previousSessionId
+            && session.recoveryShell.value?.summary.sessionId === previousSessionId;
+        if (hasStablePreviousSession) {
+            replayDeferred = true;
+            surfaceActivation.markReady(attempt, sessionScopeKey.value);
+            notifyAgentError(error, "目标对话不可用，当前对话未切换", "对话未切换");
+            return {status: "failed", error};
+        }
         const message = notifyAgentError(error, t("agent.chatSurface.loadSessionFailed"));
         surfaceActivation.markError(attempt, sessionScopeKey.value, message);
-        return false;
+        return {status: "failed", error};
+    } finally {
+        if (ownsLoadOwner) {
+            await mainSessionLoads.finish(loadOwner, replayDeferred);
+        }
     }
 };
 
@@ -1284,6 +1863,36 @@ const handleInvokeResult = async (result: InvokeAgentResult): Promise<void> => {
     if (!hasVisibleInvocationError(messages.value, result.invocationId)) {
         notification.error(result.error ?? t("agent.chatSurface.runFailed"), {title: t("agent.chatSurface.runFailed")});
     }
+};
+
+/**
+ * 处理后台 Inline AI invoke 结果，并把最终摘要留给 PromptBar 展示。
+ */
+const handleInlineEditorInvokeResult = async (
+    result: InvokeAgentResult,
+    owner: AgentSurfaceActivationAttempt,
+    sessionId: number,
+): Promise<AgentSurfaceOperationResult<void>> => {
+    if (!acceptsInlineSurfaceOperation(owner, sessionId)) {
+        return {status: "superseded"};
+    }
+    inlineEditorResultText.value = result.reportResult?.result ?? result.finalMessage ?? "";
+    if (result.status !== "error") {
+        const refreshed = await refreshInlineEditorSessions(owner);
+        return refreshed.status === "superseded"
+            ? refreshed
+            : {status: "current", value: undefined};
+    }
+    await inlineEditorStream.syncRecovery("invoke_error_fallback");
+    if (!acceptsInlineSurfaceOperation(owner, sessionId)) {
+        return {status: "superseded"};
+    }
+    // 取消同样走这个分支（停止按钮和 in-flight 阻塞 invoke 谁先返回是竞态），
+    // 但结果条不能显示 result.error 里的英文技术文本，用和停止按钮一致的说法（Task 139）。
+    inlineEditorResultText.value = result.aborted
+        ? t("agent.chatSurface.stopped")
+        : result.error ?? t("agent.chatSurface.runFailed");
+    throw new Error(inlineEditorResultText.value);
 };
 
 /**
@@ -1760,6 +2369,148 @@ const send = async (): Promise<void> => {
     }
 };
 
+/**
+ * 发送 Inline AI 编辑任务。调用方只负责构造 visible message 与 payload。
+ */
+const sendInlineEditorPrompt = async (
+    payload: InlineEditPayload,
+    visibleMessage: string,
+    expectedOperationKey?: string,
+): Promise<AgentSurfaceOperationResult<void>> => {
+    const owner = captureInlineSurfaceOperation(expectedOperationKey);
+    if (!owner) {
+        return {status: "superseded"};
+    }
+    const targetResult = await ensureInlineEditorSession(owner);
+    if (targetResult.status === "superseded") return targetResult;
+    if (targetResult.status === "empty" || targetResult.status === "failed") {
+        throw new Error(targetResult.status === "empty" ? "当前没有可用 Inline AI 对话，请先创建。" : targetResult.message);
+    }
+    const targetSession = targetResult.value;
+    if (targetSession.status === "running" || targetSession.status === "waiting") {
+        throw new Error(t("agent.chatSurface.inlineRunningError"));
+    }
+    if (inlineEditorSessionId.value !== targetSession.sessionId || !inlineEditorSession.recoveryShell.value) {
+        const loaded = await loadInlineEditorSession(targetSession.sessionId, {owner});
+        if (loaded.status === "superseded") return loaded;
+    }
+
+    if (!acceptsInlineSurfaceOperation(owner, targetSession.sessionId)) return {status: "superseded"};
+    inlineEditorResultText.value = "";
+    const clientMessageId = crypto.randomUUID();
+    const optimisticId = inlineEditorSession.appendOptimisticUserMessage(clientMessageId, visibleMessage);
+    let receivedReceipt = false;
+    try {
+        await ensureInlineEditorEvents();
+        if (!acceptsInlineSurfaceOperation(owner, targetSession.sessionId)) {
+            return {status: "superseded"};
+        }
+        const result = await agentApi.invokeSession(targetSession.sessionId, {
+            mode: "prompt",
+            clientMessageId,
+            message: {text: visibleMessage},
+            input: inlineEditPayloadToJson(payload),
+            clientState: buildClientState(),
+        });
+        if (!acceptsInlineSurfaceOperation(owner, targetSession.sessionId)) {
+            return {status: "superseded"};
+        }
+        receivedReceipt = true;
+        const reconciliation = reconcileInvocationReceipt(clientMessageId, result.acceptance);
+        if (reconciliation.state === "rejected") {
+            inlineEditorSession.removeOptimisticUserMessage(optimisticId);
+            throw new Error(result.error ?? t("agent.chatSurface.runFailed"));
+        }
+        return await handleInlineEditorInvokeResult(result, owner, targetSession.sessionId);
+    } catch (error) {
+        if (!acceptsInlineSurfaceOperation(owner, targetSession.sessionId)) {
+            return {status: "superseded"};
+        }
+        if (!receivedReceipt) {
+            inlineEditorSession.markOptimisticUserMessageUnknown(clientMessageId);
+        }
+        throw error;
+    }
+};
+
+/**
+ * 打开或创建 Inline AI Session，供 PromptBar 主动绑定。
+ */
+const openInlineEditorSession = async (): Promise<AgentSessionOpenResult<AgentSessionSummaryDto>> => {
+    const owner = captureInlineSurfaceOperation();
+    if (!owner) return {status: "superseded"};
+    const targetResult = await ensureInlineEditorSession(owner);
+    if (targetResult.status === "superseded") return targetResult;
+    if (targetResult.status === "empty" || targetResult.status === "failed") {
+        return {status: "failed", message: targetResult.status === "empty" ? "当前没有可用 Inline AI 对话，请先创建。" : targetResult.message};
+    }
+    const targetSession = targetResult.value;
+    if (!acceptsInlineSurfaceOperation(owner, targetSession.sessionId)) {
+        return {status: "superseded"};
+    }
+    if (activeSessionId.value === targetSession.sessionId && activeRecovery.value) {
+        return {status: "current", value: targetSession};
+    }
+
+    // Inline Prompt 的打开动作必须把主面板切换提升为新的前台操作；旧 SSE
+    // recovery 只在这个 handoff 完成前保留，不能在用户操作之后抢回 Session。
+    const attempt = surfaceActivation.begin(sessionScopeKey.value);
+    const operationOwner = beginSurfaceOperations(attempt.scopeKey);
+    const loadOwner = mainSessionLoads.beginForeground(attempt.scopeKey);
+    clearMainReconnectWatchers();
+    try {
+        if (!props.active) {
+            return {status: "superseded"};
+        }
+        const loaded = await loadSession(targetSession.sessionId, {
+            attempt,
+            loadOwner,
+            acceptsAdditional: () => acceptsInlineSurfaceOperation(owner, targetSession.sessionId),
+        });
+        if (!acceptsActivation(attempt)
+            || !acceptsSurfaceOperation(operationOwner)
+            || !acceptsInlineSurfaceOperation(owner, targetSession.sessionId)) {
+            return {status: "superseded"};
+        }
+        if (loaded.status === "loaded"
+            && activeSessionId.value === targetSession.sessionId
+            && activeRecovery.value?.summary.sessionId === targetSession.sessionId) {
+            return {status: "current", value: targetSession};
+        }
+        if (loaded.status === "superseded") {
+            return {status: "superseded"};
+        }
+        const message = loaded.status === "dependency_missing"
+            ? resolveApiErrorMessage(loaded.error, "关联对话不可用，无法打开当前对话")
+            : loaded.status === "failed"
+                ? resolveApiErrorMessage(loaded.error, t("agent.chatSurface.loadSessionFailed"))
+                : loaded.status === "empty"
+                    ? "当前没有可用对话"
+                    : t("agent.chatSurface.loadSessionFailed");
+        return {status: "failed", message};
+    } finally {
+        await mainSessionLoads.finish(loadOwner);
+    }
+};
+
+/**
+ * 停止后台 Inline AI session 当前运行。
+ */
+const stopInlineEditorPrompt = async (): Promise<AgentSurfaceOperationResult<void>> => {
+    const owner = captureInlineSurfaceOperation();
+    const sessionId = inlineEditorSessionId.value;
+    if (!owner || !sessionId) return {status: "superseded"};
+    await agentApi.abortSession(sessionId, {});
+    if (!acceptsInlineSurfaceOperation(owner, sessionId)) return {status: "superseded"};
+    inlineEditorResultText.value = t("agent.chatSurface.stopped");
+    await inlineEditorStream.syncRecovery("manual_refresh");
+    if (!acceptsInlineSurfaceOperation(owner, sessionId)) return {status: "superseded"};
+    const refreshed = await refreshInlineEditorSessions(owner);
+    return refreshed.status === "superseded"
+        ? refreshed
+        : {status: "current", value: undefined};
+};
+
 /** 运行中的 steer/follow-up 共用同一 receipt、SSE 与 transport unknown 对账。 */
 const sendRunningMessage = async (mode: "steer" | "followup"): Promise<void> => {
     const message = inputText.value.trim();
@@ -2143,10 +2894,194 @@ function syncSessionModelState(_summary: AgentSessionSummaryDto | null): void {
     };
 }
 
+function syncInlineSessionModelState(): void {
+    inlineSessionModelDraft.value = {
+        ...inlineSessionModelDraft.value,
+        ...modelDraftFromRecovery(inlineEditorSession.recoveryShell.value),
+    };
+}
+
+/**
+ * 判断 Inline AI session 模型设置此刻是否允许写入。
+ */
+function inlineSessionModelActionBlocked(): boolean {
+    return !inlineEditorSessionId.value || inlineEditorRunning.value || inlineEditorSessionLoading.value || inlineSessionModelSaving.value;
+}
+
+/**
+ * 丢弃未落库草稿，恢复为当前 recovery 中的真实模型设置。
+ */
+function restoreInlineSessionModelDraft(): void {
+    syncInlineSessionModelState();
+}
+
+type InlineSessionOperation = Readonly<{
+    owner: AgentSurfaceActivationAttempt;
+    sessionId: number;
+}>;
+
+/** 捕获模型命令的 Project generation 与 Inline Session 身份。 */
+function captureInlineSessionOperation(): InlineSessionOperation | null {
+    const owner = captureInlineSurfaceOperation();
+    const sessionId = inlineEditorSessionId.value;
+    return owner && sessionId ? {owner, sessionId} : null;
+}
+
+/**
+ * 更新 Inline AI session 模型覆盖，不影响右侧主 Agent 当前会话。
+ */
+const updateInlineSessionModelSelection = async (
+    modelKey: string | null,
+    requestedOperation?: InlineSessionOperation,
+): Promise<boolean> => {
+    if (inlineSessionModelActionBlocked()) {
+        restoreInlineSessionModelDraft();
+        return false;
+    }
+    const operation = requestedOperation ?? captureInlineSessionOperation();
+    if (!operation || !acceptsInlineSurfaceOperation(operation.owner, operation.sessionId)) {
+        restoreInlineSessionModelDraft();
+        return false;
+    }
+
+    inlineSessionModelDraft.value = {
+        ...inlineSessionModelDraft.value,
+        modelKey,
+    };
+
+    inlineSessionModelSaving.value = true;
+    try {
+        await agentApi.runCommand(operation.sessionId, {
+            command: "model",
+            modelKey,
+        });
+        if (!acceptsInlineSurfaceOperation(operation.owner, operation.sessionId)) return false;
+        await inlineEditorStream.syncRecovery("manual_refresh");
+        if (!acceptsInlineSurfaceOperation(operation.owner, operation.sessionId)) return false;
+        syncInlineSessionModelState();
+        return true;
+    } catch (error) {
+        if (!acceptsInlineSurfaceOperation(operation.owner, operation.sessionId)) return false;
+        console.error("更新 Inline AI session 模型失败", error);
+        notifyAgentError(error, t("agent.chatSurface.updateModelFailed"));
+        restoreInlineSessionModelDraft();
+        return false;
+    } finally {
+        if (acceptsInlineSurfaceOperation(operation.owner, operation.sessionId)) {
+            inlineSessionModelSaving.value = false;
+        }
+    }
+};
+
+/**
+ * 更新 Inline AI session 推理强度覆盖。
+ */
+const updateInlineSessionThinkingLevel = async (
+    thinkingLevel: ThinkingLevelDto | null,
+    requestedOperation?: InlineSessionOperation,
+): Promise<boolean> => {
+    if (inlineSessionModelActionBlocked()) {
+        restoreInlineSessionModelDraft();
+        return false;
+    }
+    const operation = requestedOperation ?? captureInlineSessionOperation();
+    if (!operation || !acceptsInlineSurfaceOperation(operation.owner, operation.sessionId)) {
+        restoreInlineSessionModelDraft();
+        return false;
+    }
+
+    inlineSessionModelDraft.value = {
+        ...inlineSessionModelDraft.value,
+        reasoningEffort: thinkingLevel,
+    };
+
+    inlineSessionModelSaving.value = true;
+    try {
+        await agentApi.runCommand(operation.sessionId, {
+            command: "thinking",
+            thinkingLevel,
+        });
+        if (!acceptsInlineSurfaceOperation(operation.owner, operation.sessionId)) return false;
+        await inlineEditorStream.syncRecovery("manual_refresh");
+        if (!acceptsInlineSurfaceOperation(operation.owner, operation.sessionId)) return false;
+        syncInlineSessionModelState();
+        return true;
+    } catch (error) {
+        if (!acceptsInlineSurfaceOperation(operation.owner, operation.sessionId)) return false;
+        console.error("更新 Inline AI session 推理强度失败", error);
+        notifyAgentError(error, t("agent.chatSurface.updateThinkingFailed"));
+        restoreInlineSessionModelDraft();
+        return false;
+    } finally {
+        if (acceptsInlineSurfaceOperation(operation.owner, operation.sessionId)) {
+            inlineSessionModelSaving.value = false;
+        }
+    }
+};
+
+function toggleInlineSessionModelPopover(): void {
+    if (!inlineSessionModelPopoverOpen.value && inlineSessionModelActionBlocked()) {
+        restoreInlineSessionModelDraft();
+        inlineSessionModelPopoverOpen.value = false;
+        return;
+    }
+    inlineSessionModelPopoverOpen.value = !inlineSessionModelPopoverOpen.value;
+}
+
+function setInlineSessionModelDraft(value: AgentSessionModelDraft): void {
+    if (inlineSessionModelActionBlocked()) {
+        restoreInlineSessionModelDraft();
+        return;
+    }
+    inlineSessionModelDraft.value = value;
+}
+
+function setInlineSessionModelPopoverOpen(value: boolean): void {
+    if (value && inlineSessionModelActionBlocked()) {
+        restoreInlineSessionModelDraft();
+        inlineSessionModelPopoverOpen.value = false;
+        return;
+    }
+    inlineSessionModelPopoverOpen.value = value;
+}
+
+async function applyInlineSessionModelSettings(): Promise<void> {
+    if (inlineSessionModelActionBlocked()) {
+        restoreInlineSessionModelDraft();
+        inlineSessionModelPopoverOpen.value = false;
+        return;
+    }
+    const operation = captureInlineSessionOperation();
+    if (!operation) return;
+    const nextModelKey = inlineSessionModelDraft.value.modelKey;
+    const nextThinkingLevel = inlineSessionModelDraft.value.reasoningEffort;
+    if (!await updateInlineSessionModelSelection(nextModelKey, operation)) return;
+    if (!await updateInlineSessionThinkingLevel(nextThinkingLevel, operation)) return;
+    if (!acceptsInlineSurfaceOperation(operation.owner, operation.sessionId)) return;
+    restoreInlineSessionModelDraft();
+    inlineSessionModelPopoverOpen.value = false;
+}
+
+async function resetInlineSessionModelSettings(): Promise<void> {
+    if (inlineSessionModelActionBlocked()) {
+        restoreInlineSessionModelDraft();
+        inlineSessionModelPopoverOpen.value = false;
+        return;
+    }
+    const operation = captureInlineSessionOperation();
+    if (!operation) return;
+    if (!await updateInlineSessionModelSelection(null, operation)) return;
+    if (!await updateInlineSessionThinkingLevel(null, operation)) return;
+    if (!acceptsInlineSurfaceOperation(operation.owner, operation.sessionId)) return;
+    restoreInlineSessionModelDraft();
+    inlineSessionModelPopoverOpen.value = false;
+}
+
 const sessionStream = useAgentSessionStream({
     session,
     api: agentApi,
     activeSessionId,
+    activeSessionIdentity,
     applyRecoverySideEffects: async (recovery, result, owner) => {
         if (!owner.isCurrent()) return;
         syncSessionModelState(recovery.summary);
@@ -2164,6 +3099,66 @@ const sessionStream = useAgentSessionStream({
         if (event.kind === "session" && event.event.type === "client_variable_patch_requested") {
             await acknowledgeClientPatch(owner.sessionId, event.event.request, owner.isCurrent);
         }
+    },
+    onSessionNotFound: async (_error, owner) => {
+        if (!owner.isCurrent()) return "ignored";
+        const state = surfaceActivation.state.value;
+        if (state.status === "inactive" || !acceptsActivation(state.attempt)) return "ignored";
+        const attempt = state.attempt;
+        const recovery = mainSessionLoads.runRecovery(sessionScopeKey.value, async (loadOwner) => {
+            return await recoverMissingAgentSession(owner.sessionId, null, attempt, loadOwner);
+        });
+        try {
+            await recovery.promise;
+        } catch (error) {
+            if (!owner.isCurrent() || !acceptsActivation(attempt)) return "ignored";
+            console.error("失效 Session 的 recovery 发生未处理错误", error);
+            const message = notifyAgentError(error, "目标对话已失效，恢复失败");
+            surfaceActivation.markError(attempt, sessionScopeKey.value, message);
+        }
+        return recovery.status === "deferred" ? "deferred" : "handled";
+    },
+    onError: (error, fallback) => {
+        console.error(fallback, error);
+        notifyAgentError(error, fallback);
+    },
+});
+
+const inlineEditorStream = useAgentSessionStream({
+    session: inlineEditorSession,
+    api: agentApi,
+    activeSessionId: inlineEditorSessionId,
+    activeSessionIdentity: inlineEditorSessionIdentity,
+    applyRecoverySideEffects: (_recovery, _result, owner) => {
+        if (!owner.isCurrent()) return;
+        syncInlineSessionModelState();
+    },
+    onEvent: async (event, owner) => {
+        if (event.kind === "session" && event.event.type === "client_variable_patch_requested") {
+            await acknowledgeClientPatch(owner.sessionId, event.event.request, owner.isCurrent);
+        }
+    },
+    onSessionNotFound: async (_error, streamOwner) => {
+        if (!streamOwner.isCurrent()) return "ignored";
+        const owner = captureInlineSurfaceOperation();
+        if (!owner) return "ignored";
+        const recovery = inlineSessionLoads.runRecovery(sessionScopeKey.value, async (loadOwner) => {
+            const result = await recoverMissingInlineEditorSession(streamOwner.sessionId, owner, loadOwner);
+            if (result.status === "failed"
+                && acceptsInlineSurfaceOperation(owner)
+                && inlineSessionLoads.accepts(loadOwner, sessionScopeKey.value)) {
+                notifyAgentError(new Error(result.message), "Inline AI 对话已失效，切换到可用对话失败");
+            }
+            return result;
+        });
+        try {
+            await recovery.promise;
+        } catch (error) {
+            if (!streamOwner.isCurrent() || !acceptsInlineSurfaceOperation(owner)) return "ignored";
+            console.error("失效 Inline AI Session 的 recovery 发生未处理错误", error);
+            notifyAgentError(error, "Inline AI 对话已失效，恢复失败");
+        }
+        return recovery.status === "deferred" ? "deferred" : "handled";
     },
     onError: (error, fallback) => {
         console.error(fallback, error);
@@ -2330,10 +3325,20 @@ const selectSession = async (sessionId: number): Promise<void> => {
     }
     loadingSession.value = true;
     try {
-        await loadSession(sessionId);
-        sessionDialogOpen.value = false;
+        const loaded = await loadSession(sessionId);
+        if (loaded.status === "loaded") {
+            sessionDialogOpen.value = false;
+        }
     } finally {
         loadingSession.value = false;
+    }
+};
+
+/** 关联 Agent 面板只在目标 Session 成功提交后关闭，失败时保留选择上下文。 */
+const selectLinkedAgentSession = async (sessionId: number): Promise<void> => {
+    const loaded = await loadSession(sessionId);
+    if (loaded.status === "loaded") {
+        linkedAgentPanelOpen.value = false;
     }
 };
 
@@ -2343,8 +3348,10 @@ const createSessionFromDialog = async (profileKey?: string): Promise<void> => {
     }
     loadingSession.value = true;
     try {
-        await createSession(profileKey);
-        sessionDialogOpen.value = false;
+        const created = await createSession(profileKey);
+        if (created.status === "current") {
+            sessionDialogOpen.value = false;
+        }
     } finally {
         loadingSession.value = false;
     }
@@ -2488,6 +3495,10 @@ const restoreSessionFromDialog = async (target: AgentSessionSummaryDto): Promise
 
 /** Composer 状态条动作只调用现有显式 Session 命令，不隐式创建。 */
 function handleComposerAvailabilityAction(action: AgentComposerAvailabilityAction): void {
+    if (action === "choose-session") {
+        openSessionDialog();
+        return;
+    }
     if (action === "create-session") {
         void createSessionFromHeader();
         return;
@@ -2520,10 +3531,33 @@ async function resetWorkspaceSessionState(attempt?: AgentSurfaceActivationAttemp
     sessionListLoading.value = false;
     sessionStream.stop();
     unavailableLinkedAgentWarningKeys.clear();
-    const drafts = ensureComposerDraftSession();
+    mainSessionLoads.invalidate();
+    inlineEditorSessionRequestId += 1;
+    inlineSessionLoads.invalidate();
+    invalidateInlineSurfaceOperations();
+    beginInlineSurfaceOperations(sessionScopeKey.value);
+    inlineEditorSessionLoading.value = false;    const drafts = ensureComposerDraftSession();
     if (drafts) {
         drafts.update(inputText.value);
+        try {
+            if (!resetOwner) {
+                composerContextGeneration.value = await drafts.clearContext();
+            } else {
+                const cleared = await surfaceOperations.run(
+                    resetOwner,
+                    () => sessionScopeKey.value,
+                    () => drafts.clearContext(),
+                );
+                if (cleared.status === "superseded" || (attempt && !acceptsActivation(attempt))) return;
+                composerContextGeneration.value = cleared.value;
+            }
+        } catch (error) {
+            notifyAgentError(error, "保存 Composer 草稿失败，未切换工作区", "工作区未切换");
+            throw error;
+        }
     }
+    sessionStream.stop();
+    inlineEditorStream.stop();
     activeSessionId.value = null;
     sessions.value = [];
     linkedAgentPanelOpen.value = false;
@@ -2605,6 +3639,9 @@ function closeSurfaceTransientState(): void {
     messageActionId.value = null;
 }
 
+// Inline PromptBar 在右侧面板隐藏时仍然可用，因此提前建立独立 owner。
+beginInlineSurfaceOperations(sessionScopeKey.value);
+
 watch(() => props.selectedFilePath, (nextFilePath, previousFilePath) => {
     const nextValue = nextFilePath || null;
     const previousValue = previousFilePath || null;
@@ -2616,6 +3653,31 @@ watch(() => props.selectedFilePath, (nextFilePath, previousFilePath) => {
     selectionVersion.value += 1;
 });
 
+/** 组件卸载标记：异步 continuation（await start 等）在卸载后恢复时不得再创建 watcher 或发布状态。 */
+let surfaceUnmounted = false;
+
+/** 主面板与 Inline 的重连 watcher 各自独立注册：任一 surface 的前台加载清空
+ * 自己的集合时不得误停另一个 surface 的 watcher（主/Inline owner 互不撤销合同）。 */
+const mainReconnectWatcherStops = new Set<() => void>();
+const inlineReconnectWatcherStops = new Set<() => void>();
+
+
+/** 主面板前台加载/停用/卸载时清空主面板重连 watcher（不含 Inline）。 */
+function clearMainReconnectWatchers(): void {
+    for (const stop of mainReconnectWatcherStops) {
+        stop();
+    }
+    mainReconnectWatcherStops.clear();
+}
+
+/** Inline 前台加载/卸载时清空 Inline 重连 watcher（不含主面板）。 */
+function clearInlineReconnectWatchers(): void {
+    for (const stop of inlineReconnectWatcherStops) {
+        stop();
+    }
+    inlineReconnectWatcherStops.clear();
+}
+
 watchAgentSurfaceActivation({
     active: () => props.active,
     scopeKey: () => sessionScopeKey.value,
@@ -2625,7 +3687,10 @@ watchAgentSurfaceActivation({
             return;
         }
         beginSurfaceOperations(attempt.scopeKey);
-        await restoreAgentSurface(attempt, {reset: context.scopeChanged});
+        await restoreAgentSurface(attempt, {
+            reset: context.scopeChanged,
+            forceRecovery: context.reactivated,
+        });
         const activationState = surfaceActivation.state.value;
         if (activationState.status !== "ready") {
             return;
@@ -2644,7 +3709,12 @@ watchAgentSurfaceActivation({
     },
     deactivate: (context) => {
         invalidateSurfaceOperations();
+        mainSessionLoads.invalidate();
+        sessionStream.stop();
         closeSurfaceTransientState();
+        // 主面板停用/scope 改变时旧代次重连 watcher 已无意义，统一停止防闭包累积。
+        // 只清主面板集合：Inline PromptBar/stream 保持独立（主/Inline 互不撤销合同）。
+        clearMainReconnectWatchers();
         if (context.scopeChanged) {
             void resetWorkspaceSessionState();
         }
@@ -2673,11 +3743,20 @@ watch(() => ideStore.configRevision, () => {
 });
 
 onBeforeUnmount(() => {
+    surfaceUnmounted = true;
     void composerDraftSession?.dispose().catch((error) => console.error("保存 Composer 草稿失败", error));
     composerDraftSession = null;
     sessionStream.stop();
     surfaceOperations.dispose();
+    inlineSurfaceOperations.dispose();
+    surfaceActivation.dispose();
+    mainSessionLoads.invalidate();
+    inlineSessionLoads.invalidate();
+    surfaceOperationRevision.value += 1;
+    inlineOperationRevision.value += 1;
     resetSessionAttachments();
+    clearMainReconnectWatchers();
+    clearInlineReconnectWatchers();
 });
 
 watch(queuedMessages, (items) => {
@@ -2700,13 +3779,29 @@ onMounted(() => {
 });
 
 defineExpose({
+    operationScopeKey: surfaceOperationKey,
+    inlineOperationScopeKey: inlineOperationKey,
     activeSessionId,
     sessions,
     loadingSession,
     linkedAgentsLoading,
     running,
     selectableModels,
-    sessionActionId,
+    inlineEditorRunning,
+    inlineEditorResultText,
+    inlineEditorLiveView,
+    inlineEditorSessionId,
+    inlineEditorSessions,
+    inlineEditorSessionLoading,
+    inlineEditPreview,
+    inlineEditorSessionLabel,
+    inlineSessionModelDraft,
+    inlineSessionModelPopoverOpen,
+    inlineSessionModelSaving,
+    inlineSessionModelSelectionValue,
+    inlineSessionThinkingResolvedLabel,
+    openInlineEditorSession,
+    refreshInlineEditorSessions,    sessionActionId,
     ensureSessionReady,
     refreshSessionsWithQuery,
     selectSession,
@@ -2716,20 +3811,401 @@ defineExpose({
     renameSessionFromDialog,
 });
 
-function readLastSessionId(): number | null {
+/**
+ * 确保 Project 级 Inline AI Session 可用。
+ */
+async function ensureInlineEditorSession(
+    owner: AgentSurfaceActivationAttempt,
+): Promise<AgentSurfaceOperationResult<AgentSessionSummaryDto> | {status: "empty"} | {status: "failed"; message: string}> {
+    if (inlineEditorSessionId.value && inlineEditorSession.recoveryShell.value) {
+        return {status: "current", value: inlineEditorSession.recoveryShell.value.summary};
+    }
+    const listResult = await refreshInlineEditorSessions(owner);
+    if (listResult.status === "superseded") return listResult;
+    const list = listResult.value;
+    const selected = inlineEditorSessionId.value
+        ? list.find((item) => item.sessionId === inlineEditorSessionId.value)
+        : undefined;
+    if (selected && inlineEditorSession.recoveryShell.value) {
+        return {status: "current", value: selected};
+    }
+    return list.length === 0
+        ? {status: "empty"}
+        : {status: "failed", message: "请选择一个 Inline AI 对话后继续。"};
+}
+
+/**
+ * 刷新当前 Project Workspace 下的 Inline AI sessions。
+ */
+async function refreshInlineEditorSessions(
+    requestedOwner?: AgentSurfaceActivationAttempt,
+    options: {recoverMissing?: boolean; loadSelection?: boolean; loadOwner?: AgentSessionLoadOwner} = {},
+): Promise<AgentSurfaceOperationResult<AgentSessionSummaryDto[]>> {
+    const owner = requestedOwner ?? captureInlineSurfaceOperation();
+    if (!owner) return {status: "superseded"};
+    const loadOwner = options.loadOwner ?? inlineSessionLoads.beginForeground(sessionScopeKey.value);
+    const ownsLoadOwner = options.loadOwner === undefined;
+    clearInlineReconnectWatchers();
+    const acceptsLoad = (): boolean => inlineSessionLoads.accepts(loadOwner, sessionScopeKey.value)
+        && acceptsInlineSurfaceOperation(owner);
+    if (!acceptsLoad()) {
+        return {status: "superseded"};
+    }
+    let requestId = ++inlineEditorSessionRequestId;
+    inlineEditorSessionLoading.value = true;
+    try {
+        const page = await agentApi.listSessions({
+            ...sessionScope.value,
+            profileGroup: "all",
+            profileKey: INLINE_EDITOR_PROFILE_KEY,
+            status: "active",
+            relation: "all",
+            limit: 50,
+        });
+        if (requestId !== inlineEditorSessionRequestId || !acceptsLoad()) {
+            return {status: "superseded"};
+        }
+        inlineEditorSessions.value = page.items;
+        if (options.loadSelection === false) {
+            return {status: "current", value: page.items};
+        }
+        const current = inlineEditorSessionId.value && inlineEditorSession.recoveryShell.value
+            ? page.items.find((item) => item.sessionId === inlineEditorSessionId.value)
+            : undefined;
+        const remembered = current ? null : readInlineEditorSession();
+        const target = remembered && !current ? remembered : null;
+        if (target) {
+            const loaded = await loadInlineEditorSession(target.sessionId, {
+                invalidateRefresh: false,
+                owner,
+                loadOwner,
+                recoverMissing: options.recoverMissing,
+                expectedIdentity: target.sessionIdentity,
+            });
+            const adopted = adoptInlineEditorRequest(requestId, loaded.status === "primary_missing"
+                ? {status: "failed", requestId: loaded.requestId}
+                : loaded);
+            if (adopted.status === "superseded") {
+                return {status: "superseded"};
+            }
+            requestId = adopted.requestId;
+            if (loaded.status === "empty") {
+                throw new Error(t("agent.chatSurface.inlineLoadFailed"));
+            }
+            if (loaded.status === "primary_missing") {
+                throw new Error(t("agent.chatSurface.inlineLoadFailed"));
+            }
+            if (loaded.status === "failed") {
+                throw new Error(loaded.message);
+            }
+            if (requestId !== inlineEditorSessionRequestId || !acceptsLoad()) {
+                return {status: "superseded"};
+            }
+        }
+        if (!target && !current && page.items.length === 0) {
+            clearInlineEditorSession(undefined, false);
+        }
+        return {status: "current", value: page.items};
+    } catch (error) {
+        if (requestId !== inlineEditorSessionRequestId || !acceptsLoad()) {
+            return {status: "superseded"};
+        }
+        throw error;
+    } finally {
+        if (requestId === inlineEditorSessionRequestId && acceptsLoad()) {
+            inlineEditorSessionLoading.value = false;
+        }
+        if (ownsLoadOwner) {
+            await inlineSessionLoads.finish(loadOwner);
+        }
+    }
+}
+
+/**
+ * 创建一个新的 Project 级 Inline AI session，并设为 PromptBar 当前 session。
+ */
+async function createInlineEditorSession(
+    requestedOwner?: AgentSurfaceActivationAttempt,
+): Promise<AgentSurfaceOperationResult<AgentSessionSummaryDto>> {
+    const owner = requestedOwner ?? captureInlineSurfaceOperation();
+    if (!owner) return {status: "superseded"};
+    const loadOwner = inlineSessionLoads.beginForeground(sessionScopeKey.value);
+    clearInlineReconnectWatchers();
+    const projectRoot = ideStore.workspaceKind === "novel" ? ideStore.currentProjectRoot || undefined : undefined;
+    try {
+        const created = await agentApi.createSession({
+            profileKey: INLINE_EDITOR_PROFILE_KEY,
+            initial: {},
+            currentProjectRoot: projectRoot,
+        });
+        if (!acceptsInlineSurfaceOperation(owner) || !inlineSessionLoads.accepts(loadOwner, sessionScopeKey.value)) {
+            return {status: "superseded"};
+        }
+        const loaded = await loadInlineEditorSession(created.sessionId, {owner, loadOwner});
+        if (loaded.status === "superseded") return loaded;
+        if (loaded.status === "empty") {
+            throw new Error(t("agent.chatSurface.inlineLoadFailed"));
+        }
+        if (loaded.status === "primary_missing") {
+            throw new Error(t("agent.chatSurface.inlineLoadFailed"));
+        }
+        if (loaded.status === "failed") {
+            throw new Error(loaded.message);
+        }
+        const refreshed = await refreshInlineEditorSessions(owner, {loadOwner});
+        if (refreshed.status === "superseded") return refreshed;
+        return {status: "current", value: loaded.value};
+    } finally {
+        await inlineSessionLoads.finish(loadOwner);
+    }
+}
+
+/**
+ * 选择 PromptBar 当前使用的 Inline AI session，不影响右侧 Agent 面板。
+ */
+async function selectInlineEditorSession(sessionId: number): Promise<InlineEditorSelectionResult> {
+    const owner = captureInlineSurfaceOperation();
+    if (!owner) return {status: "superseded"};
+    if (inlineEditorSessionId.value === sessionId) {
+        return {status: "current", value: undefined};
+    }
+    const loadOwner = inlineSessionLoads.beginForeground(sessionScopeKey.value);
+    clearInlineReconnectWatchers();
+    try {
+        const loaded = await loadInlineEditorSession(sessionId, {owner, loadOwner});
+        return projectInlineEditorSelection(loaded.status === "primary_missing"
+            ? {status: "failed", message: t("agent.chatSurface.inlineLoadFailed")}
+            : loaded);
+    } finally {
+        await inlineSessionLoads.finish(loadOwner);
+    }
+}
+
+type InlineEditorSessionLoadResult =
+    | {status: "current"; value: AgentSessionSummaryDto; requestId: number}
+    | {status: "superseded"}
+    | {status: "empty"; requestId: number}
+    | {status: "primary_missing"; requestId: number}
+    | {status: "failed"; message: string; requestId: number};
+
+/** 清理失效 Inline Session 并刷新一次；有列表时保持未绑定，不猜测首项。 */
+async function recoverMissingInlineEditorSession(
+    failedSessionId: number,
+    owner: AgentSurfaceActivationAttempt,
+    loadOwner: AgentSessionLoadOwner,
+    expectedIdentity?: AgentSessionIdentity,
+): Promise<InlineEditorSessionLoadResult> {
+    const acceptsLoad = (): boolean => inlineSessionLoads.accepts(loadOwner, sessionScopeKey.value)
+        && acceptsInlineSurfaceOperation(owner);
+    if (!acceptsLoad()) {
+        return {status: "superseded"};
+    }
+    const failedIdentity = expectedIdentity ?? inlineEditorSessionIdentity.value;
+    inlineEditorSessionRequestId += 1;
+
+    try {
+        const refreshed = await refreshInlineEditorSessions(owner, {
+            recoverMissing: false,
+            loadSelection: false,
+            loadOwner,
+        });
+        if (refreshed.status === "superseded" || !acceptsLoad()) {
+            return {status: "superseded"};
+        }
+        if (failedIdentity && import.meta.client) {
+            const remembered = readInlineEditorSession();
+            if (remembered?.sessionId === failedSessionId && remembered.sessionIdentity === failedIdentity) {
+                forgetRememberedSession(
+                    localStorage,
+                    `agent:inline-editor-session:${sessionMemoryScopeKey.value}`,
+                    remembered,
+                );
+            }
+        }
+        clearInlineEditorSession(failedSessionId, false, failedIdentity ?? undefined);
+        if (refreshed.value.length === 0) {
+            notification.warning("Inline AI 对话不在当前打开的 NeuroBook 中，当前没有可用对话。", {title: "对话已失效"});
+            return {status: "empty", requestId: inlineEditorSessionRequestId};
+        }
+        notification.warning("Inline AI 对话不在当前打开的 NeuroBook 中，请重新选择对话。", {title: "对话已失效"});
+        return {
+            status: "failed",
+            message: "Inline AI 对话已失效，请从列表重新选择。",
+            requestId: inlineEditorSessionRequestId,
+        };
+    } catch (error) {
+        if (!acceptsLoad()) {
+            return {status: "superseded"};
+        }
+        console.error("失效 Inline AI Session 的列表恢复失败", error);
+        return {
+            status: "failed",
+            message: resolveApiErrorMessage(error, t("agent.chatSurface.inlineLoadFailed")),
+            requestId: inlineEditorSessionRequestId,
+        };
+    }
+}
+
+/**
+ * 加载后台 Inline AI session recovery，并启动它自己的 SSE。
+ */
+async function loadInlineEditorSession(
+    sessionId: number,
+    options: {
+        invalidateRefresh?: boolean;
+        owner?: AgentSurfaceActivationAttempt;
+        loadOwner?: AgentSessionLoadOwner;
+        recoverMissing?: boolean;
+        expectedIdentity?: AgentSessionIdentity;
+    } = {},
+): Promise<InlineEditorSessionLoadResult> {
+    const owner = options.owner ?? captureInlineSurfaceOperation();
+    if (!owner || !acceptsInlineSurfaceOperation(owner)) return {status: "superseded"};
+    const loadOwner = options.loadOwner ?? inlineSessionLoads.beginForeground(sessionScopeKey.value);
+    const ownsLoadOwner = options.loadOwner === undefined;
+    const acceptsLoad = (): boolean => inlineSessionLoads.accepts(loadOwner, sessionScopeKey.value)
+        && acceptsInlineSurfaceOperation(owner);
+    if (!acceptsLoad()) {
+        return {status: "superseded"};
+    }
+    // 无论 owner 由谁创建（select/create/refresh 传 loadOwner），前台加载开始即取代旧代次。
+    clearInlineReconnectWatchers();
+    if (options.invalidateRefresh !== false) {
+        inlineEditorSessionRequestId += 1;
+    }
+    inlineEditorSessionLoading.value = true;
+    try {
+        const result = await runSessionLoadAttempt({
+            read: () => agentApi.getSessionRecovery(sessionId),
+            accepts: acceptsLoad,
+            errorCode: resolveApiErrorCode,
+            commit: (recovery) => {
+                if (recovery.summary.sessionId !== sessionId) {
+                    throw new Error(`Inline AI Session 身份不匹配：期望 ${String(sessionId)}，收到 ${String(recovery.summary.sessionId)}`);
+                }
+                if (options.expectedIdentity !== undefined
+                    && recovery.summary.sessionIdentity !== options.expectedIdentity) {
+                    throw new Error("Inline 对话身份与浏览器记忆不一致。请从当前列表重新选择。");
+                }
+                if (recovery.summary.profileKey !== INLINE_EDITOR_PROFILE_KEY) {
+                    throw new Error(t("agent.chatSurface.inlineLoadFailed"));
+                }
+                inlineEditorStream.stop();
+                inlineEditorSessionId.value = sessionId;
+                inlineEditorSessionIdentity.value = recovery.summary.sessionIdentity;
+                inlineEditorSession.reset();
+                inlineEditorResultText.value = "";
+                inlineEditorSession.applyRecovery(recovery);
+                syncInlineSessionModelState();
+                inlineEditorSessions.value = inlineEditorSessions.value.some((item) => item.sessionId === recovery.summary.sessionId)
+                    ? inlineEditorSessions.value.map((item) => item.sessionId === recovery.summary.sessionId ? recovery.summary : item)
+                    : [recovery.summary, ...inlineEditorSessions.value];
+            },
+        });
+        if (result.status === "primary_missing" && options.recoverMissing !== false) {
+            return recoverMissingInlineEditorSession(sessionId, owner, loadOwner, options.expectedIdentity);
+        }
+        if (result.status === "primary_missing") {
+            clearInlineEditorSession(sessionId, false);
+            return {status: "primary_missing", requestId: inlineEditorSessionRequestId};
+        }
+        if (result.status === "dependency_missing" || result.status === "failed") {
+            throw result.error;
+        }
+        if (result.status === "superseded") {
+            return {status: "superseded"};
+        }
+        if (result.status === "loaded") {
+            // 记忆只在事件流 open 成功且 owner 仍有效时写入（ADR 0018）；失败保留已提交 Session，不回滚。
+            const streamOutcome = await writeRememberedAfterStreamOpen({
+                start: () => inlineEditorStream.start(sessionId),
+                accepts: acceptsLoad,
+                remember: () => saveInlineEditorSession(sessionId, result.value.summary.sessionIdentity),
+            });
+            if (streamOutcome.status === "connect_failed") {
+                console.error(`连接 Inline session ${String(sessionId)} 实时事件流失败，本次不写入对话记忆`, streamOutcome.error);
+                notifyAgentError(streamOutcome.error, "Inline 对话已切换，但实时事件流连接失败，恢复连接前不会更新对话记忆。", "连接失败");
+                // watch 在异步 continuation 中创建，没有 active effect scope；登记到 setup
+                // 同步注册的重连 watcher 清理表，组件卸载时统一 stop。
+                if (surfaceUnmounted) {
+                    return {status: "superseded"};
+                }
+                const expectedInlineIdentity = result.value.summary.sessionIdentity;
+                registerReconnectRestoreWatcher({
+                    connectionStatus: inlineEditorSession.connectionStatus,
+                    stops: inlineReconnectWatcherStops,
+                    // operation 被新代次接管、目标 Session 切换或身份不符时立即自停。
+                    shouldRestore: () => acceptsInlineSurfaceOperation(owner, sessionId)
+                        && inlineEditorSessionIdentity.value === expectedInlineIdentity,
+                    onRestored: () => saveInlineEditorSession(sessionId, expectedInlineIdentity),
+                });
+            } else if (streamOutcome.status === "superseded") {
+                // 提交后等待 open 期间被新 owner 取代：新 owner 已发布自己的状态，
+                // 本代次不写记忆；结果按 superseded 转发给调用方。
+                return {status: "superseded"};
+            }
+        }
+        return {status: "current", value: result.value.summary, requestId: inlineEditorSessionRequestId};
+    } finally {
+        if (acceptsLoad()) {
+            inlineEditorSessionLoading.value = false;
+        }
+        if (ownsLoadOwner) {
+            await inlineSessionLoads.finish(loadOwner);
+        }
+    }
+}
+
+function readInlineEditorSession(): RememberedSession | null {
     if (!import.meta.client) {
         return null;
     }
-    const raw = localStorage.getItem(`agent:last-session:${sessionMemoryScopeKey.value}`);
-    const parsed = raw ? Number(raw) : NaN;
-    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+    const result = readRememberedSession(localStorage, `agent:inline-editor-session:${sessionMemoryScopeKey.value}`);
+    if (result.status === "failed") {
+        notification.warning("当前 Inline 对话已打开，但浏览器记忆不可读取；下次启动可能需要重新选择。", {title: "对话记忆不可用"});
+        return null;
+    }
+    return result.status === "valid" ? result.value : null;
 }
 
-function saveLastSessionId(sessionId: number): void {
+function saveInlineEditorSession(sessionId: number, sessionIdentity: AgentSessionIdentity): void {
     if (!import.meta.client) {
         return;
     }
-    localStorage.setItem(`agent:last-session:${sessionMemoryScopeKey.value}`, String(sessionId));
+    const result = tryWriteRememberedSession(
+        localStorage,
+        `agent:inline-editor-session:${sessionMemoryScopeKey.value}`,
+        {schema: 2, sessionId, sessionIdentity},
+    );
+    if (result.status === "failed") {
+        notification.warning("当前 Inline 对话已打开，但下次启动可能需要重新选择。", {title: "对话记忆未保存"});
+    }
+}
+
+function readLastSession(): RememberedSession | null {
+    if (!import.meta.client) {
+        return null;
+    }
+    const result = readRememberedSession(localStorage, `agent:last-session:${sessionMemoryScopeKey.value}`);
+    if (result.status === "failed") {
+        notification.warning("当前对话已打开，但浏览器记忆不可读取；下次启动可能需要重新选择。", {title: "对话记忆不可用"});
+        return null;
+    }
+    return result.status === "valid" ? result.value : null;
+}
+
+function saveLastSession(sessionId: number, sessionIdentity: AgentSessionIdentity): void {
+    if (!import.meta.client) {
+        return;
+    }
+    const result = tryWriteRememberedSession(
+        localStorage,
+        `agent:last-session:${sessionMemoryScopeKey.value}`,
+        {schema: 2, sessionId, sessionIdentity},
+    );
+    if (result.status === "failed") {
+        notification.warning("当前对话已打开，但下次启动可能需要重新选择。", {title: "对话记忆未保存"});
+    }
 }
 
 </script>
@@ -2815,7 +4291,7 @@ function saveLastSessionId(sessionId: number): void {
                 :owned-agents="linkedAgents"
                 :linked-by-agents="linkedByAgents"
                 :loading="linkedAgentsLoading"
-                @select="void loadSession($event); linkedAgentPanelOpen = false"
+                @select="void selectLinkedAgentSession($event)"
                 @refresh="void refreshLinkedAgentRelations()"
                 @close="linkedAgentPanelOpen = false"
             />
@@ -2835,6 +4311,7 @@ function saveLastSessionId(sessionId: number): void {
                 ref="chatFlowRef"
                 :messages="renderNodes"
                 :session-id="activeSessionId"
+                :unselected="surfaceActivation.state.value.status === 'unselected'"
                 :running="running"
                 mode="main"
                 :editing-message-id="editingMessageId"

--- a/packages/neuro-book/app/components/novel-ide/agent/AgentComposer.vue
+++ b/packages/neuro-book/app/components/novel-ide/agent/AgentComposer.vue
@@ -124,6 +124,15 @@ const availabilityView = computed<ComposerAvailabilityView | null>(() => {
                 actionIcon: "",
                 actionLabel: "",
             };
+        case "unselected":
+            return {
+                icon: "i-lucide-messages-square",
+                message: "请选择一个对话后继续。",
+                tone: "warning",
+                action: "choose-session",
+                actionIcon: "i-lucide-list",
+                actionLabel: "选择对话",
+            };
         case "empty":
             return {
                 icon: "i-lucide-message-square-plus",

--- a/packages/neuro-book/app/components/novel-ide/agent/agent-chat-surface-state.test.ts
+++ b/packages/neuro-book/app/components/novel-ide/agent/agent-chat-surface-state.test.ts
@@ -1,13 +1,23 @@
 import {effectScope, nextTick, ref} from "vue";
 import {describe, expect, it, vi} from "vitest";
 import {
+    AgentSessionLoadController,
     AgentSurfaceActivationController,
     AgentSurfaceOperationController,
     AgentSurfaceSupersededError,
+    adoptInlineEditorRequest,
+    forgetRememberedSession,
+    readRememberedSession,
+    projectAgentSessionLoad,
     projectAgentComposerAvailability,
-    recoverMissingSessionSelection,
-    resolveMissingSessionFallback,
+    projectInlineEditorSelection,
+    projectReconnectReady,
+    runSessionLoadAttempt,
+    tryWriteRememberedSession,
+    registerReconnectRestoreWatcher,
+    writeRememberedAfterStreamOpen,
     watchAgentSurfaceActivation,
+    type AgentSessionLoadOwner,
     type AgentSurfaceActivationState,
 } from "nbook/app/components/novel-ide/agent/agent-chat-surface-state";
 
@@ -21,87 +31,514 @@ function deferred<T>() {
     return {promise, resolve, reject};
 }
 
-describe("resolveMissingSessionFallback", () => {
-    const sessions = [{sessionId: 39}, {sessionId: 40}, {sessionId: 41}];
-
-    it("优先保留列表中仍有效的原 Session", () => {
-        expect(resolveMissingSessionFallback(sessions, 3, 40)).toBe(40);
-    });
-
-    it("原 Session 不可用时选择第一个非失败 Session", () => {
-        expect(resolveMissingSessionFallback(sessions, 3, 3)).toBe(39);
-        expect(resolveMissingSessionFallback(sessions, 3, 99)).toBe(39);
-    });
-
-    it("排除失败 ID 且空列表返回 null", () => {
-        expect(resolveMissingSessionFallback([{sessionId: 3}, {sessionId: 40}], 3, null)).toBe(40);
-        expect(resolveMissingSessionFallback([{sessionId: 3}], 3, null)).toBeNull();
-        expect(resolveMissingSessionFallback([], 3, null)).toBeNull();
+describe("projectAgentSessionLoad", () => {
+    it.each([
+        ["loaded", true, {status: "commit"}],
+        ["superseded", true, {status: "superseded"}],
+        ["primary_missing", true, {status: "preserve", reason: "primary_missing"}],
+        ["dependency_missing", true, {status: "preserve", reason: "dependency_missing"}],
+        ["failed", true, {status: "preserve", reason: "failed"}],
+        ["empty", true, {status: "preserve", reason: "empty"}],
+        ["primary_missing", false, {status: "clear", reason: "primary_missing"}],
+        ["dependency_missing", false, {status: "clear", reason: "failed"}],
+        ["failed", false, {status: "clear", reason: "failed"}],
+    ] as const)("%s + stable=%s 投影为 %o", (status, stable, expected) => {
+        expect(projectAgentSessionLoad(status, stable)).toEqual(expected);
     });
 });
 
-describe("recoverMissingSessionSelection", () => {
-    it("只刷新和加载一次，并优先恢复原有效 Session", async () => {
-        const refresh = vi.fn(async () => [{sessionId: 39}, {sessionId: 40}]);
-        const load = vi.fn(async () => true);
+describe("forgetRememberedSession", () => {
+    it("只删除仍指向失效 Session 的记忆", () => {
+        const storage = new MemoryStorage();
+        const main = {schema: 2 as const, sessionId: 3, sessionIdentity: "sha256:0000000000000000000000000000000000000000000000000000000000000000"};
+        storage.setItem("main", JSON.stringify(main));
+        storage.setItem("inline", JSON.stringify({...main, sessionId: 40}));
 
-        await expect(recoverMissingSessionSelection({
-            failedSessionId: 3,
-            previousSessionId: 40,
-            accepts: () => true,
-            refresh,
-            load,
-        })).resolves.toEqual({status: "loaded", sessionId: 40});
-        expect(refresh).toHaveBeenCalledTimes(1);
-        expect(load).toHaveBeenCalledTimes(1);
-        expect(load).toHaveBeenCalledWith(40);
+        expect(forgetRememberedSession(storage, "main", main)).toBe(true);
+        expect(storage.getItem("main")).toBeNull();
+        expect(forgetRememberedSession(storage, "inline", main)).toBe(false);
+        expect(storage.getItem("inline")).toBe(JSON.stringify({...main, sessionId: 40}));
     });
 
-    it("空列表不加载，fallback 失败也不递归重试", async () => {
-        const emptyLoad = vi.fn(async () => true);
-        await expect(recoverMissingSessionSelection({
-            failedSessionId: 3,
-            previousSessionId: null,
-            accepts: () => true,
-            refresh: async () => [],
-            load: emptyLoad,
-        })).resolves.toEqual({status: "empty"});
-        expect(emptyLoad).not.toHaveBeenCalled();
+    it("identity 轮换、记忆被替换或删除抛错时保留现值并返回 false", () => {
+        const storage = new MemoryStorage();
+        const staleIdentity = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+        const freshIdentity = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+        const remembered = {schema: 2 as const, sessionId: 3, sessionIdentity: staleIdentity};
 
-        const failedLoad = vi.fn(async () => false);
-        await expect(recoverMissingSessionSelection({
-            failedSessionId: 3,
-            previousSessionId: null,
-            accepts: () => true,
-            refresh: async () => [{sessionId: 39}, {sessionId: 40}],
-            load: failedLoad,
-        })).resolves.toEqual({status: "load_failed", sessionId: 39});
-        expect(failedLoad).toHaveBeenCalledTimes(1);
+        // 同 ID 但 identity 已轮换：不删除
+        storage.setItem("agent:last-session:p", JSON.stringify({...remembered, sessionIdentity: freshIdentity}));
+        expect(forgetRememberedSession(storage, "agent:last-session:p", remembered)).toBe(false);
+        expect(JSON.parse(storage.getItem("agent:last-session:p")!).sessionIdentity).toBe(freshIdentity);
+
+        // 记忆已被其它 Session 替换：保留新值
+        storage.setItem("agent:inline-editor-session:p", JSON.stringify({schema: 2 as const, sessionId: 9, sessionIdentity: freshIdentity}));
+        expect(forgetRememberedSession(storage, "agent:inline-editor-session:p", remembered)).toBe(false);
+        expect(JSON.parse(storage.getItem("agent:inline-editor-session:p")!).sessionId).toBe(9);
+
+        // removeItem 抛错只报告失败，不破坏现有记忆
+        storage.setItem("agent:last-session:p", JSON.stringify(remembered));
+        vi.spyOn(storage, "removeItem").mockImplementation(() => {
+            throw new Error("quota exceeded");
+        });
+        expect(forgetRememberedSession(storage, "agent:last-session:p", remembered)).toBe(false);
+        expect(JSON.parse(storage.getItem("agent:last-session:p")!).sessionId).toBe(3);
+    });
+});
+
+describe("projectReconnectReady", () => {
+    const base = {
+        activationStatus: "error" as const,
+        attemptScopeKey: "project:a",
+        attemptRevision: 3,
+        expectedScopeKey: "project:a",
+        expectedRevision: 3,
+        activeSessionId: 5,
+        expectedSessionId: 5,
+    };
+
+    it("同一 attempt 且目标 Session 仍是当前会话时恢复 ready", () => {
+        expect(projectReconnectReady(base)).toBe("restore_ready");
     });
 
-    it("刷新或加载后 ownership 失效时不发布旧结果", async () => {
-        let accepted = false;
-        const load = vi.fn(async () => true);
-        await expect(recoverMissingSessionSelection({
-            failedSessionId: 3,
-            previousSessionId: null,
-            accepts: () => accepted,
-            refresh: async () => [{sessionId: 39}],
-            load,
-        })).resolves.toEqual({status: "superseded"});
-        expect(load).not.toHaveBeenCalled();
+    it("activation 已非 error（新 owner 接管）时不恢复", () => {
+        expect(projectReconnectReady({...base, activationStatus: "ready"})).toBe("skip_not_error");
+        expect(projectReconnectReady({...base, activationStatus: "loading"})).toBe("skip_not_error");
+    });
 
-        accepted = true;
-        await expect(recoverMissingSessionSelection({
-            failedSessionId: 3,
-            previousSessionId: null,
-            accepts: () => accepted,
-            refresh: async () => [{sessionId: 39}],
-            load: async () => {
-                accepted = false;
-                return true;
+    it("旧代次 attempt 被替换时不误标新 owner 状态", () => {
+        expect(projectReconnectReady({...base, attemptRevision: 2})).toBe("skip_stale_owner");
+        expect(projectReconnectReady({...base, attemptScopeKey: "project:b"})).toBe("skip_stale_owner");
+    });
+
+    it("目标 Session 已切换到其它会话时不恢复", () => {
+        expect(projectReconnectReady({...base, activeSessionId: 9})).toBe("skip_wrong_session");
+    });
+
+    it("inactive（组件停用/卸载后）时静默丢弃，不访问 attempt 字段", () => {
+        expect(projectReconnectReady({...base, activationStatus: "inactive"})).toBe("skip_not_error");
+        expect(projectReconnectReady({...base, activationStatus: "unselected"})).toBe("skip_not_error");
+        expect(projectReconnectReady({...base, activationStatus: "empty"})).toBe("skip_not_error");
+    });
+});
+
+
+describe("registerReconnectRestoreWatcher", () => {
+    it("注册时已 connected 且 stale：立即自停并移出注册表，不执行 onRestored", () => {
+        const status = ref<string>("connected");
+        const stops = new Set<() => void>();
+        const onRestored = vi.fn();
+
+        registerReconnectRestoreWatcher({
+            connectionStatus: status,
+            stops,
+            shouldRestore: () => false,
+            onRestored,
+        });
+
+        expect(stops.size).toBe(0);
+        expect(onRestored).not.toHaveBeenCalled();
+    });
+
+    it("注册时已 connected 且守卫通过：同步恢复一次并自停", async () => {
+        const status = ref<string>("connected");
+        const stops = new Set<() => void>();
+        const onRestored = vi.fn();
+
+        registerReconnectRestoreWatcher({
+            connectionStatus: status,
+            stops,
+            shouldRestore: () => true,
+            onRestored,
+        });
+
+        expect(onRestored).toHaveBeenCalledOnce();
+        expect(stops.size).toBe(0);
+        status.value = "reconnecting";
+        await nextTick();
+        expect(onRestored).toHaveBeenCalledOnce();
+    });
+
+    it("pending 时挂起监听，connected 触发一次恢复并自停", async () => {
+        const status = ref<string>("reconnecting");
+        const stops = new Set<() => void>();
+        const onRestored = vi.fn();
+
+        registerReconnectRestoreWatcher({
+            connectionStatus: status,
+            stops,
+            shouldRestore: () => true,
+            onRestored,
+        });
+
+        expect(stops.size).toBe(1);
+        status.value = "idle";
+        await nextTick();
+        expect(onRestored).not.toHaveBeenCalled();
+        expect(stops.size).toBe(1);
+
+        status.value = "connected";
+        await nextTick();
+        expect(onRestored).toHaveBeenCalledOnce();
+        expect(stops.size).toBe(0);
+
+        status.value = "reconnecting";
+        await nextTick();
+        expect(onRestored).toHaveBeenCalledOnce();
+    });
+
+    it("未 connected 期间 owner 失效即自停，之后 connected 不再触发", async () => {
+        const status = ref<string>("reconnecting");
+        const stops = new Set<() => void>();
+        const onRestored = vi.fn();
+        let valid = true;
+
+        registerReconnectRestoreWatcher({
+            connectionStatus: status,
+            stops,
+            shouldRestore: () => valid,
+            onRestored,
+        });
+
+        expect(stops.size).toBe(1);
+        valid = false;
+        status.value = "disconnected";
+        await nextTick();
+        expect(stops.size).toBe(0);
+        expect(onRestored).not.toHaveBeenCalled();
+
+        valid = true;
+        status.value = "connected";
+        await nextTick();
+        expect(onRestored).not.toHaveBeenCalled();
+    });
+
+    it("主/Inline 注册表隔离：一个 surface 的 stale 自停不影响另一个", async () => {
+        const status = ref<string>("reconnecting");
+        const mainStops = new Set<() => void>();
+        const inlineStops = new Set<() => void>();
+        const mainStale = vi.fn(() => false);
+        const mainRestored = vi.fn();
+        const inlineRestored = vi.fn();
+
+        registerReconnectRestoreWatcher({connectionStatus: status, stops: mainStops, shouldRestore: mainStale, onRestored: mainRestored});
+        registerReconnectRestoreWatcher({connectionStatus: status, stops: inlineStops, shouldRestore: () => true, onRestored: inlineRestored});
+        // stale 主面板 watcher 在注册同步检查时即自停；Inline watcher 不受影响。
+        expect(mainStops.size).toBe(0);
+        expect(mainStale).toHaveBeenCalled();
+        expect(inlineStops.size).toBe(1);
+
+        status.value = "idle";
+        await nextTick();
+        expect(mainStops.size).toBe(0);
+        expect(inlineStops.size).toBe(1); // Inline watcher 继续挂起
+
+        status.value = "connected";
+        await nextTick();
+        expect(mainRestored).not.toHaveBeenCalled();
+        expect(inlineRestored).toHaveBeenCalledOnce();
+        expect(inlineStops.size).toBe(0);
+    });
+});
+
+describe("writeRememberedAfterStreamOpen", () => {
+    const identity = {schema: 2 as const, sessionId: 5, sessionIdentity: "sha256:2222222222222222222222222222222222222222222222222222222222222222"};
+
+    it("主面板记忆：事件流 open 成功后才写入", async () => {
+        const storage = new MemoryStorage();
+        let resolveStart: () => void = () => undefined;
+        const start = vi.fn(() => new Promise<void>((resolve) => {
+            resolveStart = resolve;
+        }));
+        const outcomePromise = writeRememberedAfterStreamOpen({
+            start,
+            accepts: () => true,
+            remember: () => {
+                expect(tryWriteRememberedSession(storage, "agent:last-session:p", identity).status).toBe("saved");
             },
+        });
+
+        await Promise.resolve();
+        expect(storage.getItem("agent:last-session:p")).toBeNull();
+        resolveStart();
+
+        expect(await outcomePromise).toEqual({status: "connected"});
+        expect(JSON.parse(storage.getItem("agent:last-session:p")!)).toEqual(identity);
+    });
+
+    it("Inline 记忆：open 前连接失败不写入并报告 connect_failed", async () => {
+        const storage = new MemoryStorage();
+        const failure = new Error("event stream closed before open");
+        const outcome = await writeRememberedAfterStreamOpen({
+            start: vi.fn(async () => {
+                throw failure;
+            }),
+            accepts: () => true,
+            remember: () => storage.setItem("agent:inline-editor-session:p", JSON.stringify(identity)),
+        });
+
+        expect(outcome).toEqual({status: "connect_failed", error: failure});
+        expect(storage.getItem("agent:inline-editor-session:p")).toBeNull();
+    });
+
+    it("open 前 owner 已失效时连接失败折叠为 superseded 且不写记忆", async () => {
+        const storage = new MemoryStorage();
+        const outcome = await writeRememberedAfterStreamOpen({
+            start: vi.fn(async () => {
+                throw new Error("aborted");
+            }),
+            accepts: () => false,
+            remember: () => storage.setItem("agent:last-session:p", JSON.stringify(identity)),
+        });
+
+        expect(outcome.status).toBe("superseded");
+        expect(storage.getItem("agent:last-session:p")).toBeNull();
+    });
+
+    it("open 成功但 owner 已失效时不写记忆", async () => {
+        const storage = new MemoryStorage();
+        const outcome = await writeRememberedAfterStreamOpen({
+            start: async () => undefined,
+            accepts: () => false,
+            remember: () => storage.setItem("agent:inline-editor-session:p", JSON.stringify(identity)),
+        });
+
+        expect(outcome.status).toBe("superseded");
+        expect(storage.getItem("agent:inline-editor-session:p")).toBeNull();
+    });
+});
+
+describe("runSessionLoadAttempt", () => {
+    const errorCode = (error: unknown): string | null => {
+        if (typeof error === "object" && error !== null && "code" in error && typeof error.code === "string") {
+            return error.code;
+        }
+        return null;
+    };
+
+    it("只在读取成功且 owner 仍有效时提交目标状态", async () => {
+        let accepted = true;
+        const commit = vi.fn();
+
+        await expect(runSessionLoadAttempt({
+            read: async () => ({sessionId: 7}),
+            commit,
+            accepts: () => accepted,
+            errorCode,
+        })).resolves.toEqual({status: "loaded", value: {sessionId: 7}});
+        expect(commit).toHaveBeenCalledWith({sessionId: 7});
+
+        accepted = false;
+        commit.mockClear();
+        await expect(runSessionLoadAttempt({
+            read: async () => ({sessionId: 8}),
+            commit,
+            accepts: () => accepted,
+            errorCode,
         })).resolves.toEqual({status: "superseded"});
+        expect(commit).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ["SESSION_NOT_FOUND", {status: "primary_missing"}],
+        ["SESSION_DEPENDENCY_NOT_FOUND", {status: "dependency_missing"}],
+    ] as const)("保留生命周期错误分区：%s", async (code, expected) => {
+        const error = Object.assign(new Error(code), {code});
+        const commit = vi.fn();
+
+        const result = await runSessionLoadAttempt({
+            read: async () => {
+                throw error;
+            },
+            commit,
+            accepts: () => true,
+            errorCode,
+        });
+
+        expect(result.status).toBe(expected.status);
+        if (expected.status === "dependency_missing") {
+            expect(result).toMatchObject({error});
+        }
+        expect(commit).not.toHaveBeenCalled();
+    });
+
+    it("普通读取错误和提交错误不被误判为 Session 缺失", async () => {
+        const readError = new Error("read failed");
+        await expect(runSessionLoadAttempt({
+            read: async () => {
+                throw readError;
+            },
+            commit: vi.fn(),
+            accepts: () => true,
+            errorCode,
+        })).resolves.toEqual({status: "failed", error: readError});
+
+        const commitError = new Error("commit failed");
+        await expect(runSessionLoadAttempt({
+            read: async () => 1,
+            commit: async () => {
+                throw commitError;
+            },
+            accepts: () => true,
+            errorCode,
+        })).resolves.toEqual({status: "failed", error: commitError});
+    });
+
+    it("提交期间 owner 失效时静默丢弃结果", async () => {
+        let accepted = true;
+        const commit = vi.fn(async () => {
+            accepted = false;
+        });
+
+        await expect(runSessionLoadAttempt({
+            read: async () => 1,
+            commit,
+            accepts: () => accepted,
+            errorCode,
+        })).resolves.toEqual({status: "superseded"});
+        expect(commit).toHaveBeenCalledOnce();
+    });
+});
+
+describe("Inline Editor 选择结果", () => {
+    it.each([
+        [{status: "current" as const}, {status: "current", value: undefined}],
+        [{status: "superseded" as const}, {status: "superseded"}],
+        [{status: "empty" as const}, {status: "empty"}],
+        [{status: "failed" as const, message: "Inline AI Session 加载失败。"}, {status: "failed", message: "Inline AI Session 加载失败。"}],
+    ])("只把 current 投影为绑定成功：%o", (result, expected) => {
+        expect(projectInlineEditorSelection(result)).toEqual(expected);
+    });
+
+    it("恢复子请求成功后父刷新接纳 successor request，旧代次不能复活", () => {
+        expect(adoptInlineEditorRequest(4, {status: "current", requestId: 5})).toEqual({status: "current", requestId: 5});
+        expect(adoptInlineEditorRequest(4, {status: "empty", requestId: 5})).toEqual({status: "current", requestId: 5});
+        expect(adoptInlineEditorRequest(4, {status: "failed", requestId: 5})).toEqual({status: "current", requestId: 5});
+        expect(adoptInlineEditorRequest(4, {status: "current", requestId: 3})).toEqual({status: "superseded"});
+        expect(adoptInlineEditorRequest(4, {status: "superseded"})).toEqual({status: "superseded"});
+    });
+});
+
+describe("AgentSessionLoadController", () => {
+    it("前台加载会立即使旧 recovery 失效，迟到 recovery 不能发布", async () => {
+        const controller = new AgentSessionLoadController();
+        const recoveryWork = deferred<string>();
+        const recovery = controller.runRecovery("project:a", async (owner) => {
+            await recoveryWork.promise;
+            return controller.accepts(owner, "project:a") ? "recovered" : "superseded";
+        });
+        expect(recovery.status).toBe("started");
+        const foreground = controller.beginForeground("project:a");
+        expect(controller.accepts(foreground, "project:a")).toBe(true);
+        recoveryWork.resolve("late");
+
+        await expect(recovery.promise).resolves.toBe("superseded");
+        expect(controller.accepts(foreground, "project:a")).toBe(true);
+    });
+
+    it("前台加载存在时延迟 recovery，同一 recovery 只复用一个 Promise", async () => {
+        const controller = new AgentSessionLoadController();
+        const foreground = controller.beginForeground("project:a");
+        const deferredRequest = controller.runRecovery("project:a", async () => "blocked");
+        expect(deferredRequest.status).toBe("deferred");
+        await controller.finish(foreground);
+        await expect(deferredRequest.promise).resolves.toBeUndefined();
+
+        const recoveryWork = deferred<void>();
+        const work = vi.fn(async () => {
+            await recoveryWork.promise;
+            return "ok";
+        });
+        const first = controller.runRecovery("project:a", work);
+        const duplicate = controller.runRecovery("project:a", work);
+        expect(duplicate.promise).toBe(first.promise);
+        expect(work).toHaveBeenCalledOnce();
+        recoveryWork.resolve();
+        await expect(first.promise).resolves.toBe("ok");
+    });
+
+    it("旧 recovery reject 后的 finally 不能清理新的前台 owner", async () => {
+        const controller = new AgentSessionLoadController();
+        const recoveryWork = deferred<void>();
+        const recovery = controller.runRecovery("project:a", async () => {
+            await recoveryWork.promise;
+            throw new Error("recovery failed");
+        });
+        const foreground = controller.beginForeground("project:a");
+        recoveryWork.resolve();
+
+        await expect(recovery.promise).rejects.toThrow("recovery failed");
+        expect(controller.accepts(foreground, "project:a")).toBe(true);
+    });
+
+    it("前台失败时只 replay 一次 deferred recovery，成功时丢弃它", async () => {
+        const controller = new AgentSessionLoadController();
+        const foreground = controller.beginForeground("project:a");
+        const recoveryWork = vi.fn(async (owner: AgentSessionLoadOwner) => {
+            expect(controller.accepts(owner, "project:a")).toBe(true);
+            return "recovered";
+        });
+        const deferredRecovery = controller.runRecovery("project:a", recoveryWork);
+        expect(deferredRecovery.status).toBe("deferred");
+        await controller.finish(foreground, true);
+        await expect(deferredRecovery.promise).resolves.toBe("recovered");
+        expect(recoveryWork).toHaveBeenCalledOnce();
+
+        const nextForeground = controller.beginForeground("project:a");
+        const discarded = controller.runRecovery("project:a", async () => "stale");
+        expect(discarded.status).toBe("deferred");
+        await controller.finish(nextForeground);
+        await expect(discarded.promise).resolves.toBeUndefined();
+    });
+
+    it("scope 改变时收口旧 deferred，不让旧 SSE 回调悬挂", async () => {
+        const controller = new AgentSessionLoadController();
+        const first = controller.beginForeground("project:a");
+        const deferredRequest = controller.runRecovery("project:a", async () => "stale");
+        controller.beginForeground("project:b");
+
+        await expect(deferredRequest.promise).resolves.toBeUndefined();
+        await controller.finish(first);
+    });
+
+    it("前台下 runRecovery 换 scope 时先收口旧 deferred 再保存新 work", async () => {
+        const controller = new AgentSessionLoadController();
+        controller.beginForeground("project:a");
+        const stale = controller.runRecovery("project:a", async () => "stale");
+        expect(stale.status).toBe("deferred");
+
+        const next = controller.runRecovery("project:b", async () => "next");
+        expect(next.status).toBe("deferred");
+        await expect(stale.promise).resolves.toBeUndefined();
+
+        const nextForeground = controller.beginForeground("project:b");
+        await controller.finish(nextForeground, true);
+        await expect(next.promise).resolves.toBe("next");
+    });
+
+    it("deferred recovery work reject 时 deferredPromise reject，finish 自身正常 settle", async () => {
+        const controller = new AgentSessionLoadController();
+        const foreground = controller.beginForeground("project:a");
+        const deferredRequest = controller.runRecovery("project:a", async () => {
+            throw new Error("deferred work failed");
+        });
+        expect(deferredRequest.status).toBe("deferred");
+        const rejection = expect(deferredRequest.promise).rejects.toThrow("deferred work failed");
+
+        await controller.finish(foreground, true);
+        await rejection;
+    });
+
+    it("不同 Surface 的 controller 互不撤销 owner，旧 finally 不能清理新前台加载", () => {
+        const main = new AgentSessionLoadController();
+        const inline = new AgentSessionLoadController();
+        const mainOwner = main.beginForeground("project:a");
+        const inlineOwner = inline.beginForeground("project:a");
+
+        main.invalidate();
+
+        expect(main.accepts(mainOwner, "project:a")).toBe(false);
+        expect(inline.accepts(inlineOwner, "project:a")).toBe(true);
     });
 });
 
@@ -331,3 +768,66 @@ describe("projectAgentComposerAvailability", () => {
         })).toEqual({status: "waiting-blocked", readonly: true, canStop: true});
     });
 });
+
+describe("tryWriteRememberedSession", () => {
+    it("写入成功返回 saved", () => {
+        const storage = new MemoryStorage();
+
+        const value = {schema: 2 as const, sessionId: 7, sessionIdentity: "sha256:0000000000000000000000000000000000000000000000000000000000000000"};
+        expect(tryWriteRememberedSession(storage, "session", value)).toEqual({status: "saved"});
+        expect(storage.getItem("session")).toBe(JSON.stringify(value));
+    });
+
+    it("Storage 写入失败只返回 failed，不影响已有记忆", () => {
+        const storage = new MemoryStorage();
+        const old = {schema: 2 as const, sessionId: 3, sessionIdentity: "sha256:0000000000000000000000000000000000000000000000000000000000000000"};
+        storage.setItem("session", JSON.stringify(old));
+        const error = new Error("quota");
+        storage.setItem = () => {
+            throw error;
+        };
+
+        const next = {...old, sessionId: 7};
+        expect(tryWriteRememberedSession(storage, "session", next)).toEqual({status: "failed", error});
+        expect(storage.getItem("session")).toBe(JSON.stringify(old));
+    });
+
+    it("旧数字值、损坏 JSON 和 identity 缺失都进入 unselected 输入", () => {
+        const storage = new MemoryStorage();
+        storage.setItem("legacy", "3");
+        storage.setItem("broken", "{");
+        storage.setItem("missing-identity", JSON.stringify({schema: 2, sessionId: 3}));
+
+        expect(readRememberedSession(storage, "legacy")).toEqual({status: "invalid"});
+        expect(readRememberedSession(storage, "broken")).toEqual({status: "invalid"});
+        expect(readRememberedSession(storage, "missing-identity")).toEqual({status: "invalid"});
+    });
+});
+
+class MemoryStorage implements Storage {
+    private readonly values = new Map<string, string>();
+
+    get length(): number {
+        return this.values.size;
+    }
+
+    clear(): void {
+        this.values.clear();
+    }
+
+    getItem(key: string): string | null {
+        return this.values.get(key) ?? null;
+    }
+
+    key(index: number): string | null {
+        return [...this.values.keys()][index] ?? null;
+    }
+
+    removeItem(key: string): void {
+        this.values.delete(key);
+    }
+
+    setItem(key: string, value: string): void {
+        this.values.set(key, value);
+    }
+}

--- a/packages/neuro-book/app/components/novel-ide/agent/agent-chat-surface-state.ts
+++ b/packages/neuro-book/app/components/novel-ide/agent/agent-chat-surface-state.ts
@@ -8,6 +8,7 @@ import {
     type MaybeRefOrGetter,
     type Ref,
 } from "vue";
+import {AgentSessionIdentitySchema, type AgentSessionIdentity} from "nbook/shared/dto/agent-session.dto";
 
 /** Agent Surface 某次激活恢复的所有权凭据。 */
 export type AgentSurfaceActivationAttempt = Readonly<{
@@ -20,52 +21,423 @@ export type AgentSurfaceActivationState =
     | {status: "inactive"}
     | {status: "loading"; attempt: AgentSurfaceActivationAttempt}
     | {status: "ready"; attempt: AgentSurfaceActivationAttempt}
+    | {status: "unselected"; attempt: AgentSurfaceActivationAttempt}
     | {status: "empty"; attempt: AgentSurfaceActivationAttempt}
     | {status: "error"; attempt: AgentSurfaceActivationAttempt; message: string};
 
-/** 缺失目标恢复时，只从当前服务端列表选择一次有效 fallback。 */
-export function resolveMissingSessionFallback(
-    sessions: readonly {readonly sessionId: number}[],
-    failedSessionId: number,
-    previousSessionId: number | null,
-): number | null {
-    if (previousSessionId !== null
-        && previousSessionId !== failedSessionId
-        && sessions.some((session) => session.sessionId === previousSessionId)) {
-        return previousSessionId;
+export type RememberedSessionWriteResult =
+    | {status: "saved"}
+    | {status: "failed"; error: unknown};
+
+/** 浏览器记忆的版本化值；身份必须与 recovery summary 完全一致。 */
+export type RememberedSession = Readonly<{
+    schema: 2;
+    sessionId: number;
+    sessionIdentity: AgentSessionIdentity;
+}>;
+
+export type RememberedSessionReadResult =
+    | {status: "missing"}
+    | {status: "invalid"}
+    | {status: "failed"; error: unknown}
+    | {status: "valid"; value: RememberedSession};
+
+/** 读取版本化 Session 记忆；损坏或旧数字值都视为未选择，不向调用方抛出。 */
+export function readRememberedSession(storage: Storage, key: string): RememberedSessionReadResult {
+    let raw: string | null;
+    try {
+        raw = storage.getItem(key);
+    } catch (error) {
+        return {status: "failed", error};
     }
-    return sessions.find((session) => session.sessionId !== failedSessionId)?.sessionId ?? null;
+    if (raw === null) return {status: "missing"};
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (typeof parsed !== "object" || parsed === null) return {status: "invalid"};
+        const value = parsed as Partial<RememberedSession>;
+        if (value.schema !== 2
+            || typeof value.sessionId !== "number"
+            || !Number.isInteger(value.sessionId)
+            || value.sessionId <= 0
+            || !AgentSessionIdentitySchema.safeParse(value.sessionIdentity).success) {
+            return {status: "invalid"};
+        }
+        return {
+            status: "valid",
+            value: {
+                schema: 2,
+                sessionId: value.sessionId,
+                sessionIdentity: value.sessionIdentity as AgentSessionIdentity,
+            },
+        };
+    } catch {
+        return {status: "invalid"};
+    }
 }
 
-export type MissingSessionRecoveryResult =
-    | {status: "superseded"}
-    | {status: "empty"}
-    | {status: "load_failed"; sessionId: number}
-    | {status: "loaded"; sessionId: number};
+/** 安全写入一次性 Session 记忆；失败不能影响已经提交的权威状态。 */
+export function tryWriteRememberedSession(
+    storage: Storage,
+    key: string,
+    value: RememberedSession,
+): RememberedSessionWriteResult {
+    try {
+        storage.setItem(key, JSON.stringify(value));
+        return {status: "saved"};
+    } catch (error) {
+        return {status: "failed", error};
+    }
+}
 
-/** 刷新一次并加载一次 fallback；调用方负责 UI 状态和提示。 */
-export async function recoverMissingSessionSelection(input: {
-    failedSessionId: number;
-    previousSessionId: number | null;
+/** 仅删除仍指向同一个 Session 身份的记忆。 */
+export function forgetRememberedSession(
+    storage: Storage,
+    key: string,
+    expected: Pick<RememberedSession, "sessionId" | "sessionIdentity">,
+): boolean {
+    const current = readRememberedSession(storage, key);
+    if (current.status !== "valid"
+        || current.value.sessionId !== expected.sessionId
+        || current.value.sessionIdentity !== expected.sessionIdentity) {
+        return false;
+    }
+    try {
+        storage.removeItem(key);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export type StreamOpenRememberOutcome =
+    | {status: "connected"}
+    | {status: "connect_failed"; error: unknown}
+    | {status: "superseded"};
+
+/** 权威提交后等待事件流 open；只有 open 成功且 owner 仍有效时才写浏览器记忆（ADR 0018）。 */
+export async function writeRememberedAfterStreamOpen(input: {
+    start: () => Promise<void>;
     accepts: () => boolean;
-    refresh: () => Promise<readonly {readonly sessionId: number}[]>;
-    load: (sessionId: number) => Promise<boolean>;
-}): Promise<MissingSessionRecoveryResult> {
-    const sessions = await input.refresh();
+    remember: () => void;
+}): Promise<StreamOpenRememberOutcome> {
+    try {
+        await input.start();
+    } catch (error) {
+        return input.accepts() ? {status: "connect_failed", error} : {status: "superseded"};
+    }
     if (!input.accepts()) {
         return {status: "superseded"};
     }
-    const fallbackSessionId = resolveMissingSessionFallback(sessions, input.failedSessionId, input.previousSessionId);
-    if (fallbackSessionId === null) {
-        return {status: "empty"};
+    input.remember();
+    return {status: "connected"};
+}
+/**
+ * 注册一个"重连恢复"watcher：任何连接状态变化先做 owner 守卫（shouldRestore 为
+ * false 立即自停并移出注册表），守卫通过且状态为 connected 时执行一次 onRestored
+ * 并自停，否则继续挂起监听。调用方负责把 watcher 登记到同步清理表——异步
+ * continuation 中创建的 watcher 不绑定组件 effect scope。
+ */
+export function registerReconnectRestoreWatcher<T extends string>(input: {
+    connectionStatus: Ref<T>;
+    stops: Set<() => void>;
+    shouldRestore: () => boolean;
+    onRestored: () => void;
+}): void {
+    let stop: (() => void) | undefined;
+    const finish = (): void => {
+        const current = stop;
+        if (!current) return;
+        stop = undefined;
+        current();
+        input.stops.delete(current);
+    };
+    const evaluate = (status: T): void => {
+        // owner 守卫失败立即自停并移出注册表；守卫通过但连接未恢复则继续挂起。
+        if (!input.shouldRestore()) {
+            finish();
+            return;
+        }
+        if (status !== "connected") {
+            return;
+        }
+        finish();
+        input.onRestored();
+    };
+    stop = watch(input.connectionStatus, evaluate);
+    if (stop) {
+        input.stops.add(stop);
+        // 注册时连接可能已建立（旧 start 被 abort 后新连接先 open，
+        // immediate:false 的 watcher 不会重放）；同步补一次检查（含 skip 自停）。
+        evaluate(input.connectionStatus.value);
     }
-    const loaded = await input.load(fallbackSessionId);
+}
+export type ReconnectReadyDecision = "restore_ready" | "skip_stale_owner" | "skip_wrong_session" | "skip_not_error";
+
+/**
+ * 握手失败后后台重连成功时，判断当前 Surface 是否应恢复 ready 并补写记忆。
+ * 纯投影：调用方负责把 decision 翻译成 markReady/saveLastSession 副作用。
+ * - restore_ready：仍是同一 activation attempt 且目标 Session 是当前会话，应恢复。
+ * - skip_*：旧代次、目标已被替换或 activation 已非 error（新 owner 已接管），不得误标。
+ */
+export function projectReconnectReady(input: {
+    activationStatus: "inactive" | "loading" | "ready" | "error" | "unselected" | "empty" | "superseded";
+    attemptScopeKey: string;
+    attemptRevision: number;
+    expectedScopeKey: string;
+    expectedRevision: number;
+    activeSessionId: number | null;
+    expectedSessionId: number;
+}): ReconnectReadyDecision {
+    if (input.activationStatus !== "error") {
+        return "skip_not_error";
+    }
+    if (input.attemptScopeKey !== input.expectedScopeKey || input.attemptRevision !== input.expectedRevision) {
+        return "skip_stale_owner";
+    }
+    if (input.activeSessionId !== input.expectedSessionId) {
+        return "skip_wrong_session";
+    }
+    return "restore_ready";
+}
+
+/** Session recovery 读取后提交的结果；dependency_missing 不得触发主资源 fallback。 */
+export type SessionLoadAttemptResult<TResult> =
+    | {status: "loaded"; value: TResult}
+    | {status: "primary_missing"}
+    | {status: "dependency_missing"; error: unknown}
+    | {status: "failed"; error: unknown}
+    | {status: "superseded"};
+
+/** 主/Inline Session 加载向调用方报告的结果；只有 loaded 可以提交为成功。 */
+export type AgentSessionLoadResult<TResult> =
+    | {status: "loaded"; value: TResult}
+    | {status: "empty"}
+    | {status: "primary_missing"}
+    | {status: "dependency_missing"; error: unknown}
+    | {status: "failed"; error: unknown}
+    | {status: "superseded"};
+
+export type AgentSessionLoadStatus =
+    | "loaded"
+    | "primary_missing"
+    | "dependency_missing"
+    | "failed"
+    | "empty"
+    | "superseded";
+
+/** 将 Session 读取结果投影成 Surface 可执行的最小副作用集合。 */
+export type AgentSessionLoadProjection =
+    | {status: "commit"}
+    | {status: "preserve"; reason: "primary_missing" | "dependency_missing" | "failed" | "empty"}
+    | {status: "clear"; reason: "primary_missing" | "failed" | "empty"}
+    | {status: "superseded"};
+
+/** 稳定当前 Session 时只保留旧内容；其余失败才允许清空 Surface。 */
+export function projectAgentSessionLoad(
+    status: AgentSessionLoadStatus,
+    hasStableSession: boolean,
+): AgentSessionLoadProjection {
+    if (status === "loaded") {
+        return {status: "commit"};
+    }
+    if (status === "superseded") {
+        return {status: "superseded"};
+    }
+    if ((status === "primary_missing" || status === "dependency_missing" || status === "empty") && hasStableSession) {
+        return {status: "preserve", reason: status};
+    }
+    if (status === "failed" && hasStableSession) {
+        return {status: "preserve", reason: "failed"};
+    }
+    return {
+        status: "clear",
+        reason: status === "primary_missing" || status === "failed" || status === "empty"
+            ? status
+            : "failed",
+    };
+}
+
+/** Session 目标加载的前台/recovery 发布权；两类 owner 共享同一 scope，但互相不会误认。 */
+export type AgentSessionLoadOwner = Readonly<{
+    scopeKey: string;
+    revision: number;
+    kind: "foreground" | "recovery";
+}>;
+
+type SessionRecoveryRequest = {
+    owner: AgentSessionLoadOwner;
+    promise: Promise<unknown>;
+};
+
+type DeferredSessionRecoveryRequest = {
+    scopeKey: string;
+    work: (owner: AgentSessionLoadOwner) => Promise<unknown>;
+    resolve: (value: unknown) => void;
+    reject: (error: unknown) => void;
+    promise: Promise<unknown>;
+};
+
+export type AgentSessionRecoveryStart<TResult> = Readonly<{
+    status: "started" | "reused" | "deferred";
+    promise: Promise<TResult>;
+}>;
+
+/**
+ * 管理一个 Session Surface 内的目标加载竞争。
+ *
+ * 前台选择会立即撤销 recovery；recovery 只在没有前台加载时启动，并在同一代次内
+ * single-flight。它不取消网络请求，只阻止迟到结果、错误和 finally 发布到新 owner。
+ */
+export class AgentSessionLoadController {
+    private nextRevision = 0;
+    private current: AgentSessionLoadOwner | null = null;
+    private recoveryRequest: SessionRecoveryRequest | null = null;
+    private deferredRecovery: DeferredSessionRecoveryRequest | null = null;
+
+    /** 开始前台加载，并立即使旧 recovery 失效。 */
+    beginForeground(scopeKey: string): AgentSessionLoadOwner {
+        if (this.deferredRecovery && this.deferredRecovery.scopeKey !== scopeKey) {
+            this.deferredRecovery.resolve(undefined);
+            this.deferredRecovery = null;
+        }
+        const owner = Object.freeze({scopeKey, revision: ++this.nextRevision, kind: "foreground" as const});
+        this.current = owner;
+        return owner;
+    }
+
+    /** 启动、复用或延迟当前 scope 的 recovery；recovery work 负责检查 owner。 */
+    runRecovery<TResult>(
+        scopeKey: string,
+        work: (owner: AgentSessionLoadOwner) => Promise<TResult>,
+    ): AgentSessionRecoveryStart<TResult> {
+        if (this.current?.kind === "foreground") {
+            if (this.deferredRecovery && this.deferredRecovery.scopeKey === scopeKey) {
+                return {
+                    status: "deferred",
+                    promise: this.deferredRecovery.promise as Promise<TResult>,
+                };
+            }
+            if (this.deferredRecovery) {
+                this.deferredRecovery.resolve(undefined);
+                this.deferredRecovery = null;
+            }
+            let resolveDeferred!: (value: unknown) => void;
+            let rejectDeferred!: (error: unknown) => void;
+            const promise = new Promise<unknown>((resolve, reject) => {
+                resolveDeferred = resolve;
+                rejectDeferred = reject;
+            });
+            this.deferredRecovery = {
+                scopeKey,
+                work: work as (owner: AgentSessionLoadOwner) => Promise<unknown>,
+                resolve: resolveDeferred,
+                reject: rejectDeferred,
+                promise,
+            };
+            return {status: "deferred", promise: promise as Promise<TResult>};
+        }
+        if (this.recoveryRequest
+            && this.current?.revision === this.recoveryRequest.owner.revision
+            && this.current.scopeKey === scopeKey
+            && this.recoveryRequest.owner.scopeKey === scopeKey) {
+            return {status: "reused", promise: this.recoveryRequest.promise as Promise<TResult>};
+        }
+
+        const owner = Object.freeze({scopeKey, revision: ++this.nextRevision, kind: "recovery" as const});
+        this.current = owner;
+        const request: SessionRecoveryRequest = {owner, promise: Promise.resolve()};
+        const promise = (async () => {
+            try {
+                return await work(owner);
+            } finally {
+                if (this.current?.revision === owner.revision) {
+                    this.current = null;
+                }
+                if (this.recoveryRequest === request) {
+                    this.recoveryRequest = null;
+                }
+            }
+        })();
+        request.promise = promise;
+        this.recoveryRequest = request;
+        return {status: "started", promise: promise as Promise<TResult>};
+    }
+
+    /** 判断 owner 是否仍拥有当前 scope 的 Session 提交权。 */
+    accepts(owner: AgentSessionLoadOwner, scopeKey: string): boolean {
+        return this.current?.revision === owner.revision
+            && this.current.scopeKey === owner.scopeKey
+            && owner.scopeKey === scopeKey;
+    }
+
+    /** 完成前台加载；成功时丢弃 deferred，失败保留旧 Session 时 replay 一次。 */
+    async finish(owner: AgentSessionLoadOwner, replayDeferred = false): Promise<void> {
+        if (!this.accepts(owner, owner.scopeKey)) return;
+        if (owner.kind !== "foreground") return;
+        this.current = null;
+        const deferred = this.deferredRecovery;
+        this.deferredRecovery = null;
+        if (!deferred) return;
+        if (deferred.scopeKey !== owner.scopeKey) {
+            deferred.resolve(undefined);
+            return;
+        }
+        if (!replayDeferred) {
+            deferred.resolve(undefined);
+            return;
+        }
+        const recovery = this.runRecovery(deferred.scopeKey, deferred.work as (recoveryOwner: AgentSessionLoadOwner) => Promise<unknown>);
+        recovery.promise.then(deferred.resolve, deferred.reject);
+        await recovery.promise.catch(() => undefined);
+    }
+
+    /** 组件/Workspace 重置时立即撤销当前 owner。 */
+    invalidate(): void {
+        this.nextRevision += 1;
+        this.current = null;
+        const deferred = this.deferredRecovery;
+        this.deferredRecovery = null;
+        deferred?.resolve(undefined);
+    }
+}
+
+/** 只在 recovery 读取成功且 owner 仍有效时提交目标 Session 状态。 */
+export async function runSessionLoadAttempt<TResult>(input: {
+    read: () => Promise<TResult>;
+    commit: (value: TResult) => Promise<void> | void;
+    accepts: () => boolean;
+    errorCode: (error: unknown) => string | null;
+}): Promise<SessionLoadAttemptResult<TResult>> {
+    let value: TResult;
+    try {
+        value = await input.read();
+    } catch (error) {
+        if (!input.accepts()) {
+            return {status: "superseded"};
+        }
+        const code = input.errorCode(error);
+        if (code === "SESSION_NOT_FOUND") {
+            return {status: "primary_missing"};
+        }
+        if (code === "SESSION_DEPENDENCY_NOT_FOUND") {
+            return {status: "dependency_missing", error};
+        }
+        return {status: "failed", error};
+    }
     if (!input.accepts()) {
         return {status: "superseded"};
     }
-    return loaded
-        ? {status: "loaded", sessionId: fallbackSessionId}
-        : {status: "load_failed", sessionId: fallbackSessionId};
+    try {
+        await input.commit(value);
+    } catch (error) {
+        if (!input.accepts()) {
+            return {status: "superseded"};
+        }
+        return {status: "failed", error};
+    }
+    return input.accepts()
+        ? {status: "loaded", value}
+        : {status: "superseded"};
 }
 
 /** 被新 scope、激活代次或组件销毁取代的请求。调用方应静默忽略。 */
@@ -175,6 +547,13 @@ export class AgentSurfaceActivationController {
         return true;
     }
 
+    /** 当前实例有可用 Session，但没有可信记忆可自动选择。 */
+    markUnselected(attempt: AgentSurfaceActivationAttempt, currentScopeKey: string): boolean {
+        if (!this.accepts(attempt, currentScopeKey)) return false;
+        this.mutableState.value = {status: "unselected", attempt};
+        return true;
+    }
+
     /** 当前代次确认没有 Session；不会隐式创建。 */
     markEmpty(attempt: AgentSurfaceActivationAttempt, currentScopeKey: string): boolean {
         if (!this.accepts(attempt, currentScopeKey)) return false;
@@ -200,6 +579,45 @@ export class AgentSurfaceActivationController {
 export type AgentSurfaceOperationResult<TResult> =
     | {status: "current"; value: TResult}
     | {status: "superseded"};
+
+/** 打开主 Agent 面板时，真实失败不能伪装成 superseded。 */
+export type AgentSessionOpenResult<TResult> = AgentSurfaceOperationResult<TResult>
+    | {status: "failed"; message: string};
+
+/** Inline Editor 选择结果；空列表和恢复失败都不能被投影为已绑定。 */
+export type InlineEditorSelectionResult =
+    | AgentSurfaceOperationResult<void>
+    | {status: "empty"}
+    | {status: "failed"; message: string};
+
+/** 将 Inline Editor 加载结果投影给 PromptBar，只有 current 才是成功。 */
+export function projectInlineEditorSelection(
+    result: {status: "current" | "superseded" | "empty" | "failed"; message?: string},
+): InlineEditorSelectionResult {
+    switch (result.status) {
+        case "current":
+            return {status: "current", value: undefined};
+        case "superseded":
+            return {status: "superseded"};
+        case "empty":
+            return {status: "empty"};
+        case "failed":
+            return {status: "failed", message: result.message ?? "Inline AI Session 加载失败。"};
+    }
+}
+
+/** 父级 Inline 列表请求接纳恢复子请求的最新代次。 */
+export function adoptInlineEditorRequest(
+    parentRequestId: number,
+    result: {status: "current" | "superseded" | "empty" | "failed"; requestId?: number},
+): {status: "current"; requestId: number} | {status: "superseded"} {
+    if (result.status === "superseded"
+        || result.requestId === undefined
+        || result.requestId < parentRequestId) {
+        return {status: "superseded"};
+    }
+    return {status: "current", requestId: result.requestId};
+}
 
 /**
  * Surface 局部异步操作所有权。
@@ -335,6 +753,7 @@ type ReadonlyAvailability = {
 export type AgentComposerAvailability =
     | {status: "ready"; readonly: false; canStop: false}
     | ({status: "restoring"} & ReadonlyAvailability)
+    | ({status: "unselected"} & ReadonlyAvailability)
     | ({status: "empty"} & ReadonlyAvailability)
     | ({status: "archived"; canRestore: boolean} & ReadonlyAvailability)
     | ({status: "profile-unavailable"; message: string} & ReadonlyAvailability)
@@ -343,7 +762,7 @@ export type AgentComposerAvailability =
     | ({status: "blocked"} & ReadonlyAvailability);
 
 /** Composer 状态条允许请求的宿主动作。 */
-export type AgentComposerAvailabilityAction = "create-session" | "retry-session" | "restore-session";
+export type AgentComposerAvailabilityAction = "create-session" | "retry-session" | "restore-session" | "choose-session";
 
 export type AgentComposerAvailabilityInput = {
     activation: AgentSurfaceActivationState;
@@ -371,6 +790,10 @@ export function projectAgentComposerAvailability(input: AgentComposerAvailabilit
     }
     if (input.activation.status === "error") {
         return {status: "load-error", readonly: true, canStop, message: input.activation.message};
+    }
+
+    if (input.activation.status === "unselected") {
+        return {status: "unselected", readonly: true, canStop};
     }
     if (input.activation.status === "empty") {
         return {status: "empty", readonly: true, canStop};

--- a/packages/neuro-book/app/components/novel-ide/agent/agent-command-result.test.ts
+++ b/packages/neuro-book/app/components/novel-ide/agent/agent-command-result.test.ts
@@ -52,6 +52,7 @@ function createContext(activeSessionId: number | null, needsRecovery: boolean): 
 function summary(sessionId: number): AgentSessionSummaryDto {
     return {
         sessionId,
+        sessionIdentity: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
         profileKey: "leader.default",
         status: "idle",
         updatedAt: 1,

--- a/packages/neuro-book/app/components/novel-ide/agent/agent-composer-draft.test.ts
+++ b/packages/neuro-book/app/components/novel-ide/agent/agent-composer-draft.test.ts
@@ -80,6 +80,42 @@ describe("Agent Composer 草稿", () => {
         await drafts.dispose();
     });
 
+    it("prepare 不改变当前 context，只有 activate 才提交目标草稿", async () => {
+        const api = new MemoryDraftApi();
+        const drafts = session(api);
+
+        await drafts.switchContext("project:a", 1);
+        drafts.update("当前正文");
+        await drafts.flush();
+        await api.saveComposerDraft({scopeKey: "project:b", sessionId: 2, text: "目标正文"});
+
+        const prepared = await drafts.prepareContext("project:b", 2);
+
+        expect(drafts.capture("当前正文")).not.toBeNull();
+        expect(prepared).toEqual({scopeKey: "project:b", sessionId: 2, text: "目标正文"});
+
+        drafts.activateContext(prepared);
+
+        expect(drafts.capture("当前正文")).toBeNull();
+        expect(drafts.capture("目标正文")).toMatchObject({scopeKey: "project:b", sessionId: 2});
+        await drafts.dispose();
+    });
+
+    it("进入 empty 前 clearContext 持久化正文并解除 active context", async () => {
+        const api = new MemoryDraftApi();
+        const drafts = session(api);
+        const initial = await drafts.switchContext("project:a", 3);
+        drafts.update("跨实例切换前仍在编辑的正文");
+
+        const generation = await drafts.clearContext();
+
+        expect(generation).toBeGreaterThan(initial.generation);
+        await expect(api.getComposerDraft({scopeKey: "project:a", sessionId: 3})).resolves.toEqual({
+            text: "跨实例切换前仍在编辑的正文",
+        });
+        expect(drafts.capture("跨实例切换前仍在编辑的正文")).toBeNull();
+    });
+
     it("acceptance 只清除提交 revision，不删除请求期间的新正文", async () => {
         const api = new MemoryDraftApi();
         const drafts = session(api);
@@ -110,6 +146,43 @@ describe("Agent Composer 草稿", () => {
         await expect(api.getComposerDraft({scopeKey: "project:a", sessionId: 2})).resolves.toEqual({text: "另一个 Session 草稿"});
         await drafts.dispose();
     });
+
+    it("目标草稿读取失败时不伪造空正文，也不改变当前 context", async () => {
+        const api = new MemoryDraftApi();
+        const drafts = session(api);
+        await drafts.switchContext("project:a", 1);
+        drafts.update("当前正文");
+        const error = new Error("draft-read-failed");
+        api.loadError = error;
+
+        await expect(drafts.prepareContext("project:b", 2)).rejects.toBe(error);
+        expect(drafts.capture("当前正文")).not.toBeNull();
+    });
+
+    it("草稿保存失败时 switch/clear 都保留当前 context 和正文", async () => {
+        const api = new MemoryDraftApi();
+        const drafts = session(api);
+        await drafts.switchContext("project:a", 1);
+        drafts.update("不能丢失的正文");
+        api.saveError = new Error("draft-save-failed");
+
+        await expect(drafts.switchContext("project:b", 2)).rejects.toThrow("draft-save-failed");
+        expect(drafts.capture("不能丢失的正文")).not.toBeNull();
+        await expect(drafts.clearContext()).rejects.toThrow("draft-save-failed");
+        expect(drafts.capture("不能丢失的正文")).not.toBeNull();
+    });
+
+    it("草稿清除失败时 acceptance 不清空内存正文", async () => {
+        const api = new MemoryDraftApi();
+        const drafts = session(api);
+        await drafts.switchContext("project:a", 1);
+        drafts.update("待确认正文");
+        const submission = drafts.capture("待确认正文")!;
+        api.clearError = new Error("draft-clear-failed");
+
+        await expect(drafts.accept(submission)).rejects.toThrow("draft-clear-failed");
+        expect(drafts.capture("待确认正文")).not.toBeNull();
+    });
 });
 
 function session(api: MemoryDraftApi): AgentComposerDraftSession {
@@ -118,6 +191,9 @@ function session(api: MemoryDraftApi): AgentComposerDraftSession {
 
 class MemoryDraftApi implements AgentComposerDraftApi {
     private readonly drafts = new Map<string, AgentComposerDraftMigrationRecord>();
+    loadError: Error | null = null;
+    saveError: Error | null = null;
+    clearError: Error | null = null;
 
     readonly migrateComposerDrafts = vi.fn(async ({drafts}: {drafts: AgentComposerDraftMigrationRecord[]}) => {
         drafts.forEach((draft) => this.drafts.set(keyOf(draft), draft));
@@ -125,10 +201,12 @@ class MemoryDraftApi implements AgentComposerDraftApi {
     });
 
     async getComposerDraft(identity: AgentComposerDraftIdentity): Promise<{text: string}> {
+        if (this.loadError) throw this.loadError;
         return {text: this.drafts.get(keyOf(identity))?.text ?? ""};
     }
 
     async saveComposerDraft(request: AgentComposerDraftSaveRequest): Promise<"saved" | "cleared" | "oversize" | "unsafe"> {
+        if (this.saveError) throw this.saveError;
         if (!request.text) {
             this.drafts.delete(keyOf(request));
             return "cleared";
@@ -138,6 +216,7 @@ class MemoryDraftApi implements AgentComposerDraftApi {
     }
 
     async clearComposerDraft(identity: AgentComposerDraftIdentity): Promise<{cleared: true}> {
+        if (this.clearError) throw this.clearError;
         this.drafts.delete(keyOf(identity));
         return {cleared: true};
     }

--- a/packages/neuro-book/app/components/novel-ide/agent/agent-composer-draft.ts
+++ b/packages/neuro-book/app/components/novel-ide/agent/agent-composer-draft.ts
@@ -1,5 +1,6 @@
 import {parseAgentImageMarkdown} from "nbook/shared/agent/agent-image-markdown";
 import {
+    AgentComposerDraftIdentitySchema,
     AgentComposerDraftScopeKeySchema,
     type AgentComposerDraftIdentity,
     type AgentComposerDraftLoadResult,
@@ -38,6 +39,11 @@ export type AgentComposerDraftContext = AgentComposerDraftIdentity & {
     text: string;
 };
 
+/** 已从磁盘读取、但尚未成为当前 Composer context 的草稿快照。 */
+export type AgentComposerDraftPreparedContext = Readonly<AgentComposerDraftIdentity & {
+    text: string;
+}>;
+
 export type AgentComposerSubmission = Readonly<AgentComposerDraftContext>;
 
 export type AgentComposerDraftSwitchResult = AgentComposerDraftLoadResult & {
@@ -45,6 +51,20 @@ export type AgentComposerDraftSwitchResult = AgentComposerDraftLoadResult & {
     /** false 表示另一次 context 切换已使本次异步 load 失效。 */
     active: boolean;
 };
+
+/** 当前正文无法安全持久化；切换/清理必须停在原 context。 */
+export class AgentComposerDraftBlockedError extends Error {
+    constructor(readonly result: Extract<AgentComposerDraftSaveResult, "oversize" | "unsafe">) {
+        super(result === "oversize" ? "Composer 草稿超过允许大小" : "Composer 草稿包含不安全图片地址");
+        this.name = "AgentComposerDraftBlockedError";
+    }
+}
+
+function assertDraftPersisted(result: AgentComposerDraftSaveResult): void {
+    if (result === "oversize" || result === "unsafe") {
+        throw new AgentComposerDraftBlockedError(result);
+    }
+}
 
 /** 前端只通过这个 Adapter 访问磁盘 Store；localStorage 只作为一次性迁移源。 */
 export class AgentComposerDraftClientStore {
@@ -96,6 +116,7 @@ export class AgentComposerDraftClientStore {
 export class AgentComposerDraftSession {
     private context: AgentComposerDraftContext | null = null;
     private generation = 0;
+    private operationRevision = 0;
     private timer: ReturnType<typeof setTimeout> | null = null;
     private queue: Promise<void> = Promise.resolve();
 
@@ -105,22 +126,40 @@ export class AgentComposerDraftSession {
         private readonly onError?: (error: unknown) => void,
     ) {}
 
+    /** 只读取目标草稿，不改变当前 context；调用方可在异步加载完成后再决定是否激活。 */
+    async prepareContext(scopeKey: string, sessionId: number): Promise<AgentComposerDraftPreparedContext> {
+        const identity = AgentComposerDraftIdentitySchema.parse({scopeKey, sessionId});
+        const loaded = await this.enqueue(() => this.store.load(identity));
+        return {...identity, text: loaded.text};
+    }
+
+    /** 在调用方完成 owner 检查后同步激活已读取的草稿快照。 */
+    activateContext(prepared: AgentComposerDraftPreparedContext): number {
+        const identity = AgentComposerDraftIdentitySchema.parse({
+            scopeKey: prepared.scopeKey,
+            sessionId: prepared.sessionId,
+        });
+        this.operationRevision += 1;
+        this.cancelTimer();
+        const generation = ++this.generation;
+        this.context = {...identity, generation, revision: 0, text: prepared.text};
+        return generation;
+    }
+
     /** 保存旧 context 后加载新 Session；过时 load 不会成为当前 context。 */
     async switchContext(scopeKey: string, sessionId: number): Promise<AgentComposerDraftSwitchResult> {
         const parsedScopeKey = AgentComposerDraftScopeKeySchema.parse(scopeKey);
         const previous = this.context ? {...this.context} : null;
-        this.cancelTimer();
-        this.generation += 1;
-        const generation = this.generation;
-        this.context = null;
+        const operationRevision = ++this.operationRevision;
         if (previous) {
-            await this.persist(previous).catch((error) => this.onError?.(error));
+            assertDraftPersisted(await this.persist(previous));
         }
-        const loaded = await this.enqueue(() => this.store.load({scopeKey: parsedScopeKey, sessionId})).catch((error) => {
-            this.onError?.(error);
-            return {text: ""};
-        });
-        if (generation !== this.generation) return {...loaded, generation, active: false};
+        const loaded = await this.prepareContext(parsedScopeKey, sessionId);
+        if (operationRevision !== this.operationRevision) {
+            return {...loaded, generation: this.generation, active: false};
+        }
+        this.cancelTimer();
+        const generation = ++this.generation;
         this.context = {scopeKey: parsedScopeKey, sessionId, generation, revision: 0, text: loaded.text};
         return {...loaded, generation, active: true};
     }
@@ -128,12 +167,23 @@ export class AgentComposerDraftSession {
     /** 关闭当前 context；用于 Project Workspace 切换和组件销毁。 */
     async clearContext(): Promise<number> {
         const previous = this.context ? {...this.context} : null;
-        this.cancelTimer();
-        this.generation += 1;
-        this.context = null;
+        const operationRevision = ++this.operationRevision;
         if (previous) {
-            await this.persist(previous).catch((error) => this.onError?.(error));
+            assertDraftPersisted(await this.persist(previous));
         }
+        if (operationRevision !== this.operationRevision) return this.generation;
+        this.cancelTimer();
+        this.context = null;
+        this.generation += 1;
+        return this.generation;
+    }
+
+    /** 用户明确放弃当前无法保存的正文后，才允许无持久化地解除 context。 */
+    discardContext(): number {
+        this.operationRevision += 1;
+        this.cancelTimer();
+        this.context = null;
+        this.generation += 1;
         return this.generation;
     }
 
@@ -173,19 +223,21 @@ export class AgentComposerDraftSession {
                 || current.text !== submission.text) {
                 return {clearEditor: false};
             }
+            await this.enqueue(() => this.store.clear(submission));
+            if (current.generation !== submission.generation
+                || current.revision !== submission.revision
+                || current.text !== submission.text) {
+                return {clearEditor: false};
+            }
             this.cancelTimer();
             current.text = "";
             current.revision += 1;
-            await this.enqueue(() => this.store.clear(submission)).catch((error) => this.onError?.(error));
             return {clearEditor: true};
         }
 
-        const stored = await this.enqueue(() => this.store.load(submission)).catch((error) => {
-            this.onError?.(error);
-            return {text: ""};
-        });
+        const stored = await this.enqueue(() => this.store.load(submission));
         if (stored.text === submission.text) {
-            await this.enqueue(() => this.store.clear(submission)).catch((error) => this.onError?.(error));
+            await this.enqueue(() => this.store.clear(submission));
         }
         return {clearEditor: false};
     }

--- a/packages/neuro-book/app/components/novel-ide/agent/useAgentSession-pagination.test.ts
+++ b/packages/neuro-book/app/components/novel-ide/agent/useAgentSession-pagination.test.ts
@@ -389,6 +389,7 @@ function userPreview(id: string, preview: string, bytes: number, omitted: boolea
 function summary(sessionId: number): AgentSessionRecoveryDto["summary"] {
     return {
         sessionId,
+        sessionIdentity: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
         profileKey: "leader.default",
         status: "idle",
         updatedAt: 1,

--- a/packages/neuro-book/app/components/novel-ide/agent/useAgentSession.test.ts
+++ b/packages/neuro-book/app/components/novel-ide/agent/useAgentSession.test.ts
@@ -342,7 +342,7 @@ function liveState(): AgentSessionLiveStateDto {
 }
 
 function summary(): AgentSessionRecoveryDto["summary"] {
-    return {sessionId: 1, profileKey: "leader.default", status: "idle", updatedAt: 1, archived: false};
+    return {sessionId: 1, sessionIdentity: "sha256:0000000000000000000000000000000000000000000000000000000000000000", profileKey: "leader.default", status: "idle", updatedAt: 1, archived: false};
 }
 
 function control(seq: number, event: Extract<AgentSessionEventDto, {kind: "session"}>["event"]): AgentSessionEventDto {

--- a/packages/neuro-book/app/components/novel-ide/agent/useAgentSession.ts
+++ b/packages/neuro-book/app/components/novel-ide/agent/useAgentSession.ts
@@ -482,6 +482,9 @@ export function useAgentSession() {
             ...recoveryShell.value,
             linkedAgents: payload.linkedAgents,
             linkedByAgents: payload.linkedByAgents,
+            ...(payload.unavailableLinkedAgents !== undefined
+                ? {unavailableLinkedAgents: payload.unavailableLinkedAgents}
+                : {unavailableLinkedAgents: undefined}),
         };
     };
 

--- a/packages/neuro-book/app/components/novel-ide/agent/useAgentSessionStream.test.ts
+++ b/packages/neuro-book/app/components/novel-ide/agent/useAgentSessionStream.test.ts
@@ -1,6 +1,7 @@
 import {beforeEach, describe, expect, it, vi} from "vitest";
 import {ref} from "vue";
 import {useAgentSession} from "nbook/app/components/novel-ide/agent/useAgentSession";
+import {AgentSessionLoadController} from "nbook/app/components/novel-ide/agent/agent-chat-surface-state";
 import {useAgentSessionStream} from "nbook/app/components/novel-ide/agent/useAgentSessionStream";
 import type {AgentChatEntryDto} from "nbook/shared/dto/agent-public-event.dto";
 import type {AgentSessionEventDto, AgentSessionEventsQueryDto, AgentSessionRecoveryDto} from "nbook/shared/dto/agent-session.dto";
@@ -31,6 +32,36 @@ describe("useAgentSessionStream", () => {
         await stream.start(1);
 
         expect(cursors).toEqual([{eventEpoch: "epoch-1", after: 3}]);
+        stream.stop();
+    });
+
+    it("stop 后显式 ensure 会重新建立 Session SSE", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 3));
+        const subscribeSessionEvents = vi.fn(async (
+            _sessionId: number,
+            _cursor: AgentSessionEventsQueryDto,
+            _onEvent: (event: AgentSessionEventDto) => Promise<void>,
+            signal: AbortSignal,
+            options?: {onOpen?: () => void},
+        ) => {
+            options?.onOpen?.();
+            await untilAbort(signal);
+        });
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery: vi.fn(async () => recovery(1, 3)),
+                subscribeSessionEvents,
+            },
+        });
+
+        await stream.start(1);
+        stream.stop();
+        await stream.ensure();
+
+        expect(subscribeSessionEvents).toHaveBeenCalledTimes(2);
         stream.stop();
     });
 
@@ -384,6 +415,315 @@ describe("useAgentSessionStream", () => {
         expect(session.recoveryShell.value?.activePathRevision).toBe("rev-2");
     });
 
+    it("普通 recovery 的 Session Not Found 只调用一次专用回调", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        const onSessionNotFound = vi.fn(async () => undefined);
+        const onError = vi.fn();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery: vi.fn(async () => {
+                    throw sessionNotFoundHttpError();
+                }),
+                subscribeSessionEvents: vi.fn(async () => never()),
+            },
+            onSessionNotFound,
+            onError,
+        });
+
+        const first = stream.syncRecovery("snapshot_required");
+        const second = stream.syncRecovery("seq_gap");
+
+        await expect(first).resolves.toBe(true);
+        await expect(second).resolves.toBe(true);
+        expect(onSessionNotFound).toHaveBeenCalledTimes(1);
+        expect(onSessionNotFound).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({sessionId: 1, isCurrent: expect.any(Function)}),
+        );
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("404 deferred 结果跳过普通错误出口，等待前台操作收口", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        const onSessionNotFound = vi.fn(async () => "deferred" as const);
+        const onError = vi.fn();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery: vi.fn(async () => {
+                    throw sessionNotFoundHttpError();
+                }),
+                subscribeSessionEvents: vi.fn(async () => never()),
+            },
+            onSessionNotFound,
+            onError,
+        });
+
+        await expect(stream.syncRecovery("snapshot_required")).resolves.toBe(true);
+        expect(onSessionNotFound).toHaveBeenCalledOnce();
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("onSessionNotFound 挂起等待前台收口：前台成功不运行 work，前台失败 replay 且拒绝由回调捕获", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        const loads = new AgentSessionLoadController();
+        const work = vi.fn(async () => {
+            throw new Error("recovery failed");
+        });
+        const onSessionNotFound = vi.fn(async () => {
+            const started = loads.runRecovery("project:a", work);
+            try {
+                await started.promise;
+            } catch {
+                // Surface 层负责把 rejection 投影成错误状态；这里验证不产生 unhandled rejection
+            }
+            return started.status === "deferred" ? "deferred" as const : "handled" as const;
+        });
+        const onError = vi.fn();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery: vi.fn(async () => {
+                    throw sessionNotFoundHttpError();
+                }),
+                subscribeSessionEvents: vi.fn(async () => never()),
+            },
+            onSessionNotFound,
+            onError,
+        });
+
+        const foreground = loads.beginForeground("project:a");
+        const syncing = stream.syncRecovery("snapshot_required");
+        await vi.waitFor(() => expect(onSessionNotFound).toHaveBeenCalledOnce());
+
+        await loads.finish(foreground);
+        await expect(syncing).resolves.toBe(true);
+        expect(work).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+
+        const nextForeground = loads.beginForeground("project:a");
+        const replaying = stream.syncRecovery("snapshot_required");
+        await vi.waitFor(() => expect(onSessionNotFound).toHaveBeenCalledTimes(2));
+
+        await loads.finish(nextForeground, true);
+        await expect(replaying).resolves.toBe(true);
+        expect(work).toHaveBeenCalledOnce();
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("404 ignored 结果不再发布普通错误", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        const onSessionNotFound = vi.fn(async () => "ignored" as const);
+        const onError = vi.fn();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery: vi.fn(async () => {
+                    throw sessionNotFoundHttpError();
+                }),
+                subscribeSessionEvents: vi.fn(async () => never()),
+            },
+            onSessionNotFound,
+            onError,
+        });
+
+        await expect(stream.syncRecovery("snapshot_required")).resolves.toBe(false);
+        expect(onSessionNotFound).toHaveBeenCalledOnce();
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("强制 recovery 的 Session Not Found 交给专用回调而不向调用方抛出", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        const onSessionNotFound = vi.fn(async () => undefined);
+        const onError = vi.fn();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery: vi.fn(async () => {
+                    throw sessionNotFoundHttpError();
+                }),
+                subscribeSessionEvents: vi.fn(async () => never()),
+            },
+            onSessionNotFound,
+            onError,
+        });
+
+        await expect(stream.refreshRecovery("manual_refresh")).resolves.toBe(true);
+        expect(onSessionNotFound).toHaveBeenCalledTimes(1);
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("新 event epoch 触发的 Session Not Found 进入专用恢复", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        const onSessionNotFound = vi.fn(async () => undefined);
+        const onError = vi.fn();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery: vi.fn(async () => {
+                    throw sessionNotFoundHttpError();
+                }),
+                subscribeSessionEvents: vi.fn(async (_sessionId, _cursor, onEvent, signal, options) => {
+                    options?.onOpen?.();
+                    await onEvent({
+                        ...control(2, {type: "connected", eventEpoch: "epoch-2", latestSeq: 2}),
+                        eventEpoch: "epoch-2",
+                    });
+                    await untilAbort(signal);
+                }),
+            },
+            onSessionNotFound,
+            onError,
+        });
+
+        await stream.start(1);
+        await vi.waitFor(() => expect(onSessionNotFound).toHaveBeenCalledTimes(1));
+        expect(onError).not.toHaveBeenCalled();
+        stream.stop();
+    });
+
+    it("Session Not Found 到达时 owner 已失效则静默丢弃", async () => {
+        const session = useAgentSession();
+        const activeSessionId = ref<number | null>(1);
+        session.applyRecovery(recovery(1, 1));
+        const request = deferred<AgentSessionRecoveryDto>();
+        const onSessionNotFound = vi.fn(async () => undefined);
+        const onError = vi.fn();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId,
+            api: {
+                getSessionRecovery: vi.fn(() => request.promise),
+                subscribeSessionEvents: vi.fn(async () => never()),
+            },
+            onSessionNotFound,
+            onError,
+        });
+
+        const recoveryRequest = stream.syncRecovery("snapshot_required");
+        activeSessionId.value = 2;
+        request.reject(sessionNotFoundHttpError());
+
+        await expect(recoveryRequest).resolves.toBe(false);
+        expect(onSessionNotFound).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("未配置专用回调时保持普通 recovery 错误行为", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        const onError = vi.fn();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery: vi.fn(async () => {
+                    throw sessionNotFoundHttpError();
+                }),
+                subscribeSessionEvents: vi.fn(async () => never()),
+            },
+            onError,
+        });
+
+        await expect(stream.syncRecovery("snapshot_required")).resolves.toBe(false);
+        expect(onError).toHaveBeenCalledTimes(1);
+    });
+
+    it("关联 Session 缺失走普通 recovery 错误出口，不调用 Session Not Found 回调", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        session.requestRecovery("snapshot_required");
+        const onSessionNotFound = vi.fn(async () => undefined);
+        const onError = vi.fn();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery: vi.fn(async () => {
+                    throw sessionDependencyNotFoundHttpError();
+                }),
+                subscribeSessionEvents: vi.fn(async () => never()),
+            },
+            onSessionNotFound,
+            onError,
+        });
+
+        await expect(stream.syncRecovery("snapshot_required")).resolves.toBe(false);
+        expect(onSessionNotFound).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledOnce();
+        expect(session.needsRecovery.value).toBe(false);
+        expect(session.connectionStatus.value).toBe("idle");
+    });
+
+    it("活动连接遇到关联 Session 缺失时清除 latch，不重复发起 recovery", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        const getSessionRecovery = vi.fn(async () => {
+            throw sessionDependencyNotFoundHttpError();
+        });
+        const onError = vi.fn();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery,
+                subscribeSessionEvents: vi.fn(async (_sessionId, _cursor, onEvent, signal, options) => {
+                    options?.onOpen?.();
+                    await onEvent(control(2, {type: "snapshot_required", reason: "dependency missing"}));
+                    await untilAbort(signal);
+                }),
+            },
+            onError,
+        });
+
+        await stream.start(1);
+        await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+        expect(getSessionRecovery).toHaveBeenCalledOnce();
+        expect(session.needsRecovery.value).toBe(false);
+        expect(session.connectionStatus.value).toBe("connected");
+        stream.stop();
+    });
+
+    it("强制 recovery 的关联 Session 缺失保留调用方错误，不调用专用回调", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        session.requestRecovery("snapshot_required");
+        const onSessionNotFound = vi.fn(async () => undefined);
+        const onError = vi.fn();
+        const error = sessionDependencyNotFoundHttpError();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery: vi.fn(async () => {
+                    throw error;
+                }),
+                subscribeSessionEvents: vi.fn(async () => never()),
+            },
+            onSessionNotFound,
+            onError,
+        });
+
+        await expect(stream.refreshRecovery("manual_refresh")).rejects.toBe(error);
+        expect(onSessionNotFound).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+        expect(session.needsRecovery.value).toBe(false);
+        expect(session.connectionStatus.value).toBe("idle");
+    });
+
     it("强制 recovery 开启新 generation，旧成功和旧错误都静默失效", async () => {
         const session = useAgentSession();
         session.applyRecovery(recovery(1, 1));
@@ -603,13 +943,41 @@ describe("useAgentSessionStream", () => {
         expect(subscribeSessionEvents).toHaveBeenCalledTimes(5);
         stream.stop();
     });
+
+    it("服务端迟迟不返回 headers 时握手超时，start 拒绝并安排重连", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 0));
+        const subscribeSessionEvents = vi.fn(async (
+            _sessionId: number,
+            _cursor: AgentSessionEventsQueryDto,
+            _onEvent: (event: AgentSessionEventDto) => void,
+            signal?: AbortSignal,
+        ) => untilAbort(signal));
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery: vi.fn(async () => recovery(1, 0)),
+                subscribeSessionEvents,
+            },
+        });
+
+        const starting = stream.start(1);
+        const rejection = expect(starting).rejects.toThrow("connect timeout");
+        await vi.advanceTimersByTimeAsync(15_000);
+        await rejection;
+        expect(session.connectionStatus.value).toBe("reconnecting");
+        await vi.advanceTimersByTimeAsync(300);
+        expect(subscribeSessionEvents).toHaveBeenCalledTimes(2);
+        stream.stop();
+    });
 });
 
 function recovery(sessionId: number, after: number, revision: string | null = null): AgentSessionRecoveryDto {
     return {
         kind: "recovery",
         eventCursor: {eventEpoch: "epoch-1", after},
-        summary: {sessionId, profileKey: "leader.default", status: "idle", updatedAt: 1, archived: false},
+        summary: {sessionId, sessionIdentity: "sha256:0000000000000000000000000000000000000000000000000000000000000000", profileKey: "leader.default", status: "idle", updatedAt: 1, archived: false},
         activeLeafId: null,
         activePathRevision: revision,
         history: {entries: [], previousCursor: null},
@@ -684,4 +1052,12 @@ function untilAbort(signal?: AbortSignal): Promise<void> {
     if (!signal) return never();
     if (signal.aborted) return Promise.resolve();
     return new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve(), {once: true}));
+}
+
+function sessionNotFoundHttpError(): {response: {_data: {data: {code: "SESSION_NOT_FOUND"}}}} {
+    return {response: {_data: {data: {code: "SESSION_NOT_FOUND"}}}};
+}
+
+function sessionDependencyNotFoundHttpError(): {response: {_data: {data: {code: "SESSION_DEPENDENCY_NOT_FOUND"}}}} {
+    return {response: {_data: {data: {code: "SESSION_DEPENDENCY_NOT_FOUND"}}}};
 }

--- a/packages/neuro-book/app/components/novel-ide/agent/useAgentSessionStream.ts
+++ b/packages/neuro-book/app/components/novel-ide/agent/useAgentSessionStream.ts
@@ -1,8 +1,9 @@
-import type {AgentSessionEventDto, AgentSessionEventsQueryDto, AgentSessionRecoveryDto} from "nbook/shared/dto/agent-session.dto";
+import type {AgentSessionEventDto, AgentSessionEventsQueryDto, AgentSessionRecoveryDto, AgentSessionIdentity} from "nbook/shared/dto/agent-session.dto";
 import type {AgentRecoveryApplyResult} from "nbook/app/components/novel-ide/agent/useAgentSession";
 import type {Ref} from "vue";
 import {ref} from "vue";
 import {SseReconnectBackoff} from "nbook/app/utils/http/sse-reconnect-backoff";
+import {resolveApiErrorCode} from "nbook/app/utils/api-error";
 
 export type AgentSessionStreamRecoveryReason =
     | "initial_load"
@@ -37,18 +38,27 @@ type AgentSessionStreamApi = {
     ): Promise<void>;
 };
 
-type AgentSessionStreamOptions = {
+export type AgentSessionStreamOptions = {
     session: AgentSessionStreamStore;
     api: AgentSessionStreamApi;
     activeSessionId: Ref<number | null>;
+    /** 可选的 Session 逻辑身份；存在时 SSE recovery 也必须匹配。 */
+    activeSessionIdentity?: Ref<AgentSessionIdentity | null>;
     applyRecoverySideEffects?: (
         recovery: AgentSessionRecoveryDto,
         result: AgentRecoveryApplyResult,
         owner: AgentSessionStreamOwner,
     ) => void | Promise<void>;
     onEvent?: (event: AgentSessionEventDto, owner: AgentSessionStreamOwner) => void | Promise<void>;
+    onSessionNotFound?: (
+        error: unknown,
+        owner: AgentSessionStreamOwner,
+    ) => AgentSessionNotFoundHandling | void | Promise<AgentSessionNotFoundHandling | void>;
     onError?: (error: unknown, fallback: string) => void;
 };
+
+/** Session 缺失回调对 stream 错误出口的处理结果。 */
+export type AgentSessionNotFoundHandling = "handled" | "deferred" | "ignored";
 
 /** Session stream 回调的连接所有权；异步副作用提交前必须再次检查 isCurrent。 */
 export type AgentSessionStreamOwner = Readonly<{
@@ -68,6 +78,9 @@ type ConnectionReady = {
 };
 
 const DISCONNECTED_AFTER_ATTEMPTS = 3;
+
+/** 服务端迟迟不返回 SSE headers 时，不允许 Surface 永久停在 connecting/restoring。 */
+const CONNECT_HANDSHAKE_TIMEOUT_MS = 15_000;
 
 const isAbortError = (error: unknown): boolean => error instanceof DOMException && error.name === "AbortError";
 
@@ -107,6 +120,8 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
         attemptedAutomaticRecoveryReasons.clear();
     };
 
+
+
     const restoreConnectionStatusAfterRecoveryFailure = (targetSessionId: number): void => {
         const activeController = controller.value;
         const streamAlive = activeController !== null
@@ -114,7 +129,6 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
             && sessionId.value === targetSessionId;
         options.session.applyConnectionStatus(streamAlive ? "connected" : "idle");
     };
-
     const clearReconnectTimer = (): void => {
         if (!reconnectTimer) {
             return;
@@ -163,6 +177,19 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
         }, retry.delayMs);
     };
 
+    /** 终结一次 Session 生命周期 recovery，避免 409 后永久停在 recovering。 */
+    const settleRecoveryFailure = (targetSessionId: number, isCurrent: () => boolean): void => {
+        if (!isCurrent()) {
+            return;
+        }
+        options.session.clearRecoveryRequest();
+        const liveConnection = Boolean(controller.value)
+            && sessionId.value === targetSessionId
+            && !controller.value?.signal.aborted
+            && !stopped;
+        options.session.applyConnectionStatus(liveConnection ? "connected" : "idle");
+    };
+
     const runRecovery = async (
         reason: AgentSessionStreamRecoveryReason,
         behavior: {force: boolean; reportError: boolean},
@@ -203,6 +230,11 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
                 if (recovery.summary.sessionId !== targetSessionId) {
                     throw new Error(`Agent session recovery 身份不匹配：期望 ${String(targetSessionId)}，收到 ${String(recovery.summary.sessionId)}`);
                 }
+                if (options.activeSessionIdentity?.value !== null
+                    && options.activeSessionIdentity?.value !== undefined
+                    && recovery.summary.sessionIdentity !== options.activeSessionIdentity.value) {
+                    throw new Error("Agent session recovery 身份与当前绑定不一致");
+                }
                 const applyResult = options.session.applyRecovery(recovery);
                 options.session.clearRecoveryRequest();
                 const owner = {sessionId: targetSessionId, isCurrent};
@@ -231,9 +263,26 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
                 if (!isCurrent()) {
                     return false;
                 }
+                const errorCode = resolveApiErrorCode(error);
+                if (errorCode === "SESSION_NOT_FOUND") {
+                    options.session.clearRecoveryRequest();
+                    if (options.onSessionNotFound) {
+                        const handling = await options.onSessionNotFound(error, {sessionId: targetSessionId, isCurrent});
+                        if (handling !== "ignored") {
+                            settleRecoveryFailure(targetSessionId, isCurrent);
+                            return true;
+                        }
+                        return false;
+                    }
+                    settleRecoveryFailure(targetSessionId, isCurrent);
+                }
+                if (errorCode === "SESSION_DEPENDENCY_NOT_FOUND") {
+                    settleRecoveryFailure(targetSessionId, isCurrent);
+                }
+                // 其余错误（invalid cursor 等）也收口：清 recovery 请求并按连接存续恢复状态，
+                // 不让单次 recovery 失败把会话永久钉在 recovering（master 行为）。
                 options.session.clearRecoveryRequest();
-                restoreConnectionStatusAfterRecoveryFailure(targetSessionId);
-                if (behavior.reportError) {
+                restoreConnectionStatusAfterRecoveryFailure(targetSessionId);                if (behavior.reportError) {
                     options.onError?.(error, translate("agent.chatSurface.syncSessionFailed", "同步 Agent session 失败"));
                     return false;
                 }
@@ -342,6 +391,18 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
         nextController.signal.addEventListener("abort", () => {
             nextReady.reject(new DOMException("Agent session event stream aborted", "AbortError"));
         }, {once: true});
+        // 握手超时：服务端迟迟不返回 SSE headers 时，先收口 ready，再 abort 当前 controller，
+        // 并复用既有重连调度；timer 在所有出口（open/abort/错误/finally）统一清除。
+        const handshakeTimer = setTimeout(() => {
+            if (nextReady.settled || controller.value !== nextController) {
+                return;
+            }
+            nextReady.reject(new Error("Agent session event stream connect timeout"));
+            nextController.abort();
+            if (targetSessionId === options.activeSessionId.value && !stopped) {
+                scheduleReconnect(targetSessionId, "event stream connect timeout");
+            }
+        }, CONNECT_HANDSHAKE_TIMEOUT_MS);
         options.session.applyConnectionStatus(reconnectAttempt.value > 0 ? "reconnecting" : "connecting");
 
         void (async () => {
@@ -358,6 +419,7 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
                             || nextController.signal.aborted) {
                             return;
                         }
+                        clearTimeout(handshakeTimer);
                         reconnectBackoff.opened();
                         options.session.applyConnectionStatus("connected");
                         nextReady.resolve();
@@ -380,6 +442,7 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
                     scheduleReconnect(targetSessionId, error instanceof Error ? error.message : String(error));
                 }
             } finally {
+                clearTimeout(handshakeTimer);
                 if (controller.value === nextController) {
                     controller.value = null;
                     sessionId.value = null;
@@ -424,6 +487,7 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
         ready = null;
         recoveryGeneration += 1;
         recoveryPromise = null;
+        options.session.clearRecoveryRequest();
         reconnectBackoff.reset();
         reconnectAttempt.value = 0;
         backoffSessionId = null;

--- a/packages/neuro-book/app/composables/useInlineEditorAgentController.test.ts
+++ b/packages/neuro-book/app/composables/useInlineEditorAgentController.test.ts
@@ -123,10 +123,10 @@ function summary(sessionId: number): AgentSessionSummaryDto {
     return {
         sessionId,
         profileKey: "inline.editor",
+        sessionIdentity: "sha256:" + "0".repeat(64),
         status: "idle",
         updatedAt: 1,
-        archived: false,
-    };
+        archived: false,    };
 }
 
 function recovery(sessionId: number): AgentSessionRecoveryDto {

--- a/packages/neuro-book/app/pages/index.vue
+++ b/packages/neuro-book/app/pages/index.vue
@@ -208,8 +208,24 @@ const agentSurfaceRef = ref<InstanceType<typeof AgentChatSurface> | null>(null);
 type InlinePromptOwner = Readonly<{
     revision: number;
     operationKey: string;
+    surface: NonNullable<typeof agentSurfaceRef.value>;
 }>;
 let inlinePromptRequestRevision = 0;
+
+/** 捕获 Prompt Bar 调用时的 Surface 实例与独立 Inline Project generation。 */
+function captureInlinePromptOwner(): InlinePromptOwner | null {
+    const surface = agentSurfaceRef.value;
+    const operationKey = unref(surface?.inlineOperationScopeKey);
+    if (!surface || typeof operationKey !== "string") return null;
+    return {revision: ++inlinePromptRequestRevision, operationKey, surface};
+}
+
+/** 页面副作用只能由当前 Prompt 请求和当前 Project generation 发布。 */
+function acceptsInlinePromptOwner(owner: InlinePromptOwner): boolean {
+    return owner.revision === inlinePromptRequestRevision
+        && agentSurfaceRef.value === owner.surface
+        && unref(owner.surface.inlineOperationScopeKey) === owner.operationKey;
+}
 
 const studio = useMarkdownStudioController({
     markdown: selectedFileContent,
@@ -230,18 +246,7 @@ const desktopBridge = computed(() => import.meta.client ? window.neuroBookDeskto
 let removeDesktopMenuListener: (() => void) | null = null;
 let desktopZoomQueue: Promise<void> = Promise.resolve();
 
-/** 捕获 Prompt Bar 调用时的 Inline controller 与 Project ready generation。 */
-function captureInlinePromptOwner(): InlinePromptOwner | null {
-    const operationKey = inlineEditorAgent.operationScopeKey.value;
-    if (!operationKey) return null;
-    return {revision: ++inlinePromptRequestRevision, operationKey};
-}
 
-/** 页面副作用只能由当前 Prompt 请求和当前 Project generation 发布。 */
-function acceptsInlinePromptOwner(owner: InlinePromptOwner): boolean {
-    return owner.revision === inlinePromptRequestRevision
-        && inlineEditorAgent.operationScopeKey.value === owner.operationKey;
-}
 
 /** 执行当前焦点元素支持的原生编辑命令；没有选区时给出明确反馈。 */
 function executeDesktopEditCommand(command: "cut" | "copy" | "paste" | "selectAll"): void {
@@ -1116,6 +1121,7 @@ async function selectInlineEditorSession(sessionId: number): Promise<void> {
     try {
         const result = await inlineEditorAgent.selectSession(sessionId);
         if (!acceptsInlinePromptOwner(owner) || result.status === "superseded") return;
+
         inlinePromptStatusText.value = t("ide.inlineAi.boundSession");
     } catch (error) {
         if (!acceptsInlinePromptOwner(owner)) return;
@@ -1148,7 +1154,15 @@ async function openInlineEditorSessionChat(): Promise<void> {
     const owner = captureInlinePromptOwner();
     if (!owner) return;
     try {
-        const result = await inlineEditorAgent.openSession();
+        agentSessionPanelOpen.value = true;
+        await nextTick();
+        const result = await owner.surface.openInlineEditorSession();
+        if (result.status === "failed") {
+            if (owner.revision === inlinePromptRequestRevision && agentSurfaceRef.value === owner.surface) {
+                inlinePromptStatusText.value = result.message;
+            }
+            return;
+        }
         if (!acceptsInlinePromptOwner(owner) || result.status === "superseded") return;
         await showAgentSession(result.value.sessionId);
     } catch (error) {
@@ -1181,7 +1195,16 @@ watch(currentWorkspaceViewMode, (mode) => {
     viewMode.value = mode;
 }, {immediate: true});
 
-watch(() => inlineEditorAgent.operationScopeKey.value, (nextScope, previousScope) => {
+watch([inlinePromptAvailable, agentSurfaceRef], ([available, surface]) => {
+    if (available && surface?.refreshInlineEditorSessions) {
+        void surface.refreshInlineEditorSessions().catch((error: unknown) => {
+            if (agentSurfaceRef.value !== surface) return;
+            notification.error(resolveApiErrorMessage(error, t("ide.inlineAi.bindFailed")), {title: "Inline AI"});
+        });
+    }
+}, {immediate: true});
+
+watch(() => unref(agentSurfaceRef.value?.inlineOperationScopeKey), (nextScope, previousScope) => {
     if (previousScope === undefined || nextScope === previousScope) return;
     inlinePromptRequestRevision += 1;
     inlinePromptRunning.value = false;

--- a/packages/neuro-book/docs/adr/0018-session-identity-and-browser-memory.md
+++ b/packages/neuro-book/docs/adr/0018-session-identity-and-browser-memory.md
@@ -1,0 +1,41 @@
+# ADR 0018：Session 身份与浏览器记忆
+
+- 状态：Accepted
+- 日期：2026-08-05
+- 关联任务：[Task 118](../tasks/118-project-catalog-snapshot-path-integration/README.md)
+- 关联 Issue：[Issue #26](https://github.com/notnotype/neuro-book/issues/26)
+
+## 背景
+
+`sessionId` 只是一个 State Root 内的数字定位符。用户在同一个浏览器 origin 上先后打开两个 State Root 时，两个实例可能合法地拥有同一个数字 ID；浏览器保存的裸数字无法证明它仍然指向原来的对话。继续把这个数字当作可信身份，会把旧实例的请求误发给新实例，或者把新实例的对话误显示成旧对话。
+
+Session 的 JSONL 文件还需要兼容已经存在的 header。不能为了补身份而复制历史文件、引入备份恢复流程或建立全局实例注册表。
+
+## 决策
+
+1. 每个新 Session 在 header 中生成 UUID 形式的不可变 `sessionIdentity`。
+2. 没有身份字段的现有 header 使用 header 元数据的稳定 SHA-256 派生身份；读取时不改写历史 JSONL。请求的数字 ID 必须同时匹配文件名和 header，否则拒绝读取。
+3. Agent Session 列表、recovery、关系投影和 SSE 所消费的公开 summary 都携带 `sessionIdentity`。浏览器记忆使用版本化 `{schema: 2, sessionId, sessionIdentity}`；裸数字、损坏 JSON 或缺少 identity 均进入未选择状态。
+4. 浏览器记忆只用于启动时尝试恢复，不是 Session 存在性或 owner 证明。权威 recovery 成功提交后才写记忆；`localStorage` 写入失败不回滚已打开的对话，也不删除旧值。
+5. 404 的主 Session 缺失只刷新当前 State Root 的列表并执行一次有界恢复；只有数字 ID 与 identity 都匹配时才清理失效记忆。关联 Session 缺失只投影为局部不可用并返回 409，主对话继续可读。
+6. 不在本 ADR 建立 State Root 实例身份协议。两个 State Root 恰好复用同一个数字 ID 时，缺少可信 identity 的旧记忆必须进入未选择态，而不是猜测、自动切换或自动创建。
+
+## 原因
+
+UUID 让新文件拥有直接生成的稳定身份，SHA-256 派生值让旧文件可以在不迁移数据的前提下获得同样的比较语义。把 identity 和数字定位符一起保存，能在浏览器记忆与当前实例不一致时 fail closed，同时不需要把绝对路径、State Root 名称或用户正文暴露给客户端。
+
+关联关系与主 Session 的生命周期不同。把缺失关联目标投影成计数而不是让整个 recovery 失败，能保留用户正在看的对话；损坏文件、权限错误和非目标路径的缺失仍然抛出，避免把真实数据错误伪装成“关联对话不可用”。
+
+## 后果
+
+- 旧浏览器记忆不会自动选择一个可能同号但不同身份的对话，用户需要从当前实例的列表选择一次。
+- 旧 JSONL 不需要立即重写，identity 计算是读取时的纯投影；新文件从创建起具备显式 UUID。
+- 不同 State Root 的同号 Session 仍可能存在，但不会由本地记忆协议推断它们是同一个对话。真正的实例隔离需要后续独立协议。
+- 关系面板可能显示“关联对话不可用”的局部提示；主对话和其它错误语义保持不变。
+
+## 未采用方案
+
+- 用数字 `sessionId` 单独作为浏览器记忆：无法区分同 origin 的不同 State Root。
+- 把 State Root 路径或实例名称写进 localStorage：路径不是稳定公开身份，也会泄露本地布局。
+- 发现同号 Session 后自动选择列表首项、复制历史或恢复备份：会把不确定性变成静默数据串线。
+- 为此次修复建立全局 Session 注册表或跨实例锁：复杂度和生命周期都超出当前本地优先应用的实际边界。

--- a/packages/neuro-book/docs/adr/0018-session-identity-and-browser-memory.md
+++ b/packages/neuro-book/docs/adr/0018-session-identity-and-browser-memory.md
@@ -2,7 +2,7 @@
 
 - 状态：Accepted
 - 日期：2026-08-05
-- 关联任务：[Task 118](../tasks/118-project-catalog-snapshot-path-integration/README.md)
+- 关联任务：[Task 118](../../.agents/tasks/118-project-catalog-snapshot-path-integration/README.md)
 - 关联 Issue：[Issue #26](https://github.com/notnotype/neuro-book/issues/26)
 
 ## 背景

--- a/packages/neuro-book/server/agent/drafts/agent-composer-draft-store.test.ts
+++ b/packages/neuro-book/server/agent/drafts/agent-composer-draft-store.test.ts
@@ -23,13 +23,13 @@ describe("AgentComposerDraftStore", () => {
         expect(file.drafts).toHaveLength(1);
     });
 
-    it("拒绝 Blob/data 图片与超过 256 KiB 的正文，并清除同身份旧草稿", async () => {
+    it("拒绝 Blob/data 图片与超过 256 KiB 的正文，并保留同身份旧草稿", async () => {
         const store = new AgentComposerDraftStore(await fixture());
         const identity = {scopeKey: "project:a" as const, sessionId: 1};
         await store.save(identity, "旧正文", 1);
 
         await expect(store.save(identity, "![图](data:image/png;base64,AAAA)", 2)).resolves.toBe("unsafe");
-        await expect(store.load(identity, 3)).resolves.toEqual({text: ""});
+        await expect(store.load(identity, 3)).resolves.toEqual({text: "旧正文"});
         await expect(store.save(identity, "![图](blob:http://localhost/id)", 4)).resolves.toBe("unsafe");
         await expect(store.save(identity, "x".repeat(256 * 1024 + 1), 5)).resolves.toBe("oversize");
     });

--- a/packages/neuro-book/server/agent/drafts/agent-composer-draft-store.ts
+++ b/packages/neuro-book/server/agent/drafts/agent-composer-draft-store.ts
@@ -55,7 +55,8 @@ export class AgentComposerDraftStore {
     async save(identity: AgentComposerDraftIdentity, text: string, now = Date.now()): Promise<AgentComposerDraftSaveResult> {
         return await withFileLock(this.filePath, async () => {
             const current = await this.read();
-            const withoutCurrent = validDrafts(current.drafts, now).filter((item) => !sameIdentity(item, identity));
+            const valid = validDrafts(current.drafts, now);
+            const withoutCurrent = valid.filter((item) => !sameIdentity(item, identity));
             let result: AgentComposerDraftSaveResult = "saved";
             if (!text) {
                 result = "cleared";
@@ -66,7 +67,8 @@ export class AgentComposerDraftStore {
             } else {
                 withoutCurrent.push({...identity, text, updatedAt: now});
             }
-            await this.write(recentDrafts(withoutCurrent));
+            // 非法新正文不能删除旧的安全草稿；用户仍可返回编辑或明确放弃。
+            await this.write(recentDrafts(result === "oversize" || result === "unsafe" ? valid : withoutCurrent));
             return result;
         });
     }

--- a/packages/neuro-book/server/agent/harness/neuro-agent-harness.ts
+++ b/packages/neuro-book/server/agent/harness/neuro-agent-harness.ts
@@ -52,7 +52,7 @@ import {projectRelatedSessions} from "nbook/server/agent/session/relation-projec
 import {SessionWriteExecutor} from "nbook/server/agent/session/write-plan";
 import type {AppendManySessionEntryDraft, SessionWriteEntryBatch, SessionWritePlan, SessionWriteResult, SessionWriteTimingSink} from "nbook/server/agent/session/write-plan";
 import {ToolSessionWriteSink} from "nbook/server/agent/session/tool-session-write-sink";
-import {relationLedgerChange} from "nbook/server/agent/session/relation-ledger";
+import {relationLedgerChange} from "nbook/server/agent/session/relation-ledger";
 import {AGENT_FOLLOW_UP_QUEUE_STATE_KEY, AGENT_MODE_STATE_KEY, AGENT_MODE_UI_STATE_KEY, AGENT_PENDING_USER_RESOLUTION_STATE_PREFIX, SESSION_SUMMARIZER_STATE_KEY, SESSION_TITLE_OWNER_STATE_KEY, readTitleOwner, type SessionTitleOwnerState} from "nbook/server/agent/session/custom-state-keys";
 import type {InvocationErrorInfo, InvocationErrorPhase, ModelChangeEntry, NeuroSessionContext, SessionEntry, SessionEntryDraft, SessionEntryId, SessionMetadata, SessionSnapshot} from "nbook/server/agent/session/types";
 import {SessionCurrentProjectError} from "nbook/server/agent/session/current-project-error";
@@ -2777,16 +2777,23 @@ export class NeuroAgentHarness {
     ): Promise<AgentSessionRelationsDto> {
         const index = await this.relationIndex();
         const sessionId = projection.snapshot.metadata.sessionId;
-        const linkedAgents = await projectRelatedSessions(
-            this.currentOwnedLinks(sessionId, index).map((linked) => linked.targetSessionId),
+        const linkedSessionIds = this.currentOwnedLinks(sessionId, index).map((linked) => linked.targetSessionId);
+        const ownerSessionIds = this.currentOwnerLinks(sessionId, index).map((linked) => linked.ownerSessionId);
+        // 无关联目标时保持旧的同步空路径，避免 recovery 在 abort 收口后额外让出事件循环。
+        const linkedAgents = linkedSessionIds.length === 0
+            ? {items: [] as AgentSessionSummaryDto[], unavailable: 0}
+            : await projectRelatedSessions(
+            linkedSessionIds,
             async (linkedSessionId) => {
                 const linkedSnapshot = await measureAgentTimingStep(timing, "readSession", () => this.repo.readSession(linkedSessionId));
                 const linkedProjection = await this.resolveSessionRuntimeProjection(linkedSessionId, linkedSnapshot, timing);
                 return linkedProjection.summary;
             },
         );
-        const linkedByAgents = await projectRelatedSessions(
-            this.currentOwnerLinks(sessionId, index).map((linked) => linked.ownerSessionId),
+        const linkedByAgents = ownerSessionIds.length === 0
+            ? {items: [] as AgentSessionSummaryDto[], unavailable: 0}
+            : await projectRelatedSessions(
+            ownerSessionIds,
             async (ownerSessionId) => {
                 const ownerSnapshot = await measureAgentTimingStep(timing, "readSession", () => this.repo.readSession(ownerSessionId));
                 const ownerProjection = await this.resolveSessionRuntimeProjection(ownerSessionId, ownerSnapshot, timing);

--- a/packages/neuro-book/server/agent/http.test.ts
+++ b/packages/neuro-book/server/agent/http.test.ts
@@ -8,6 +8,9 @@ import {
     listAgentSessionAttachments,
     listAgentSessions,
     moveAgentSessionTree,
+    mapAgentHttpError,
+    requireAgentSessionId,
+    requireAgentSessionIdValue,
     runAgentSessionCommand,
     toInvokeInput,
     updateAgentSessionCurrentProject,
@@ -17,6 +20,7 @@ import {AgentSessionNotFoundError} from "nbook/server/agent/session/session-not-
 import {SessionCurrentProjectError} from "nbook/server/agent/session/current-project-error";
 import {AttachmentError} from "nbook/server/agent/attachments/types";
 import {assertPublicToolCallId} from "nbook/shared/agent/public-tool-identity";
+import {AgentSessionIdSchema} from "nbook/shared/dto/agent-session.dto";
 
 describe("agent session http helpers", () => {
     it("createAgentSession 调用 harness.createAgent", async () => {
@@ -41,6 +45,49 @@ describe("agent session http helpers", () => {
             currentProjectRoot: "novel",
             parentSessionId: 1,
         });
+    });
+
+    it.each([
+        [undefined, undefined],
+        ["1", 1],
+        ["0007", 7],
+    ] as const)("解析可选 Session ID %s", (raw, expected) => {
+        expect(requireAgentSessionIdValue(raw)).toBe(expected);
+    });
+
+    it.each(["abc", "NaN", "0", "-1", "1.5", "9007199254740992"])("拒绝无效的可选 Session ID %s", (raw) => {
+        expect(() => requireAgentSessionIdValue(raw)).toThrowError(expect.objectContaining({
+            statusCode: 400,
+            message: "sessionId 必须是正整数",
+        }));
+    });
+
+    it.each([
+        ["12", 12],
+        [String(Number.MAX_SAFE_INTEGER), Number.MAX_SAFE_INTEGER],
+    ] as const)("canonical parser 接受安全正整数路由参数 %s", (raw, expected) => {
+        expect(requireAgentSessionId({context: {params: {sessionId: raw}}} as never)).toBe(expected);
+    });
+
+    it.each(["0", "-12", "12.5", "abc", String(2 ** 53), undefined])(
+        "canonical parser 拒绝非法或非安全整数路由参数 %s",
+        (raw) => {
+            expect(() => requireAgentSessionId({context: {params: {sessionId: raw}}} as never)).toThrowError(
+                expect.objectContaining({
+                    statusCode: 400,
+                    message: "sessionId 必须是正整数",
+                }),
+            );
+        },
+    );
+
+    it("AgentSessionIdSchema 只接受正的安全整数", () => {
+        expect(AgentSessionIdSchema.safeParse(Number.MAX_SAFE_INTEGER).success).toBe(true);
+        expect(AgentSessionIdSchema.safeParse(2 ** 53).success).toBe(false);
+        expect(AgentSessionIdSchema.safeParse(Number.MAX_SAFE_INTEGER + 1).success).toBe(false);
+        expect(AgentSessionIdSchema.safeParse(0).success).toBe(false);
+        expect(AgentSessionIdSchema.safeParse(-1).success).toBe(false);
+        expect(AgentSessionIdSchema.safeParse(1.5).success).toBe(false);
     });
 
     it("listAgentSessions 调用 harness.listSessionPage", async () => {
@@ -132,6 +179,17 @@ describe("agent session http helpers", () => {
         await expect(getAgentSessionQuery(12, query as never, {getSessionQuery} as never)).rejects.toMatchObject({
             statusCode: 404,
             data: {code: "SESSION_NOT_FOUND"},
+        });
+    });
+
+    it("按请求 Session 身份区分主资源 404 与关联资源 409", () => {
+        expect(mapAgentHttpError(new AgentSessionNotFoundError(12), 12)).toMatchObject({
+            statusCode: 404,
+            data: {code: "SESSION_NOT_FOUND"},
+        });
+        expect(mapAgentHttpError(new AgentSessionNotFoundError(13), 12)).toMatchObject({
+            statusCode: 409,
+            data: {code: "SESSION_DEPENDENCY_NOT_FOUND"},
         });
     });
 

--- a/packages/neuro-book/server/agent/http.ts
+++ b/packages/neuro-book/server/agent/http.ts
@@ -82,10 +82,33 @@ export function requireAgentSessionId(event: Parameters<typeof getRouterParam>[0
 }
 
 /**
+ * 解析请求体中的可选 Session ID；未提供时保留 undefined，提供但不是安全正整数时返回 400。
+ */
+export function requireAgentSessionIdValue(raw: string | undefined): number | undefined {
+    if (raw === undefined) {
+        return undefined;
+    }
+    if (!/^\d+$/u.test(raw)) {
+        throw createError({
+            statusCode: 400,
+            message: "sessionId 必须是正整数",
+        });
+    }
+    const parsed = AgentSessionIdSchema.safeParse(Number(raw));
+    if (!parsed.success || !Number.isSafeInteger(parsed.data)) {
+        throw createError({
+            statusCode: 400,
+            message: "sessionId 必须是正整数",
+        });
+    }
+    return parsed.data;
+}
+
+/**
  * 创建 Agent session。
  */
 export async function createAgentSession(body: AgentCreateSessionRequestDto, harness = useAgentHarness()) {
-    return withAgentHttpError(() => harness.createAgent({
+    return withAgentHttpError(undefined, () => harness.createAgent({
         profileKey: body.profileKey,
         initial: body.initial,
         currentProjectRoot: body.currentProjectRoot,
@@ -99,7 +122,7 @@ export async function updateAgentSessionCurrentProject(
     body: AgentCurrentProjectRequestDto,
     harness = useAgentHarness(),
 ) {
-    return withAgentHttpError(() => harness.updateCurrentProject(sessionId, body.projectRoot));
+    return withAgentSessionHttpError(sessionId, () => harness.updateCurrentProject(sessionId, body.projectRoot));
 }
 
 /**
@@ -128,7 +151,7 @@ export async function getAgentSessionQuery(
     harness = useAgentHarness(),
     timingSink?: ServerTimingSink,
 ): Promise<AgentSessionQueryResultDto> {
-    return withAgentHttpError(() => timingSink
+    return withAgentSessionHttpError(sessionId, () => timingSink
         ? harness.getSessionQuery(sessionId, query, timingSink)
         : harness.getSessionQuery(sessionId, query));
 }
@@ -137,7 +160,7 @@ export async function getAgentSessionQuery(
  * 返回关联 Agent 面板使用的轻量关系投影。
  */
 export async function getAgentSessionRelations(sessionId: number, harness = useAgentHarness(), timingSink?: ServerTimingSink) {
-    return withAgentHttpError(() => timingSink
+    return withAgentSessionHttpError(sessionId, () => timingSink
         ? harness.getSessionRelations(sessionId, timingSink)
         : harness.getSessionRelations(sessionId));
 }
@@ -146,7 +169,7 @@ export async function getAgentSessionRelations(sessionId: number, harness = useA
  * 阻塞调用 Agent session。
  */
 export async function invokeAgentSession(sessionId: number, body: AgentInvokeRequestDto, harness = useAgentHarness()): Promise<InvokeAgentResult> {
-    return withAgentHttpError(async () => {
+    return withAgentSessionHttpError(sessionId, async () => {
         const result = await harness.invokeAgent(toInvokeInput(sessionId, body));
         return projectPublicInvocationResult(result);
     });
@@ -158,7 +181,7 @@ export async function listAgentSessionAttachments(
     query: AgentSessionAttachmentListQueryDto,
     harness = useAgentHarness(),
 ): Promise<AgentSessionAttachmentPageDto> {
-    return withAgentHttpError(() => harness.listSessionAttachments(sessionId, query));
+    return withAgentSessionHttpError(sessionId, () => harness.listSessionAttachments(sessionId, query));
 }
 
 /** 按请求顺序批量解析当前 Session 已授权附件。 */
@@ -167,7 +190,7 @@ export async function resolveAgentSessionAttachments(
     attachmentIds: readonly import("nbook/shared/dto/agent-attachment.dto").AttachmentId[],
     harness = useAgentHarness(),
 ): Promise<AgentSessionAttachmentResolveResultDto> {
-    return withAgentHttpError(async () => ({
+    return withAgentSessionHttpError(sessionId, async () => ({
         items: await harness.resolveSessionAttachments(sessionId, attachmentIds),
     }));
 }
@@ -178,7 +201,7 @@ export async function uploadAgentSessionAttachment(
     input: {bytes: Uint8Array; mimeType?: string; name?: string},
     harness = useAgentHarness(),
 ): Promise<AgentSessionAttachmentItemDto> {
-    return withAgentHttpError(() => harness.uploadSessionAttachment(sessionId, input));
+    return withAgentSessionHttpError(sessionId, () => harness.uploadSessionAttachment(sessionId, input));
 }
 
 /** 上传路由在消费 multipart body 前执行的 Session 交互门禁。 */
@@ -186,7 +209,7 @@ export async function preflightAgentSessionAttachmentRegistration(
     sessionId: number,
     harness = useAgentHarness(),
 ): Promise<void> {
-    return withAgentHttpError(async () => {
+    return withAgentSessionHttpError(sessionId, async () => {
         await harness.preflightSessionAttachmentRegistration(sessionId);
     });
 }
@@ -197,7 +220,7 @@ export async function snapshotAgentSessionAttachment(
     input: AgentSessionAttachmentSnapshotRequestDto,
     harness = useAgentHarness(),
 ): Promise<AgentSessionAttachmentItemDto> {
-    return withAgentHttpError(() => harness.snapshotSessionAttachment(sessionId, input));
+    return withAgentSessionHttpError(sessionId, () => harness.snapshotSessionAttachment(sessionId, input));
 }
 
 /** 返回历史用户消息按 stored content 顺序重建的完整 Markdown。 */
@@ -206,14 +229,14 @@ export async function getAgentSessionUserContent(
     entryId: string,
     harness = useAgentHarness(),
 ): Promise<AgentUserMessageContentDto> {
-    return withAgentHttpError(() => harness.getSessionUserContent(sessionId, entryId));
+    return withAgentSessionHttpError(sessionId, () => harness.getSessionUserContent(sessionId, entryId));
 }
 
 /**
  * 执行 session command。slash command 在前端识别后进入这里。
  */
 export async function runAgentSessionCommand(sessionId: number, body: AgentCommandRequestDto, harness = useAgentHarness(), timingSink?: ServerTimingSink) {
-    return withAgentHttpError(() => timingSink
+    return withAgentSessionHttpError(sessionId, () => timingSink
         ? harness.runCommand(sessionId, body, timingSink)
         : harness.runCommand(sessionId, body));
 }
@@ -224,7 +247,7 @@ export async function runAgentSessionCommand(sessionId: number, body: AgentComma
  * 当前实现先移动 leaf 再 invoke；若 invoke 失败，leaf 不会自动回滚。
  */
 export async function moveAgentSessionTree(sessionId: number, body: AgentTreeRequestDto, harness = useAgentHarness()): Promise<AgentTreeResult> {
-    return withAgentHttpError(async () => {
+    return withAgentSessionHttpError(sessionId, async () => {
         const result = await harness.moveTree(sessionId, body);
         return result.invocation
             ? {...result, invocation: projectPublicInvocationResult(result.invocation)}
@@ -236,14 +259,14 @@ export async function moveAgentSessionTree(sessionId: number, body: AgentTreeReq
  * 请求中断当前 invocation。
  */
 export async function abortAgentSession(sessionId: number, body: AgentAbortRequestDto, harness = useAgentHarness()) {
-    return withAgentHttpError(() => harness.abortInvocation(sessionId, body));
+    return withAgentSessionHttpError(sessionId, () => harness.abortInvocation(sessionId, body));
 }
 
 /**
  * 前端确认 client.* variable patch 已应用。
  */
 export async function acknowledgeClientVariablePatch(sessionId: number, body: ClientVariablePatchAckDto, harness = useAgentHarness()) {
-    return withAgentHttpError(async () => {
+    return withAgentSessionHttpError(sessionId, async () => {
         await harness.acknowledgeClientVariablePatch(sessionId, body);
         return {ok: true};
     });
@@ -281,12 +304,20 @@ export function toInvokeInput(
 }
 
 /** 统一保护 Session HTTP helper，避免各路由重复识别领域错误。 */
-async function withAgentHttpError<TResult>(operation: () => Promise<TResult>): Promise<TResult> {
+export async function withAgentHttpError<TResult>(requestSessionId: number | undefined, operation: () => Promise<TResult>): Promise<TResult> {
     try {
         return await operation();
     } catch (error) {
-        throw mapAgentHttpError(error);
+        throw mapAgentHttpError(error, requestSessionId);
     }
+}
+
+/** 以 Session 为主资源的 HTTP 边界；关联读取缺失会与主资源 404 明确区分。 */
+export async function withAgentSessionHttpError<TResult>(
+    requestSessionId: number,
+    operation: () => Promise<TResult>,
+): Promise<TResult> {
+    return withAgentHttpError(requestSessionId, operation);
 }
 
 /** 将 Attachment 稳定错误映射为前端可处理的 HTTP 合同。 */
@@ -330,12 +361,13 @@ function mapAgentAttachmentHttpError(error: unknown): Error {
 }
 
 /** Session HTTP 路由共享的稳定错误出口。 */
-export function mapAgentHttpError(error: unknown): Error {
+export function mapAgentHttpError(error: unknown, requestSessionId: number | undefined): Error {
     if (isAgentSessionNotFoundError(error)) {
+        const primaryMissing = error.sessionId === requestSessionId;
         return createError({
-            statusCode: 404,
-            message: "Session 不存在或已不可用",
-            data: {code: "SESSION_NOT_FOUND"},
+            statusCode: primaryMissing ? 404 : 409,
+            message: primaryMissing ? "Session 不存在或已不可用" : "关联对话不存在或已不可用",
+            data: {code: primaryMissing ? "SESSION_NOT_FOUND" : "SESSION_DEPENDENCY_NOT_FOUND"},
         });
     }
     if (error instanceof AgentHistoryQueryError) {
@@ -358,10 +390,11 @@ export function mapAgentHttpError(error: unknown): Error {
     return mapAgentAttachmentHttpError(error);
 }
 
-/** 宽泛 entry/attachment 404 Adapter 用稳定 HTTP code 保留 Session Not Found。 */
-export function isAgentSessionNotFoundHttpError(error: unknown): boolean {
+/** 宽泛 entry/attachment Adapter 用稳定 HTTP code 保留两类 Session 生命周期错误。 */
+export function isAgentSessionLifecycleHttpError(error: unknown): boolean {
     if (!(error instanceof Error) || !("data" in error) || typeof error.data !== "object" || error.data === null) {
         return false;
     }
-    return "code" in error.data && error.data.code === "SESSION_NOT_FOUND";
+    return "code" in error.data
+        && (error.data.code === "SESSION_NOT_FOUND" || error.data.code === "SESSION_DEPENDENCY_NOT_FOUND");
 }

--- a/packages/neuro-book/server/agent/profiles/profile-compile-worker-lifecycle.test.ts
+++ b/packages/neuro-book/server/agent/profiles/profile-compile-worker-lifecycle.test.ts
@@ -32,6 +32,49 @@ const PROFILE_SOURCE = `
 `;
 
 describe("profile compile worker Project lifecycle", () => {
+    it("worker runtime 将 Session lifecycle error 返回为内部字段", async () => {
+        await withLifecycleProfile(async (assets) => {
+            const source = await readFile(profilePath(assets, PROFILE_FILE_NAME), "utf8");
+
+            const result = await runProfileCompile({
+                fileName: PROFILE_FILE_NAME,
+                source,
+                dryRun: true,
+                preview: true,
+                sessionId: "999999",
+                userProfileRoot: assets.userProfileRoot,
+            });
+
+            expect(result.lifecycleError).toEqual({
+                code: "SESSION_NOT_FOUND",
+                sessionId: 999_999,
+            });
+            expect(result.issues).toEqual([]);
+        });
+    }, 120_000);
+
+    it("worker service 将 Session lifecycle error 重新抛为领域错误", async () => {
+        await withLifecycleProfile(async (assets) => {
+            const source = await readFile(profilePath(assets, PROFILE_FILE_NAME), "utf8");
+            const worker = new ProfileCompileWorkerService("test-session-lifecycle-error", 1, undefined, assets.userProfileRoot);
+            try {
+                await expect(worker.compile({
+                    fileName: PROFILE_FILE_NAME,
+                    source,
+                    dryRun: true,
+                    preview: true,
+                    sessionId: "999999",
+                })).rejects.toMatchObject({
+                    name: "AgentSessionNotFoundError",
+                    code: "SESSION_NOT_FOUND",
+                    sessionId: 999_999,
+                });
+            } finally {
+                worker.dispose();
+            }
+        });
+    }, 120_000);
+
     it("worker runtime 将 Project lifecycle error 返回为内部字段", async () => {
         await withLifecycleProfile(async (assets) => {
             const {projectRoot, projectWorkspaceRoot, sessionId} = await createUnopenedProjectSession(assets);

--- a/packages/neuro-book/server/agent/profiles/profile-compile-worker-lifecycle.test.ts
+++ b/packages/neuro-book/server/agent/profiles/profile-compile-worker-lifecycle.test.ts
@@ -32,49 +32,6 @@ const PROFILE_SOURCE = `
 `;
 
 describe("profile compile worker Project lifecycle", () => {
-    it("worker runtime 将 Session lifecycle error 返回为内部字段", async () => {
-        await withLifecycleProfile(async (assets) => {
-            const source = await readFile(profilePath(assets, PROFILE_FILE_NAME), "utf8");
-
-            const result = await runProfileCompile({
-                fileName: PROFILE_FILE_NAME,
-                source,
-                dryRun: true,
-                preview: true,
-                sessionId: "999999",
-                userProfileRoot: assets.userProfileRoot,
-            });
-
-            expect(result.lifecycleError).toEqual({
-                code: "SESSION_NOT_FOUND",
-                sessionId: 999_999,
-            });
-            expect(result.issues).toEqual([]);
-        });
-    }, 120_000);
-
-    it("worker service 将 Session lifecycle error 重新抛为领域错误", async () => {
-        await withLifecycleProfile(async (assets) => {
-            const source = await readFile(profilePath(assets, PROFILE_FILE_NAME), "utf8");
-            const worker = new ProfileCompileWorkerService("test-session-lifecycle-error", 1, undefined, assets.userProfileRoot);
-            try {
-                await expect(worker.compile({
-                    fileName: PROFILE_FILE_NAME,
-                    source,
-                    dryRun: true,
-                    preview: true,
-                    sessionId: "999999",
-                })).rejects.toMatchObject({
-                    name: "AgentSessionNotFoundError",
-                    code: "SESSION_NOT_FOUND",
-                    sessionId: 999_999,
-                });
-            } finally {
-                worker.dispose();
-            }
-        });
-    }, 120_000);
-
     it("worker runtime 将 Project lifecycle error 返回为内部字段", async () => {
         await withLifecycleProfile(async (assets) => {
             const {projectRoot, projectWorkspaceRoot, sessionId} = await createUnopenedProjectSession(assets);

--- a/packages/neuro-book/server/agent/profiles/profile-compile-worker-runtime.ts
+++ b/packages/neuro-book/server/agent/profiles/profile-compile-worker-runtime.ts
@@ -27,6 +27,10 @@ import {
     isProjectNotOpenError,
     type ProjectNotOpenError,
 } from "nbook/server/workspace-files/project-session-service";
+import {
+    isAgentSessionNotFoundError,
+    type AgentSessionNotFoundError,
+} from "nbook/server/agent/session/session-not-found-error";
 
 type InternalProfileCompileRequest = AgentProfileCompileRequestDto & {
     profileRoot?: string;
@@ -98,6 +102,9 @@ export async function runProfileCompile(input: InternalProfileCompileRequest): P
         };
     } catch (error) {
         if (isProjectNotOpenError(error)) {
+            return lifecycleErrorResult(error, startedAt);
+        }
+        if (isAgentSessionNotFoundError(error)) {
             return lifecycleErrorResult(error, startedAt);
         }
         if (error instanceof ProfileArtifactSourceMissingError) {
@@ -342,17 +349,16 @@ function resolveProfileRoot(input: {profileRoot?: string}): string {
     return resolve(input.profileRoot);
 }
 
-function lifecycleErrorResult(error: ProjectNotOpenError, startedAt: number): ProfileCompileWorkerResult {
+function lifecycleErrorResult(error: ProjectNotOpenError | AgentSessionNotFoundError, startedAt: number): ProfileCompileWorkerResult {
     return {
         ok: false,
         stale: false,
         detail: null,
         preview: null,
         issues: [],
-        lifecycleError: {
-            code: "PROJECT_NOT_OPEN",
-            projectRoot: error.projectRoot,
-        },
+        lifecycleError: isAgentSessionNotFoundError(error)
+            ? {code: "SESSION_NOT_FOUND", sessionId: error.sessionId}
+            : {code: "PROJECT_NOT_OPEN", projectRoot: error.projectRoot},
         elapsedMs: Math.round((performance.now() - startedAt) * 100) / 100,
     };
 }

--- a/packages/neuro-book/server/agent/profiles/profile-compile-worker-types.ts
+++ b/packages/neuro-book/server/agent/profiles/profile-compile-worker-types.ts
@@ -14,10 +14,9 @@ export type ProfileCompileStagedRelease = {
 /**
  * worker 内部生命周期错误。它不是公开 DTO 字段，主线程收到后会重新抛 typed error。
  */
-export type ProfileCompileLifecycleError = {
-    code: "PROJECT_NOT_OPEN";
-    projectRoot: string;
-};
+export type ProfileCompileLifecycleError =
+    | {code: "PROJECT_NOT_OPEN"; projectRoot: string}
+    | {code: "SESSION_NOT_FOUND"; sessionId: number};
 
 /**
  * worker 线程内部返回值。stagedRelease 是 server 内部字段，不进入 HTTP DTO schema。

--- a/packages/neuro-book/server/agent/profiles/profile-compile-worker.ts
+++ b/packages/neuro-book/server/agent/profiles/profile-compile-worker.ts
@@ -36,6 +36,10 @@ import type {
     AgentProfileIssueDto,
 } from "nbook/shared/dto/agent-profile.dto";
 import {resolveRuntimeArtifactCompilerContext} from "nbook/server/utils/runtime-artifact-compiler-context";
+import {
+    AgentSessionNotFoundError,
+    isAgentSessionNotFoundError,
+} from "nbook/server/agent/session/session-not-found-error";
 
 type CompileTask = {
     id: number;
@@ -337,7 +341,7 @@ export class ProfileCompileWorkerService {
             } catch (error) {
                 slot.task = null;
                 this.running.delete(task.id);
-                if (isProjectNotOpenError(error)) {
+                if (isProjectNotOpenError(error) || isAgentSessionNotFoundError(error)) {
                     task.reject(error);
                 } else {
                     task.resolve(workerFailedResult(task.input, error instanceof Error ? error : new Error(String(error))));
@@ -695,6 +699,7 @@ function throwLifecycleError(result: ProfileCompileWorkerResult): void {
     if (result.lifecycleError.code === "PROJECT_NOT_OPEN") {
         throw new ProjectNotOpenError(result.lifecycleError.projectRoot);
     }
+    throw new AgentSessionNotFoundError(result.lifecycleError.sessionId);
 }
 
 function workerFailedResult(input: AgentProfileCompileRequestDto | AgentProfileCompileAllRequestDto, error: Error): AgentProfileCompileResultDto {

--- a/packages/neuro-book/server/agent/profiles/profile-http-service.test.ts
+++ b/packages/neuro-book/server/agent/profiles/profile-http-service.test.ts
@@ -32,6 +32,61 @@ afterEach(async () => {
 });
 
 describe("Profile prepare preview物理Workspace Root", () => {
+    it("关联 Session 缺失保持领域错误，不降级为 prepare issue", async () => {
+        const fixture = await fixtureRoot();
+        const applicationRoot = absoluteFsPath(path.join(fixture, "application"));
+        const stateRoot = absoluteFsPath(path.join(fixture, "state"));
+        const runtimePaths = createRuntimePaths({applicationRoot, stateRoot});
+        await Promise.all([
+            mkdir(applicationRoot, {recursive: true}),
+            mkdir(runtimePaths.workspaceRoot, {recursive: true}),
+        ]);
+        process.env.NEURO_BOOK_APPLICATION_ROOT = applicationRoot;
+        process.env.NEURO_BOOK_STATE_ROOT = stateRoot;
+        setWorkspaceRuntimeRootContextForTest({workspaceRoot: runtimePaths.workspaceRoot});
+
+        const repo = new JsonlSessionRepository(runtimePaths.workspaceRoot);
+        const harness = new NeuroAgentHarness({
+            runtimePaths,
+            repo,
+            profiles: new AgentProfileCatalog(
+                path.join(fixture, "missing-system-profiles"),
+                undefined,
+                undefined,
+                undefined,
+                (profileRoot: string, rootLabel: string) => resolveProfileArtifactPathContext(profileRoot, rootLabel, path.join(fixture, "application")),
+                {install: "workspace/.nbook/agent/profiles"},
+            ),
+            enableSessionSummarizer: false,
+        });
+        harness.profiles.register(defineAgentProfile({
+            manifest: {key: "test.missing-dependency", name: "Missing Dependency"},
+            initialSchema: Type.Object({}),
+            tools: {},
+            async prepare({session}) {
+                await session.read(999_999);
+                return {systemPrompt: "unreachable"};
+            },
+        }), false);
+
+        try {
+            const current = await repo.createSession({
+                profileKey: "test.missing-dependency",
+                initial: {},
+            });
+            await expect(previewAgentProfilePrepare(harness, {
+                profileKey: "test.missing-dependency",
+                sessionId: String(current.metadata.sessionId),
+            })).rejects.toMatchObject({
+                name: "AgentSessionNotFoundError",
+                code: "SESSION_NOT_FOUND",
+                sessionId: 999_999,
+            });
+        } finally {
+            await harness.dispose();
+        }
+    });
+
     it("Project与未绑定Session共用真实Workspace Root，Project另携ready handle", async () => {
         const fixture = await fixtureRoot();
         const applicationRoot = absoluteFsPath(path.join(fixture, "application"));

--- a/packages/neuro-book/server/agent/profiles/profile-http-service.ts
+++ b/packages/neuro-book/server/agent/profiles/profile-http-service.ts
@@ -41,6 +41,7 @@ import {absoluteFsPath, type AbsoluteFsPath} from "nbook/server/runtime/paths/fi
 import type {RuntimePaths} from "nbook/server/runtime/paths/runtime-paths";
 import {resolvePiModelFromConfig} from "nbook/server/agent/harness/model-resolver";
 import {resolveAgentVisibleModels} from "nbook/server/agent/harness/agent-visible-models";
+import {isAgentSessionNotFoundError} from "nbook/server/agent/session/session-not-found-error";
 
 /**
  * 列出 v3 Agent Profile catalog，并适配旧 profile 工作台 DTO。
@@ -115,8 +116,8 @@ export async function previewAgentProfilePrepare(
     harness: NeuroAgentHarness,
     request: AgentProfilePreparePreviewRequestDto,
 ): Promise<AgentProfilePreparePreviewDto> {
-    const previewSnapshot = request.sessionId ? await harness.repo.readSession(Number(request.sessionId)).catch(() => null) : null;
-    const sessionContext = previewSnapshot ? harness.repo.reduce(previewSnapshot) : await buildPreviewSession(harness, request);
+    const previewSnapshot = request.sessionId ? await harness.repo.readSession(Number(request.sessionId)) : null;
+    const sessionContext = previewSnapshot ? harness.repo.reduce(previewSnapshot) : buildPreviewSession(request);
     const workspaceRoot = absoluteFsPath(harness.repo.rootWorkspace);
     const readyProject = sessionContext.currentProjectRoot
         ? requireActiveReadyProject(projectWorkspaceRef(sessionContext.currentProjectRoot))
@@ -237,6 +238,9 @@ export async function previewAgentProfilePrepare(
                     : null,
             };
         } catch (error) {
+            if (isAgentSessionNotFoundError(error)) {
+                throw error;
+            }
             return {
                 profileKey: request.profileKey,
                 ok: false,
@@ -336,11 +340,7 @@ function buildSchemaDetail(input: {
 /**
  * 构造预览用 session context。传 sessionId 时复用真实 session，否则用请求中的临时历史。
  */
-async function buildPreviewSession(harness: NeuroAgentHarness, request: AgentProfilePreparePreviewRequestDto): Promise<NeuroSessionContext> {
-    if (request.sessionId) {
-        const snapshot = await harness.repo.readSession(Number(request.sessionId));
-        return harness.repo.reduce(snapshot);
-    }
+function buildPreviewSession(request: AgentProfilePreparePreviewRequestDto): NeuroSessionContext {
     return {
         systemPrompt: "",
         messages: (request.historyMessages ?? []).map(toPreviewHistoryMessage),

--- a/packages/neuro-book/server/agent/session/session-identity.test.ts
+++ b/packages/neuro-book/server/agent/session/session-identity.test.ts
@@ -1,0 +1,27 @@
+import {describe, expect, it} from "vitest";
+import {createSessionIdentity, deriveSessionIdentity, resolveSessionIdentity} from "nbook/server/agent/session/session-identity";
+import type {SessionMetadata} from "nbook/server/agent/session/types";
+
+const metadata = (sessionId: number): Omit<SessionMetadata, "sessionIdentity"> => ({
+    schemaVersion: 2,
+    sessionId,
+    profileKey: "leader.default",
+    initial: {},
+    createdAt: 1,
+    kind: "chat",
+});
+
+describe("Session identity", () => {
+    it("新 Session 使用 UUID，旧 header 使用稳定 sha256", () => {
+        expect(createSessionIdentity()).toMatch(/^[0-9a-f-]{36}$/u);
+        const first = deriveSessionIdentity(metadata(1));
+        const second = deriveSessionIdentity({...metadata(1), profileKey: "leader.default"});
+        expect(first).toBe(second);
+        expect(first).toMatch(/^sha256:[0-9a-f]{64}$/u);
+    });
+
+    it("显式 identity 优先于旧 header 派生值", () => {
+        const identity = createSessionIdentity();
+        expect(resolveSessionIdentity({...metadata(1), sessionIdentity: identity})).toBe(identity);
+    });
+});

--- a/packages/neuro-book/server/agent/session/session-identity.ts
+++ b/packages/neuro-book/server/agent/session/session-identity.ts
@@ -1,0 +1,49 @@
+import {createHash, randomUUID} from "node:crypto";
+import type {JsonValue} from "nbook/server/agent/messages/types";
+import type {SessionMetadata} from "nbook/server/agent/session/types";
+import {AgentSessionIdentitySchema, type AgentSessionIdentity} from "nbook/shared/dto/agent-session.dto";
+
+const IDENTITY_PREFIX = "neuro-book:agent-session:v1\u0000";
+
+/** 为新建 Session 生成不会因数字序号冲突的逻辑身份。 */
+export function createSessionIdentity(): AgentSessionIdentity {
+    return randomUUID();
+}
+
+/**
+ * 为没有持久化身份字段的现有 header 生成稳定身份。
+ * 只使用 header，不使用正文、文件路径或当前 project 投影，因此追加历史不会改变结果。
+ */
+export function deriveSessionIdentity(metadata: Omit<SessionMetadata, "sessionIdentity">): AgentSessionIdentity {
+    const payload = {...metadata} as Omit<SessionMetadata, "sessionIdentity"> & {sessionIdentity?: AgentSessionIdentity};
+    delete payload.sessionIdentity;
+    const canonical = stableJson(payload as unknown as JsonValue);
+    return `sha256:${createHash("sha256").update(`${IDENTITY_PREFIX}${canonical}`, "utf8").digest("hex")}`;
+}
+
+/** 读取现有 metadata 后得到运行时必有的 Session identity。 */
+export function resolveSessionIdentity(metadata: SessionMetadata): AgentSessionIdentity {
+    if (metadata.sessionIdentity !== undefined) {
+        const parsed = AgentSessionIdentitySchema.safeParse(metadata.sessionIdentity);
+        if (!parsed.success) {
+            throw new Error("Agent Session identity 格式非法。");
+        }
+        return parsed.data;
+    }
+    return deriveSessionIdentity(metadata);
+}
+
+/** 递归排序 object key，且与 JSON.stringify 一样忽略 object 中的 undefined。 */
+function stableJson(value: JsonValue | undefined): string {
+    if (value === undefined) return "null";
+    if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+        return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+        return `[${value.map((item) => stableJson(item)).join(",")}]`;
+    }
+    return `{${Object.keys(value).sort().flatMap((key) => {
+        const child = value[key];
+        return child === undefined ? [] : [`${JSON.stringify(key)}:${stableJson(child)}`];
+    }).join(",")}}`;
+}

--- a/packages/neuro-book/server/agent/session/session-repo.ts
+++ b/packages/neuro-book/server/agent/session/session-repo.ts
@@ -23,6 +23,7 @@ import type {
     SessionEntryDraft,
 } from "nbook/server/agent/session/types";
 import type {AgentSessionListQueryDto, AgentSessionSummaryDto} from "nbook/shared/dto/agent-session.dto";
+import {AgentSessionIdentitySchema} from "nbook/shared/dto/agent-session.dto";
 import {reduceRelationLedger} from "nbook/server/agent/session/relation-ledger";
 import {storedMessageText} from "nbook/server/agent/messages/stored-message-presentation";
 import {PUBLIC_TREE_TEXT_BYTES} from "nbook/server/agent/events/public-event-policy";
@@ -31,6 +32,7 @@ import {chatEntryKind} from "nbook/server/agent/events/public-chat-entry-project
 import {parseDurableSessionModelRef} from "nbook/server/agent/session/session-model-redaction";
 import {ProjectRootDtoSchema} from "nbook/shared/dto/project.dto";
 import {AgentSessionNotFoundError} from "nbook/server/agent/session/session-not-found-error";
+import {resolveSessionIdentity, createSessionIdentity} from "nbook/server/agent/session/session-identity";
 
 type CreateSessionInput = {
     profileKey: string;
@@ -109,6 +111,7 @@ export class JsonlSessionRepository {
         const metadata: SessionMetadata = {
             schemaVersion: 2,
             sessionId,
+            sessionIdentity: createSessionIdentity(),
             profileKey: input.profileKey,
             initial: input.initial,
             currentProjectRoot: input.currentProjectRoot,
@@ -157,7 +160,7 @@ export class JsonlSessionRepository {
             this.assertStoredEntry(entry);
         }
         return {
-            metadata: this.effectiveMetadata(this.assertMetadata(header.metadata), entries),
+            metadata: this.effectiveMetadata(this.normalizeHeader(sessionId, header.metadata), entries),
             entries,
             leafId: this.resolveLeaf(entries),
         };
@@ -192,7 +195,7 @@ export class JsonlSessionRepository {
                 }
                 const record = JSON.parse(line) as SessionFileRecord;
                 if (record.kind === "header") {
-                    metadata = this.assertMetadata(record.metadata);
+                    metadata = this.normalizeHeader(sessionId, record.metadata);
                     continue;
                 }
                 const recordEntries = record.kind === "entry"
@@ -250,7 +253,7 @@ export class JsonlSessionRepository {
                 }
                 const record = JSON.parse(line) as SessionFileRecord;
                 if (record.kind === "header") {
-                    metadata = this.assertMetadata(record.metadata);
+                    metadata = this.normalizeHeader(sessionId, record.metadata);
                     continue;
                 }
                 const recordEntries = record.kind === "entry"
@@ -706,6 +709,7 @@ export class JsonlSessionRepository {
 
         return {
             sessionId: snapshot.metadata.sessionId,
+            sessionIdentity: resolveSessionIdentity(snapshot.metadata),
             profileKey: context.profileKey,
             currentProjectRoot: snapshot.metadata.currentProjectRoot,
             migrationReview: snapshot.metadata.migrationReview,
@@ -964,6 +968,7 @@ export class JsonlSessionRepository {
         const allowedKeys = new Set<keyof SessionMetadata>([
             "schemaVersion",
             "sessionId",
+            "sessionIdentity",
             "profileKey",
             "initial",
             "currentProjectRoot",
@@ -981,6 +986,10 @@ export class JsonlSessionRepository {
             throw new Error(`Agent Session schema v2 metadata包含已删除或未知字段：${unknownKeys.sort().join(", ")}`);
         }
         if (metadata.schemaVersion !== 2) throw new Error("Agent Session schema不是v2，请先运行应用状态迁移。");
+        if (metadata.sessionIdentity !== undefined) {
+            const parsedIdentity = AgentSessionIdentitySchema.safeParse(metadata.sessionIdentity);
+            if (!parsedIdentity.success) throw new Error("Agent Session identity 格式非法。");
+        }
         if (metadata.currentProjectRoot !== undefined) ProjectRootDtoSchema.parse(metadata.currentProjectRoot);
         if (metadata.migrationReview) {
             if (metadata.migrationReview.status !== "required"
@@ -990,6 +999,15 @@ export class JsonlSessionRepository {
             }
         }
         return {...metadata};
+    }
+
+    /** 验证文件名/请求 ID，并把旧 header 归一化为带 identity 的运行时 metadata。 */
+    private normalizeHeader(sessionId: SessionId, metadata: SessionMetadata): SessionMetadata {
+        const header = this.assertMetadata(metadata);
+        if (header.sessionId !== sessionId) {
+            throw new Error(`session ${sessionId} 文件 header 与请求 ID 不一致`);
+        }
+        return {...header, sessionIdentity: resolveSessionIdentity(header)};
     }
 
     /** 将append-only重绑事实投影到本次读取的有效metadata。 */

--- a/packages/neuro-book/server/agent/session/types.ts
+++ b/packages/neuro-book/server/agent/session/types.ts
@@ -5,6 +5,7 @@ import type {VariableJsonPatchOperation, VariableNamespace} from "nbook/server/a
 import type {AgentMode} from "nbook/shared/dto/agent-session.dto";
 import type {ChatEntryKind} from "nbook/shared/dto/agent-public-event.dto";
 import type {AttachmentRef} from "nbook/shared/dto/agent-attachment.dto";
+import type {AgentSessionIdentity} from "nbook/shared/dto/agent-session.dto";
 
 export type SessionId = number;
 export type SessionEntryId = string;
@@ -12,6 +13,8 @@ export type SessionEntryId = string;
 export type SessionMetadata = {
     schemaVersion: 2;
     sessionId: SessionId;
+    /** 新 Session 持久化 UUID；旧文件读取时由原始 header 派生。 */
+    sessionIdentity?: AgentSessionIdentity;
     profileKey: string;
     initial: JsonValue;
     /** 缺失表示 Workspace Root Session；非空时必须是单段 Project root。 */

--- a/packages/neuro-book/server/agent/session/write-plan.test.ts
+++ b/packages/neuro-book/server/agent/session/write-plan.test.ts
@@ -31,6 +31,7 @@ describe("SessionWriteExecutor", () => {
                 return {
                     summary: {
                         sessionId,
+                        sessionIdentity: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
                         profileKey: "leader.default",
                         status: "idle",
                         updatedAt: 1,
@@ -231,6 +232,7 @@ describe("SessionWriteExecutor", () => {
                 return {
                     summary: {
                         sessionId,
+                        sessionIdentity: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
                         profileKey: "leader.default",
                         status: "idle",
                         updatedAt: 1,
@@ -318,6 +320,7 @@ describe("SessionWriteExecutor", () => {
                 return {
                     summary: {
                         sessionId,
+                        sessionIdentity: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
                         profileKey: "leader.default",
                         status: "idle",
                         updatedAt: 1,

--- a/packages/neuro-book/server/api/agent/profiles/compile.post.test.ts
+++ b/packages/neuro-book/server/api/agent/profiles/compile.post.test.ts
@@ -3,6 +3,7 @@ import {join} from "node:path";
 
 import {beforeEach, describe, expect, it, vi} from "vitest";
 
+
 describe("POST /api/agent/profiles/compile", () => {
     beforeEach(() => {
         vi.resetModules();
@@ -27,6 +28,7 @@ describe("POST /api/agent/profiles/compile", () => {
             const {createRuntimePaths} = await import("nbook/server/runtime/paths/runtime-paths");
             const {absoluteFsPath} = await import("nbook/server/runtime/paths/file-path");
             return {
+                ...await vi.importActual<typeof import("nbook/server/agent/http")>("nbook/server/agent/http"),
                 useAgentHarness: vi.fn(() => ({
                     profiles: {},
                     runtimePaths: createRuntimePaths({
@@ -69,6 +71,76 @@ describe("POST /api/agent/profiles/compile", () => {
                 code: "PROJECT_NOT_OPEN",
                 projectRoot: "profile-compile-not-open",
             },
+        });
+    }, 10_000);
+
+    it("compile preview 保留关联 Session 缺失的 409", async () => {
+        vi.doMock("nbook/server/utils/novel-chapter", () => ({
+            validateBody: vi.fn(async () => ({
+                fileName: "builtin/writer.profile.tsx",
+                dryRun: false,
+                preview: true,
+                sessionId: "7",
+            })),
+        }));
+        vi.doMock("nbook/server/agent/http", async () => ({
+            ...await vi.importActual<typeof import("nbook/server/agent/http")>("nbook/server/agent/http"),
+            useAgentHarness: vi.fn(() => ({profiles: {}, runtimePaths: {}})),
+        }));
+        vi.doMock("nbook/server/agent/profiles/profile-compile-worker", () => ({
+            useProfileCompileWorker: vi.fn(() => ({
+                compile: vi.fn(async () => ({
+                    ok: true,
+                    stale: false,
+                    detail: null,
+                    preview: null,
+                    issues: [],
+                })),
+            })),
+        }));
+        vi.doMock("nbook/server/agent/profiles/workbench-service", () => ({
+            readProfileSource: vi.fn(async () => ({manifest: {key: "writer"}})),
+        }));
+        vi.doMock("nbook/server/agent/profiles/profile-workbench-roots", () => ({
+            profileWorkbenchRootsFromRuntime: vi.fn(() => ({})),
+        }));
+        vi.doMock("nbook/server/agent/profiles/profile-http-service", () => ({
+            previewAgentProfilePrepare: vi.fn(async () => {
+                throw Object.assign(new Error("dependency missing"), {
+                    name: "AgentSessionNotFoundError",
+                    code: "SESSION_NOT_FOUND",
+                    sessionId: 8,
+                });
+            }),
+        }));
+
+        const handler = (await import("nbook/server/api/agent/profiles/compile.post")).default;
+
+        await expect(handler({} as never)).rejects.toMatchObject({
+            statusCode: 409,
+            data: {code: "SESSION_DEPENDENCY_NOT_FOUND"},
+        });
+    });
+
+    it.each(["abc", "NaN", "0", "-1", "9007199254740992"])("拒绝无效 Session ID %s", async (sessionId) => {
+        vi.doMock("nbook/server/utils/novel-chapter", () => ({
+            validateBody: vi.fn(async () => ({
+                fileName: "builtin/writer.profile.tsx",
+                dryRun: false,
+                preview: true,
+                sessionId,
+            })),
+        }));
+        vi.doMock("nbook/server/agent/http", async () => ({
+            ...await vi.importActual<typeof import("nbook/server/agent/http")>("nbook/server/agent/http"),
+            useAgentHarness: vi.fn(),
+        }));
+
+        const handler = (await import("nbook/server/api/agent/profiles/compile.post")).default;
+
+        await expect(handler({} as never)).rejects.toMatchObject({
+            statusCode: 400,
+            message: "sessionId 必须是正整数",
         });
     });
 });

--- a/packages/neuro-book/server/api/agent/profiles/compile.post.ts
+++ b/packages/neuro-book/server/api/agent/profiles/compile.post.ts
@@ -1,7 +1,7 @@
 import {validateBody} from "nbook/server/utils/novel-chapter";
 import {useProfileCompileWorker} from "nbook/server/agent/profiles/profile-compile-worker";
 import {AgentProfileCompileRequestDtoSchema} from "nbook/shared/dto/agent-profile.dto";
-import {useAgentHarness} from "nbook/server/agent/http";
+import {requireAgentSessionIdValue, useAgentHarness, withAgentHttpError} from "nbook/server/agent/http";
 import {previewAgentProfilePrepare} from "nbook/server/agent/profiles/profile-http-service";
 import {readProfileSource} from "nbook/server/agent/profiles/workbench-service";
 import {withProjectHttpError} from "nbook/server/api/projects/project-http-error";
@@ -10,32 +10,36 @@ import {profileWorkbenchRootsFromRuntime} from "nbook/server/agent/profiles/prof
 /**
  * 手动编译用户 profile 源码。真实 TSX loader 在后台 worker 中执行。
  */
-export default defineEventHandler((event) => withProjectHttpError(async () => {
+export default defineEventHandler(async (event) => {
     const body = await validateBody(event, AgentProfileCompileRequestDtoSchema);
-    const harness = useAgentHarness();
-    const runtimePaths = harness.runtimePaths;
-    if (!runtimePaths) {
-        throw new Error("Profile compile API 需要显式 RuntimePaths。");
-    }
-    const roots = profileWorkbenchRootsFromRuntime(runtimePaths);
-    const result = await useProfileCompileWorker(roots.profileRoot, runtimePaths, "workspace/.nbook/agent/profiles").compile(body, {
-        mode: "in_process",
-        registry: harness.profiles,
+    const requestSessionId = requireAgentSessionIdValue(body.sessionId);
+    const operation = () => withProjectHttpError(async () => {
+        const harness = useAgentHarness();
+        const runtimePaths = harness.runtimePaths;
+        if (!runtimePaths) {
+            throw new Error("Profile compile API 需要显式 RuntimePaths。");
+        }
+        const roots = profileWorkbenchRootsFromRuntime(runtimePaths);
+        const result = await useProfileCompileWorker(roots.profileRoot, runtimePaths, "workspace/.nbook/agent/profiles").compile(body, {
+            mode: "in_process",
+            registry: harness.profiles,
+        });
+        const detail = await readProfileSource(harness.profiles, {fileName: body.fileName}, roots).catch(() => result.detail);
+        const preview = body.preview && detail?.manifest?.key
+            ? await previewAgentProfilePrepare(harness, {
+                profileKey: detail.manifest.key,
+                sessionId: body.sessionId,
+                initial: body.initial,
+                initialOverrides: body.initialOverrides,
+            })
+            : result.preview ?? null;
+        return {
+            ...result,
+            ok: result.ok && (!preview || preview.ok),
+            detail,
+            preview,
+            issues: preview ? [...result.issues, ...preview.issues] : result.issues,
+        };
     });
-    const detail = await readProfileSource(harness.profiles, {fileName: body.fileName}, roots).catch(() => result.detail);
-    const preview = body.preview && detail?.manifest?.key
-        ? await previewAgentProfilePrepare(harness, {
-            profileKey: detail.manifest.key,
-            sessionId: body.sessionId,
-            initial: body.initial,
-            initialOverrides: body.initialOverrides,
-        })
-        : result.preview ?? null;
-    return {
-        ...result,
-        ok: result.ok && (!preview || preview.ok),
-        detail,
-        preview,
-        issues: preview ? [...result.issues, ...preview.issues] : result.issues,
-    };
-}));
+    return withAgentHttpError(requestSessionId, operation);
+});

--- a/packages/neuro-book/server/api/agent/profiles/preview-prepare.post.test.ts
+++ b/packages/neuro-book/server/api/agent/profiles/preview-prepare.post.test.ts
@@ -3,6 +3,7 @@ import {join} from "node:path";
 
 import {beforeEach, describe, expect, it, vi} from "vitest";
 
+
 describe("POST /api/agent/profiles/preview-prepare", () => {
     beforeEach(() => {
         vi.resetModules();
@@ -29,6 +30,7 @@ describe("POST /api/agent/profiles/preview-prepare", () => {
             const {createRuntimePaths} = await import("nbook/server/runtime/paths/runtime-paths");
             const {absoluteFsPath} = await import("nbook/server/runtime/paths/file-path");
             return {
+                ...await vi.importActual<typeof import("nbook/server/agent/http")>("nbook/server/agent/http"),
                 useAgentHarness: vi.fn(() => ({
                     profiles: {},
                     runtimePaths: createRuntimePaths({
@@ -61,5 +63,88 @@ describe("POST /api/agent/profiles/preview-prepare", () => {
                 projectRoot: "profile-preview-not-open",
             },
         });
-    });
+    }, 10_000);
+
+    it.each([
+        [7, 404, "SESSION_NOT_FOUND"],
+        [8, 409, "SESSION_DEPENDENCY_NOT_FOUND"],
+    ] as const)("in-process preview 将缺失 Session %i 映射为稳定生命周期错误", async (missingSessionId, statusCode, code) => {
+        vi.doMock("nbook/server/utils/novel-chapter", () => ({
+            validateBody: vi.fn(async () => ({
+                profileKey: "writer",
+                sessionId: "7",
+            })),
+        }));
+        vi.doMock("nbook/server/agent/http", async () => ({
+            ...await vi.importActual<typeof import("nbook/server/agent/http")>("nbook/server/agent/http"),
+            useAgentHarness: vi.fn(() => ({profiles: {}})),
+        }));
+        vi.doMock("nbook/server/agent/profiles/profile-http-service", () => ({
+            previewAgentProfilePrepare: vi.fn(async () => {
+                throw Object.assign(new Error("missing"), {
+                    name: "AgentSessionNotFoundError",
+                    code: "SESSION_NOT_FOUND",
+                    sessionId: missingSessionId,
+                });
+            }),
+        }));
+        vi.doMock("nbook/server/agent/profiles/profile-compile-worker", () => ({
+            useProfileCompileWorker: vi.fn(),
+        }));
+
+        const handler = (await import("nbook/server/api/agent/profiles/preview-prepare.post")).default;
+
+        await expect(handler({} as never)).rejects.toMatchObject({
+            statusCode,
+            data: {code},
+        });
+    }, 10_000);
+
+    it("未提供 Session ID 仍映射关联 Session 缺失为 409", async () => {
+        vi.doMock("nbook/server/utils/novel-chapter", () => ({
+            validateBody: vi.fn(async () => ({
+                profileKey: "writer",
+            })),
+        }));
+        vi.doMock("nbook/server/agent/http", async () => ({
+            ...await vi.importActual<typeof import("nbook/server/agent/http")>("nbook/server/agent/http"),
+            useAgentHarness: vi.fn(() => ({profiles: {}})),
+        }));
+        vi.doMock("nbook/server/agent/profiles/profile-http-service", () => ({
+            previewAgentProfilePrepare: vi.fn(async () => {
+                throw Object.assign(new Error("missing dependency"), {
+                    name: "AgentSessionNotFoundError",
+                    code: "SESSION_NOT_FOUND",
+                    sessionId: 8,
+                });
+            }),
+        }));
+
+        const handler = (await import("nbook/server/api/agent/profiles/preview-prepare.post")).default;
+
+        await expect(handler({} as never)).rejects.toMatchObject({
+            statusCode: 409,
+            data: {code: "SESSION_DEPENDENCY_NOT_FOUND"},
+        });
+    }, 10_000);
+
+    it.each(["abc", "NaN", "0", "-1", "9007199254740992"])("拒绝无效 Session ID %s", async (sessionId) => {
+        vi.doMock("nbook/server/utils/novel-chapter", () => ({
+            validateBody: vi.fn(async () => ({
+                profileKey: "writer",
+                sessionId,
+            })),
+        }));
+        vi.doMock("nbook/server/agent/http", async () => ({
+            ...await vi.importActual<typeof import("nbook/server/agent/http")>("nbook/server/agent/http"),
+            useAgentHarness: vi.fn(),
+        }));
+
+        const handler = (await import("nbook/server/api/agent/profiles/preview-prepare.post")).default;
+
+        await expect(handler({} as never)).rejects.toMatchObject({
+            statusCode: 400,
+            message: "sessionId 必须是正整数",
+        });
+    }, 10_000);
 });

--- a/packages/neuro-book/server/api/agent/profiles/preview-prepare.post.ts
+++ b/packages/neuro-book/server/api/agent/profiles/preview-prepare.post.ts
@@ -1,5 +1,5 @@
 import {validateBody} from "nbook/server/utils/novel-chapter";
-import {useAgentHarness} from "nbook/server/agent/http";
+import {requireAgentSessionIdValue, useAgentHarness, withAgentHttpError} from "nbook/server/agent/http";
 import {previewAgentProfilePrepare} from "nbook/server/agent/profiles/profile-http-service";
 import {useProfileCompileWorker} from "nbook/server/agent/profiles/profile-compile-worker";
 import {profileWorkbenchRootsFromRuntime} from "nbook/server/agent/profiles/profile-workbench-roots";
@@ -9,36 +9,40 @@ import {withProjectHttpError} from "nbook/server/api/projects/project-http-error
 /**
  * 调用真实 profile.prepare 生成 TSX Profile 预览。
  */
-export default defineEventHandler((event) => withProjectHttpError(async () => {
+export default defineEventHandler(async (event) => {
     const body = await validateBody(event, AgentProfilePreparePreviewRequestDtoSchema);
-    const harness = useAgentHarness();
-    if (!body.sourceOverride) {
-        return previewAgentProfilePrepare(harness, body);
-    }
-    const runtimePaths = harness.runtimePaths;
-    if (!runtimePaths) {
-        throw new Error("Profile preview API 需要显式 RuntimePaths。");
-    }
-    const roots = profileWorkbenchRootsFromRuntime(runtimePaths);
-    const result = await useProfileCompileWorker(roots.profileRoot, runtimePaths, "workspace/.nbook/agent/profiles").compile({
-        fileName: body.sourceOverride.fileName,
-        source: body.sourceOverride.source,
-        dryRun: true,
-        preview: true,
-        sessionId: body.sessionId,
-        initial: body.initial,
-        initialOverrides: body.initialOverrides,
+    const requestSessionId = requireAgentSessionIdValue(body.sessionId);
+    const operation = () => withProjectHttpError(async () => {
+        const harness = useAgentHarness();
+        if (!body.sourceOverride) {
+            return previewAgentProfilePrepare(harness, body);
+        }
+        const runtimePaths = harness.runtimePaths;
+        if (!runtimePaths) {
+            throw new Error("Profile preview API 需要显式 RuntimePaths。");
+        }
+        const roots = profileWorkbenchRootsFromRuntime(runtimePaths);
+        const result = await useProfileCompileWorker(roots.profileRoot, runtimePaths, "workspace/.nbook/agent/profiles").compile({
+            fileName: body.sourceOverride.fileName,
+            source: body.sourceOverride.source,
+            dryRun: true,
+            preview: true,
+            sessionId: body.sessionId,
+            initial: body.initial,
+            initialOverrides: body.initialOverrides,
+        });
+        if (result.preview) {
+            return result.preview;
+        }
+        return {
+            profileKey: body.profileKey,
+            ok: false,
+            issues: result.issues,
+            messages: [],
+            persistedMessageCount: 0,
+            variables: [],
+            reportResultSchema: null,
+        };
     });
-    if (result.preview) {
-        return result.preview;
-    }
-    return {
-        profileKey: body.profileKey,
-        ok: false,
-        issues: result.issues,
-        messages: [],
-        persistedMessageCount: 0,
-        variables: [],
-        reportResultSchema: null,
-    };
-}));
+    return withAgentHttpError(requestSessionId, operation);
+});

--- a/packages/neuro-book/server/api/agent/sessions/[sessionId]/context-inspection.get.test.ts
+++ b/packages/neuro-book/server/api/agent/sessions/[sessionId]/context-inspection.get.test.ts
@@ -1,0 +1,62 @@
+import type {H3Event} from "h3";
+import {afterAll, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    missingSessionId: 12,
+    getSessionContextInspection: vi.fn(),
+}));
+
+vi.mock("h3", async (importOriginal) => ({
+    ...await importOriginal<typeof import("h3")>(),
+    getQuery: () => ({}),
+}));
+
+vi.mock("nbook/server/agent/http", async () => {
+    const actual = await vi.importActual<typeof import("nbook/server/agent/http")>("nbook/server/agent/http");
+    return {
+        ...actual,
+        requireAgentSessionId: () => 12,
+        useAgentHarness: () => ({
+            getSessionContextInspection: mocks.getSessionContextInspection,
+        }),
+    };
+});
+
+let handler: (event: H3Event) => Promise<unknown>;
+const originalDefineEventHandler = (globalThis as typeof globalThis & {defineEventHandler?: unknown}).defineEventHandler;
+
+beforeAll(async () => {
+    vi.stubGlobal("defineEventHandler", (routeHandler: typeof handler) => routeHandler);
+    handler = (await import("nbook/server/api/agent/sessions/[sessionId]/context-inspection.get")).default;
+});
+
+afterAll(() => {
+    vi.unstubAllGlobals();
+    (globalThis as typeof globalThis & {defineEventHandler?: unknown}).defineEventHandler = originalDefineEventHandler;
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.missingSessionId = 12;
+    mocks.getSessionContextInspection.mockImplementation(async () => {
+        throw Object.assign(new Error("missing"), {
+            name: "AgentSessionNotFoundError",
+            code: "SESSION_NOT_FOUND",
+            sessionId: mocks.missingSessionId,
+        });
+    });
+});
+
+describe("GET /api/agent/sessions/:sessionId/context-inspection", () => {
+    it.each([
+        [12, 404, "SESSION_NOT_FOUND"],
+        [13, 409, "SESSION_DEPENDENCY_NOT_FOUND"],
+    ] as const)("按缺失 Session %i 保留目标或关联生命周期错误", async (missingSessionId, statusCode, code) => {
+        mocks.missingSessionId = missingSessionId;
+
+        await expect(handler({} as H3Event)).rejects.toMatchObject({
+            statusCode,
+            data: {code},
+        });
+    });
+});

--- a/packages/neuro-book/server/api/agent/sessions/[sessionId]/context-inspection.get.ts
+++ b/packages/neuro-book/server/api/agent/sessions/[sessionId]/context-inspection.get.ts
@@ -1,5 +1,5 @@
-import {createError, getQuery, getRouterParam} from "h3";
-import {useAgentHarness} from "nbook/server/agent/http";
+import {createError, getQuery} from "h3";
+import {requireAgentSessionId, useAgentHarness, withAgentSessionHttpError} from "nbook/server/agent/http";
 import {isValidTraceId} from "nbook/server/agent/observability/pi-trace-reader";
 import type {AgentContextInspectionDto} from "nbook/shared/dto/agent-context-inspection.dto";
 
@@ -10,13 +10,13 @@ import type {AgentContextInspectionDto} from "nbook/shared/dto/agent-context-ins
  * `traceId` 会直接参与文件路径拼接，必须过白名单防路径穿越。
  */
 export default defineEventHandler(async (event): Promise<AgentContextInspectionDto> => {
-    const sessionId = Number(getRouterParam(event, "sessionId"));
-    if (!Number.isInteger(sessionId) || sessionId <= 0) {
-        throw createError({statusCode: 400, message: "sessionId 必须是正整数"});
-    }
+    const sessionId = requireAgentSessionId(event);
     const rawTraceId = getQuery(event).traceId;
     if (rawTraceId !== undefined && (typeof rawTraceId !== "string" || !isValidTraceId(rawTraceId))) {
         throw createError({statusCode: 400, message: "traceId 必须是 trace 序号"});
     }
-    return useAgentHarness().getSessionContextInspection(sessionId, rawTraceId);
+    return withAgentSessionHttpError(
+        sessionId,
+        () => useAgentHarness().getSessionContextInspection(sessionId, rawTraceId),
+    );
 });

--- a/packages/neuro-book/server/api/agent/sessions/[sessionId]/current-project.post.test.ts
+++ b/packages/neuro-book/server/api/agent/sessions/[sessionId]/current-project.post.test.ts
@@ -1,6 +1,8 @@
 import {beforeEach, describe, expect, it, vi} from "vitest";
 import {createError} from "h3";
 import {ProjectLifecycleError} from "nbook/server/workspace-files/project-lifecycle";
+import type {NeuroAgentHarness} from "nbook/server/agent/harness/neuro-agent-harness";
+import {AgentSessionNotFoundError} from "nbook/server/agent/session/session-not-found-error";
 
 const mocks = vi.hoisted(() => ({
     requireAgentSessionId: vi.fn(() => 12),
@@ -8,10 +10,21 @@ const mocks = vi.hoisted(() => ({
     validateBody: vi.fn(),
 }));
 
-vi.mock("nbook/server/agent/http", () => ({
-    requireAgentSessionId: mocks.requireAgentSessionId,
-    updateAgentSessionCurrentProject: mocks.updateAgentSessionCurrentProject,
-}));
+vi.mock("nbook/server/agent/http", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("nbook/server/agent/http")>();
+    return {
+        ...actual,
+        requireAgentSessionId: mocks.requireAgentSessionId,
+        updateAgentSessionCurrentProject: (
+            sessionId: number,
+            body: Parameters<typeof actual.updateAgentSessionCurrentProject>[1],
+        ) => actual.updateAgentSessionCurrentProject(
+            sessionId,
+            body,
+            {updateCurrentProject: mocks.updateAgentSessionCurrentProject} as NeuroAgentHarness,
+        ),
+    };
+});
 
 vi.mock("nbook/server/utils/novel-chapter", () => ({
     validateBody: mocks.validateBody,
@@ -35,8 +48,8 @@ describe("POST /api/agent/sessions/:sessionId/current-project", () => {
             sessionId: 12,
             currentProjectRoot: "novel-a",
         });
-        expect(mocks.updateAgentSessionCurrentProject).toHaveBeenCalledWith(12, {projectRoot: "novel-a"});
-    });
+        expect(mocks.updateAgentSessionCurrentProject).toHaveBeenCalledWith(12, "novel-a");
+    }, 10_000);
 
     it("通过统一 Project HTTP mapper 返回不存在 Project 的稳定 404", async () => {
         mocks.validateBody.mockResolvedValue({projectRoot: "missing-project"});
@@ -64,6 +77,20 @@ describe("POST /api/agent/sessions/:sessionId/current-project", () => {
         await expect(handler({} as never)).rejects.toMatchObject({
             statusCode: 409,
             data: {code: "current_project_rebind_forbidden", projectRoot: "novel-a"},
+        });
+    }, 10_000);
+
+    it.each([
+        [12, 404, "SESSION_NOT_FOUND"],
+        [13, 409, "SESSION_DEPENDENCY_NOT_FOUND"],
+    ] as const)("使用生产 Session mapper 区分主/关联缺失 %i", async (missingSessionId, statusCode, code) => {
+        mocks.validateBody.mockResolvedValue({projectRoot: "novel-a"});
+        mocks.updateAgentSessionCurrentProject.mockRejectedValue(new AgentSessionNotFoundError(missingSessionId));
+        const handler = (await import("nbook/server/api/agent/sessions/[sessionId]/current-project.post")).default;
+
+        await expect(handler({} as never)).rejects.toMatchObject({
+            statusCode,
+            data: {code},
         });
     });
 });

--- a/packages/neuro-book/server/api/agent/sessions/[sessionId]/entries/[entryId]/attachments/[contentIndex].get.test.ts
+++ b/packages/neuro-book/server/api/agent/sessions/[sessionId]/entries/[entryId]/attachments/[contentIndex].get.test.ts
@@ -19,6 +19,11 @@ const mocks = vi.hoisted(() => ({
         code: "SESSION_NOT_FOUND",
         sessionId: 12,
     }),
+    sessionDependencyNotFoundError: Object.assign(new Error("Session dependency missing"), {
+        name: "AgentSessionNotFoundError",
+        code: "SESSION_NOT_FOUND",
+        sessionId: 13,
+    }),
 }));
 
 vi.mock("h3", async (importOriginal) => ({
@@ -34,22 +39,16 @@ vi.mock("h3", async (importOriginal) => ({
     },
 }));
 
-vi.mock("nbook/server/agent/http", () => ({
-    isAgentSessionNotFoundHttpError: (error: unknown) => typeof error === "object"
-        && error !== null
-        && "data" in error
-        && (error as {data?: {code?: string}}).data?.code === "SESSION_NOT_FOUND",
-    mapAgentHttpError: (error: unknown) => error === mocks.sessionNotFoundError
-        ? Object.assign(new Error("Session 不存在或已不可用"), {
-            statusCode: 404,
-            data: {code: "SESSION_NOT_FOUND"},
-        })
-        : error,
-    requireAgentSessionId: (event: TestEvent) => event.sessionId,
-    useAgentHarness: () => ({
-        resolveSessionAttachment: mocks.resolveSessionAttachment,
-    }),
-}));
+vi.mock("nbook/server/agent/http", async () => {
+    const actual = await vi.importActual<typeof import("nbook/server/agent/http")>("nbook/server/agent/http");
+    return {
+        ...actual,
+        requireAgentSessionId: (event: TestEvent) => event.sessionId,
+        useAgentHarness: () => ({
+            resolveSessionAttachment: mocks.resolveSessionAttachment,
+        }),
+    };
+});
 
 vi.mock("nbook/server/media/image-variant-runtime", () => ({
     useImageVariantModule: () => ({render: mocks.render}),
@@ -110,6 +109,15 @@ describe("GET /api/agent/sessions/:sessionId/entries/:entryId/attachments/:conte
         await expect(handler(createEvent())).rejects.toMatchObject({
             statusCode: 404,
             data: {code: "SESSION_NOT_FOUND"},
+        });
+    });
+
+    it("保留 Session Dependency Not Found，不改写为 Attachment Not Found", async () => {
+        mocks.resolveSessionAttachment.mockRejectedValue(mocks.sessionDependencyNotFoundError);
+
+        await expect(handler(createEvent())).rejects.toMatchObject({
+            statusCode: 409,
+            data: {code: "SESSION_DEPENDENCY_NOT_FOUND"},
         });
     });
 

--- a/packages/neuro-book/server/api/agent/sessions/[sessionId]/entries/[entryId]/attachments/[contentIndex].get.ts
+++ b/packages/neuro-book/server/api/agent/sessions/[sessionId]/entries/[entryId]/attachments/[contentIndex].get.ts
@@ -1,6 +1,6 @@
 import {createError, getRequestHeader, getRouterParam, setResponseHeader, setResponseStatus} from "h3";
 import {canonicalImageMime, imageMimeType} from "nbook/server/agent/attachments/agent-attachment-codec";
-import {isAgentSessionNotFoundHttpError, mapAgentHttpError, requireAgentSessionId, useAgentHarness} from "nbook/server/agent/http";
+import {isAgentSessionLifecycleHttpError, mapAgentHttpError, requireAgentSessionId, useAgentHarness} from "nbook/server/agent/http";
 import {withProjectHttpError} from "nbook/server/api/projects/project-http-error";
 import {ImageVariantError, type ImageVariantSpec} from "nbook/server/media/image-variant-contract";
 import {imageVariantHttpError, imageVariantSpecFromEvent} from "nbook/server/media/image-variant-http";
@@ -26,8 +26,8 @@ export default defineEventHandler(async (event) => withProjectHttpError(async ()
         if (isProjectNotOpenError(error)) {
             throw error;
         }
-        const mapped = mapAgentHttpError(error);
-        if (isAgentSessionNotFoundHttpError(mapped)) {
+        const mapped = mapAgentHttpError(error, sessionId);
+        if (isAgentSessionLifecycleHttpError(mapped)) {
             throw mapped;
         }
         setResponseHeader(event, "Cache-Control", "no-store");

--- a/packages/neuro-book/server/api/agent/sessions/[sessionId]/entries/[entryId]/user-content.get.test.ts
+++ b/packages/neuro-book/server/api/agent/sessions/[sessionId]/entries/[entryId]/user-content.get.test.ts
@@ -10,14 +10,17 @@ vi.mock("h3", async (importOriginal) => ({
     getRouterParam: (_event: H3Event, name: string) => name === "entryId" ? "entry-1" : undefined,
 }));
 
-vi.mock("nbook/server/agent/http", () => ({
-    getAgentSessionUserContent: mocks.getAgentSessionUserContent,
-    isAgentSessionNotFoundHttpError: (error: unknown) => typeof error === "object"
-        && error !== null
-        && "data" in error
-        && (error as {data?: {code?: string}}).data?.code === "SESSION_NOT_FOUND",
-    requireAgentSessionId: () => 12,
-}));
+vi.mock("nbook/server/agent/http", async () => {
+    const actual = await vi.importActual<typeof import("nbook/server/agent/http")>("nbook/server/agent/http");
+    return {
+        ...actual,
+        requireAgentSessionId: () => 12,
+        getAgentSessionUserContent: (sessionId: number, entryId: string) => actual.withAgentSessionHttpError(
+            sessionId,
+            () => mocks.getAgentSessionUserContent(sessionId, entryId),
+        ),
+    };
+});
 
 vi.mock("nbook/server/api/projects/project-http-error", () => ({
     withProjectHttpError: async <T>(operation: () => Promise<T>): Promise<T> => operation(),
@@ -46,14 +49,28 @@ beforeEach(() => {
 
 describe("GET /api/agent/sessions/:sessionId/entries/:entryId/user-content", () => {
     it("保留 Session Not Found，不改写为 User Message Not Found", async () => {
-        mocks.getAgentSessionUserContent.mockRejectedValue(Object.assign(new Error("Session 不存在或已不可用"), {
-            statusCode: 404,
-            data: {code: "SESSION_NOT_FOUND"},
+        mocks.getAgentSessionUserContent.mockRejectedValue(Object.assign(new Error("missing"), {
+            name: "AgentSessionNotFoundError",
+            code: "SESSION_NOT_FOUND",
+            sessionId: 12,
         }));
 
         await expect(handler({} as H3Event)).rejects.toMatchObject({
             statusCode: 404,
             data: {code: "SESSION_NOT_FOUND"},
+        });
+    });
+
+    it("保留 Session Dependency Not Found，不改写为 User Message Not Found", async () => {
+        mocks.getAgentSessionUserContent.mockRejectedValue(Object.assign(new Error("missing"), {
+            name: "AgentSessionNotFoundError",
+            code: "SESSION_NOT_FOUND",
+            sessionId: 13,
+        }));
+
+        await expect(handler({} as H3Event)).rejects.toMatchObject({
+            statusCode: 409,
+            data: {code: "SESSION_DEPENDENCY_NOT_FOUND"},
         });
     });
 

--- a/packages/neuro-book/server/api/agent/sessions/[sessionId]/entries/[entryId]/user-content.get.ts
+++ b/packages/neuro-book/server/api/agent/sessions/[sessionId]/entries/[entryId]/user-content.get.ts
@@ -1,5 +1,5 @@
 import {createError, getRouterParam} from "h3";
-import {getAgentSessionUserContent, isAgentSessionNotFoundHttpError, requireAgentSessionId} from "nbook/server/agent/http";
+import {getAgentSessionUserContent, isAgentSessionLifecycleHttpError, requireAgentSessionId} from "nbook/server/agent/http";
 import {withProjectHttpError} from "nbook/server/api/projects/project-http-error";
 import {isProjectNotOpenError} from "nbook/server/workspace-files/project-session";
 
@@ -12,7 +12,7 @@ export default defineEventHandler(async (event) => withProjectHttpError(async ()
     try {
         return await getAgentSessionUserContent(requireAgentSessionId(event), entryId);
     } catch (error) {
-        if (isProjectNotOpenError(error) || isAgentSessionNotFoundHttpError(error)) {
+        if (isProjectNotOpenError(error) || isAgentSessionLifecycleHttpError(error)) {
             throw error;
         }
         throw createError({statusCode: 404, message: "用户消息不存在", data: {code: "USER_MESSAGE_NOT_FOUND"}});

--- a/packages/neuro-book/server/api/agent/sessions/[sessionId]/index.get.test.ts
+++ b/packages/neuro-book/server/api/agent/sessions/[sessionId]/index.get.test.ts
@@ -1,25 +1,50 @@
 import {beforeEach, describe, expect, it, vi} from "vitest";
+import type {NeuroAgentHarness} from "nbook/server/agent/harness/neuro-agent-harness";
+import {AgentSessionNotFoundError} from "nbook/server/agent/session/session-not-found-error";
+import {ProjectNotOpenError} from "nbook/server/workspace-files/project-session-service";
+
+const mocks = vi.hoisted(() => ({
+    getQuery: vi.fn(() => ({})),
+    getSessionQuery: vi.fn(),
+    requireAgentSessionId: vi.fn(() => 12),
+}));
 
 describe("GET /api/agent/sessions/:sessionId", () => {
     beforeEach(() => {
         vi.resetModules();
         vi.clearAllMocks();
+        mocks.getQuery.mockReset().mockReturnValue({});
+        mocks.getSessionQuery.mockReset();
+        mocks.requireAgentSessionId.mockReset().mockReturnValue(12);
         vi.stubGlobal("defineEventHandler", (handler: unknown) => handler);
     });
 
     it("Project 未 open 时返回稳定 PROJECT_NOT_OPEN", async () => {
         const projectRoot = "session-route-not-open";
-        const {ProjectNotOpenError} = await import("nbook/server/workspace-files/project-session-service");
+        mocks.getQuery.mockReturnValue({});
+        mocks.getSessionQuery.mockImplementation(async () => {
+            throw new ProjectNotOpenError(projectRoot);
+        });
         vi.doMock("h3", async (importOriginal) => ({
             ...(await importOriginal<typeof import("h3")>()),
-            getQuery: vi.fn(() => ({})),
+            getQuery: mocks.getQuery,
         }));
-        vi.doMock("nbook/server/agent/http", () => ({
-            requireAgentSessionId: vi.fn(() => 12),
-            getAgentSessionQuery: vi.fn(async () => {
-                throw new ProjectNotOpenError(projectRoot);
-            }),
-        }));
+        vi.doMock("nbook/server/agent/http", async (importOriginal) => {
+            const actual = await importOriginal<typeof import("nbook/server/agent/http")>();
+            const harness = {
+                getSessionQuery: mocks.getSessionQuery,
+            } as NeuroAgentHarness;
+            return {
+                ...actual,
+                requireAgentSessionId: mocks.requireAgentSessionId,
+                getAgentSessionQuery: (
+                    sessionId: number,
+                    query: Parameters<typeof actual.getAgentSessionQuery>[1],
+                    _harness: NeuroAgentHarness | undefined,
+                    timing: Parameters<typeof actual.getAgentSessionQuery>[3],
+                ) => actual.getAgentSessionQuery(sessionId, query, harness, timing),
+            };
+        });
         vi.doMock("nbook/server/utils/server-timing", () => ({
             createServerTiming: vi.fn(() => ({
                 mark: vi.fn(),
@@ -35,43 +60,90 @@ describe("GET /api/agent/sessions/:sessionId", () => {
                 projectRoot,
             },
         });
-    });
+    }, 10_000);
 
     it("把严格判别 query 交给统一 session query Interface", async () => {
-        const getAgentSessionQuery = vi.fn(async () => ({
+        mocks.getQuery.mockReturnValue({view: "history", cursor: "cursor-1"});
+        mocks.getSessionQuery.mockResolvedValue({
             kind: "history",
             sessionId: 12,
             activePathRevision: null,
             history: {entries: [], previousCursor: null},
-        }));
+        });
         vi.doMock("h3", async (importOriginal) => ({
             ...(await importOriginal<typeof import("h3")>()),
-            getQuery: vi.fn(() => ({view: "history", cursor: "cursor-1"})),
+            getQuery: mocks.getQuery,
         }));
-        vi.doMock("nbook/server/agent/http", () => ({
-            requireAgentSessionId: vi.fn(() => 12),
-            getAgentSessionQuery,
-        }));
+        vi.doMock("nbook/server/agent/http", async (importOriginal) => {
+            const actual = await importOriginal<typeof import("nbook/server/agent/http")>();
+            const harness = {getSessionQuery: mocks.getSessionQuery} as NeuroAgentHarness;
+            return {
+                ...actual,
+                requireAgentSessionId: mocks.requireAgentSessionId,
+                getAgentSessionQuery: (
+                    sessionId: number,
+                    query: Parameters<typeof actual.getAgentSessionQuery>[1],
+                    _harness: NeuroAgentHarness | undefined,
+                    timing: Parameters<typeof actual.getAgentSessionQuery>[3],
+                ) => actual.getAgentSessionQuery(sessionId, query, harness, timing),
+            };
+        });
         vi.doMock("nbook/server/utils/server-timing", () => ({
             createServerTiming: vi.fn(() => ({mark: vi.fn()})),
         }));
 
         const handler = (await import("nbook/server/api/agent/sessions/[sessionId]/index.get")).default;
         await expect(handler({} as never)).resolves.toEqual(expect.objectContaining({kind: "history"}));
-        expect(getAgentSessionQuery).toHaveBeenCalledWith(12, {
+        expect(mocks.getSessionQuery).toHaveBeenCalledWith(12, {
             view: "history",
             cursor: "cursor-1",
-        }, undefined, expect.anything());
+        }, expect.anything());
+    });
+
+    it.each([
+        [12, 404, "SESSION_NOT_FOUND"],
+        [13, 409, "SESSION_DEPENDENCY_NOT_FOUND"],
+    ] as const)("使用生产 Session mapper 区分主/关联缺失 %i", async (missingSessionId, statusCode, code) => {
+        mocks.getQuery.mockReturnValue({});
+        mocks.getSessionQuery.mockRejectedValue(new AgentSessionNotFoundError(missingSessionId));
+        vi.doMock("h3", async (importOriginal) => ({
+            ...(await importOriginal<typeof import("h3")>()),
+            getQuery: mocks.getQuery,
+        }));
+        vi.doMock("nbook/server/agent/http", async (importOriginal) => {
+            const actual = await importOriginal<typeof import("nbook/server/agent/http")>();
+            const harness = {getSessionQuery: mocks.getSessionQuery} as NeuroAgentHarness;
+            return {
+                ...actual,
+                requireAgentSessionId: mocks.requireAgentSessionId,
+                getAgentSessionQuery: (
+                    sessionId: number,
+                    query: Parameters<typeof actual.getAgentSessionQuery>[1],
+                    _harness: NeuroAgentHarness | undefined,
+                    timing: Parameters<typeof actual.getAgentSessionQuery>[3],
+                ) => actual.getAgentSessionQuery(sessionId, query, harness, timing),
+            };
+        });
+        vi.doMock("nbook/server/utils/server-timing", () => ({
+            createServerTiming: vi.fn(() => ({mark: vi.fn()})),
+        }));
+
+        const handler = (await import("nbook/server/api/agent/sessions/[sessionId]/index.get")).default;
+        await expect(handler({} as never)).rejects.toMatchObject({
+            statusCode,
+            data: {code},
+        });
     });
 
     it("拒绝跨 view 的非法 query 组合", async () => {
+        mocks.getQuery.mockReturnValue({view: "systemPrompt", cursor: "cursor-1"});
         vi.doMock("h3", async (importOriginal) => ({
             ...(await importOriginal<typeof import("h3")>()),
-            getQuery: vi.fn(() => ({view: "systemPrompt", cursor: "cursor-1"})),
+            getQuery: mocks.getQuery,
         }));
-        vi.doMock("nbook/server/agent/http", () => ({
-            requireAgentSessionId: vi.fn(() => 12),
-            getAgentSessionQuery: vi.fn(),
+        vi.doMock("nbook/server/agent/http", async (importOriginal) => ({
+            ...(await importOriginal<typeof import("nbook/server/agent/http")>()),
+            requireAgentSessionId: mocks.requireAgentSessionId,
         }));
         vi.doMock("nbook/server/utils/server-timing", () => ({
             createServerTiming: vi.fn(() => ({mark: vi.fn()})),

--- a/packages/neuro-book/server/api/agent/workflow-demo/direct-chat.post.ts
+++ b/packages/neuro-book/server/api/agent/workflow-demo/direct-chat.post.ts
@@ -1,15 +1,23 @@
 import {createError, readBody} from "h3";
 import {useWorkflowDemoService} from "nbook/server/agent/workflow/workflow-demo-service";
+import {isAgentSessionLifecycleHttpError, withAgentSessionHttpError} from "nbook/server/agent/http";
 
 /** Workflow demo：RP 轮间用户直聊（写入真实 session 主线，origin=manual） */
 export default defineEventHandler(async (event) => {
     const body = await readBody<{sessionId?: number; message?: string}>(event);
-    if (!Number.isInteger(body?.sessionId) || !body?.message) {
+    const sessionId = body?.sessionId;
+    if (typeof sessionId !== "number" || !Number.isSafeInteger(sessionId) || sessionId <= 0 || !body?.message) {
         throw createError({statusCode: 400, message: "sessionId 与 message 必填"});
     }
     try {
-        return await useWorkflowDemoService().directChat(body.sessionId as number, body.message);
+        return await withAgentSessionHttpError(
+            sessionId,
+            () => useWorkflowDemoService().directChat(sessionId, body.message as string),
+        );
     } catch (error) {
+        if (isAgentSessionLifecycleHttpError(error)) {
+            throw error;
+        }
         throw createError({statusCode: 400, message: error instanceof Error ? error.message : String(error)});
     }
 });

--- a/packages/neuro-book/server/api/agent/workflow-demo/session-lifecycle.test.ts
+++ b/packages/neuro-book/server/api/agent/workflow-demo/session-lifecycle.test.ts
@@ -1,0 +1,110 @@
+import type {H3Event} from "h3";
+import {afterAll, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    sessionTree: vi.fn(),
+    directChat: vi.fn(),
+}));
+
+const h3State = vi.hoisted(() => ({
+    routerParam: "12" as string | undefined,
+    body: {sessionId: 12, message: "hello"} as {sessionId?: number; message?: string},
+}));
+
+vi.mock("h3", async (importOriginal) => ({
+    ...await importOriginal<typeof import("h3")>(),
+    getRouterParam: () => h3State.routerParam,
+    readBody: async () => h3State.body,
+}));
+
+vi.mock("nbook/server/agent/workflow/workflow-demo-service", () => ({
+    useWorkflowDemoService: () => ({
+        sessionTree: mocks.sessionTree,
+        directChat: mocks.directChat,
+    }),
+}));
+
+vi.mock("nbook/server/agent/http", async () => {
+    return vi.importActual<typeof import("nbook/server/agent/http")>("nbook/server/agent/http");
+});
+
+let treeHandler: (event: H3Event) => Promise<unknown>;
+let directChatHandler: (event: H3Event) => Promise<unknown>;
+const originalDefineEventHandler = (globalThis as typeof globalThis & {defineEventHandler?: unknown}).defineEventHandler;
+
+beforeAll(async () => {
+    vi.stubGlobal("defineEventHandler", (routeHandler: typeof treeHandler) => routeHandler);
+    treeHandler = (await import("nbook/server/api/agent/workflow-demo/sessions/[sessionId]/tree.get")).default;
+    directChatHandler = (await import("nbook/server/api/agent/workflow-demo/direct-chat.post")).default;
+});
+
+afterAll(() => {
+    vi.unstubAllGlobals();
+    (globalThis as typeof globalThis & {defineEventHandler?: unknown}).defineEventHandler = originalDefineEventHandler;
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    h3State.routerParam = "12";
+    h3State.body = {sessionId: 12, message: "hello"};
+});
+
+describe("Workflow Preview Session lifecycle", () => {
+    it("tree 保留目标 Session 404", async () => {
+        mocks.sessionTree.mockRejectedValue(sessionMissing(12));
+
+        await expect(treeHandler({} as H3Event)).rejects.toMatchObject({
+            statusCode: 404,
+            data: {code: "SESSION_NOT_FOUND"},
+        });
+    });
+
+    it("direct-chat 保留关联 Session 409", async () => {
+        mocks.directChat.mockRejectedValue(sessionMissing(13));
+
+        await expect(directChatHandler({} as H3Event)).rejects.toMatchObject({
+            statusCode: 409,
+            data: {code: "SESSION_DEPENDENCY_NOT_FOUND"},
+        });
+    });
+
+    it("其它 tree/direct-chat 错误维持既有 404/400", async () => {
+        mocks.sessionTree.mockRejectedValue(new Error("tree failed"));
+        mocks.directChat.mockRejectedValue(new Error("chat failed"));
+
+        await expect(treeHandler({} as H3Event)).rejects.toMatchObject({statusCode: 404});
+        await expect(directChatHandler({} as H3Event)).rejects.toMatchObject({statusCode: 400});
+    });
+
+    it.each([undefined, 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+        "direct-chat 拒绝非安全正整数 sessionId %s",
+        async (badSessionId) => {
+            h3State.body = {sessionId: badSessionId, message: "hello"};
+
+            await expect(directChatHandler({} as H3Event)).rejects.toMatchObject({statusCode: 400});
+            expect(mocks.directChat).not.toHaveBeenCalled();
+        },
+    );
+
+    it.each(["0", "-12", "12.5", "abc", String(Number.MAX_SAFE_INTEGER + 1), undefined])(
+        "tree 路由拒绝非法 sessionId 参数 %s",
+        async (rawSessionId) => {
+            h3State.routerParam = rawSessionId;
+
+            await expect(treeHandler({} as H3Event)).rejects.toMatchObject({
+                statusCode: 400,
+                message: "sessionId 必须是正整数",
+            });
+            expect(mocks.sessionTree).not.toHaveBeenCalled();
+        },
+    );
+});
+
+/** 构造跨 HMR 仍可识别的 Session 生命周期错误。 */
+function sessionMissing(sessionId: number): Error {
+    return Object.assign(new Error("missing"), {
+        name: "AgentSessionNotFoundError",
+        code: "SESSION_NOT_FOUND",
+        sessionId,
+    });
+}

--- a/packages/neuro-book/server/api/agent/workflow-demo/sessions/[sessionId]/tree.get.ts
+++ b/packages/neuro-book/server/api/agent/workflow-demo/sessions/[sessionId]/tree.get.ts
@@ -1,16 +1,19 @@
-import {createError, getRouterParam} from "h3";
+import {createError} from "h3";
 import {useWorkflowDemoService} from "nbook/server/agent/workflow/workflow-demo-service";
+import {isAgentSessionLifecycleHttpError, requireAgentSessionId, withAgentSessionHttpError} from "nbook/server/agent/http";
 
 /** Workflow demo：参与者 session 的真实树投影（直接读 JSONL 仓库） */
 export default defineEventHandler(async (event) => {
-    const raw = getRouterParam(event, "sessionId");
-    const sessionId = Number(raw);
-    if (!Number.isInteger(sessionId) || sessionId <= 0) {
-        throw createError({statusCode: 400, message: "sessionId 必须是正整数"});
-    }
+    const sessionId = requireAgentSessionId(event);
     try {
-        return await useWorkflowDemoService().sessionTree(sessionId);
+        return await withAgentSessionHttpError(
+            sessionId,
+            () => useWorkflowDemoService().sessionTree(sessionId),
+        );
     } catch (error) {
+        if (isAgentSessionLifecycleHttpError(error)) {
+            throw error;
+        }
         throw createError({statusCode: 404, message: error instanceof Error ? error.message : String(error)});
     }
 });

--- a/packages/neuro-book/shared/dto/agent-session.dto.ts
+++ b/packages/neuro-book/shared/dto/agent-session.dto.ts
@@ -17,7 +17,13 @@ const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() => z.union([
     z.record(z.string(), JsonValueSchema),
 ]));
 
-export const AgentSessionIdSchema = z.number().int().positive();
+export const AgentSessionIdSchema = z.number().int().positive().safe();
+/** Session 的不可变逻辑身份；UUID 用于新 Session，sha256 用于没有身份字段的现有 header。 */
+export const AgentSessionIdentitySchema = z.union([
+    z.string().uuid(),
+    z.string().regex(/^sha256:[0-9a-f]{64}$/u, "Agent Session identity 格式非法"),
+]);
+export type AgentSessionIdentity = z.infer<typeof AgentSessionIdentitySchema>;
 export const AgentClientMessageIdSchema = z.string().uuid();
 export const AgentAttachmentIdSchema = z.string()
     .regex(/^sha256:[0-9a-f]{64}$/u, "Attachment ID 格式非法")
@@ -334,6 +340,7 @@ export type AgentSessionContextUsageDto = {
 
 export type AgentSessionSummaryDto = {
     sessionId: number;
+    sessionIdentity: AgentSessionIdentity;
     profileKey: string;
     /**
      * 当前 session 引用的 profile 是否仍可用于后续运行。


### PR DESCRIPTION
[git.exe remote -v]
[git.exe config --get-regexp ^remote\..*\.gh-resolved$]
* Request at 2026-08-25 11:34:04.9423026 +0800 CST m=+0.225037901
* Request to https://api.github.com/graphql
* Request took 957.818ms
Closes #26

## 范围

- 让 Session SSE 的 normal、forced 与新 event epoch recovery 保持已有 single-flight；只有主资源缺失（404）进入专用 Session 恢复，关联资源缺失（409）清除 recovery latch、恢复当前连接状态并走普通错误出口，不清空当前选择或循环重试。
- 让主 Agent 面板与 Inline Editor 的直接加载和 SSE 缺失共用“读取后提交”边界：目标 recovery 与目标草稿读取成功且 owner 仍有效后才停止旧流、切换 ID、清空 shell 和提交新状态。
- 主面板与 Inline Editor 使用独立的 Project owner。右侧面板隐藏只停止主面板 SSE 和主 owner，保留主 Session、Composer 草稿与后台 Agent；Inline PromptBar、Inline SSE、模型设置和 Inline owner 继续工作。
- 主面板重新打开时显式读取 recovery，并在 recovery 成功后重新建立主 Session SSE；409 且保留完整 recovery 时保持 ready，并使用旧 cursor 恢复 SSE。
- 主面板与 Inline Editor 对 404 仍只刷新一次、最多 fallback 一次；409 或仍有稳定 recovery 的普通读取失败保留稳定当前 Session、草稿、stream 和记忆；无稳定绑定时进入明确 error/empty/unselected 状态，不自动创建。
- 前台选择期间到达的 404 不再被静默丢弃：controller 返回 `deferred`，前台成功时丢弃，前台失败且旧 Session 仍稳定时只 replay 一次；旧 owner、scope 和组件销毁会静默清理 deferred。
- 草稿读取或保存失败不再变成空正文，也不会解除当前 context；只有保存和读取成功才提交新草稿 context。acceptance 清除失败时保留用户输入并显示局部提示。
- fallback 二次 404、列表为空或列表刷新失败时，稳定旧 Session 保持 ready；任一确认的主 Session 404 在浏览器记忆中数字 ID 与 identity 仍同时匹配时才清理 remembered value（重放后合同，详见 Follow-up）。
- 权威 Session 提交和 stream 启动成功后才写 remembered ID；Storage 写入失败不回滚当前状态、不删除旧记忆，并显示一次可见提示。
- 新 Session 使用 UUID identity，旧 JSONL header 使用稳定 `sha256:` identity；summary、recovery 和 SSE 传递 identity，浏览器记忆使用 schema 2，缺 identity 时进入 `unselected` 而不是按数字 ID 或列表首项猜测。
- 关联目标自身缺失只投影为 `unavailableLinkedAgents`，主对话 recovery 和轻量 relations 继续成功；损坏、权限和非目标路径错误原样失败。
- Context Inspector、Profile Preview/Compile、Workflow Preview tree/direct-chat、current-project 与 entry/attachment 宽泛错误出口继续使用统一 Session-bound HTTP 合同；route 测试消费生产 mapper。
- 更新 Task 118、PROJECT-STATUS、ADR 0018（monorepo 重放后重编号，原 0013）和 CONTEXT。

## 用户结果

同一浏览器 origin 先后连接不同 State Root 时，旧的主 Session 请求返回 `404 / SESSION_NOT_FOUND`；关联 Session 缺失返回 `409 / SESSION_DEPENDENCY_NOT_FOUND`，不暴露磁盘路径或正文。主面板和 Inline Editor 只在新 Session recovery 与草稿准备成功后切换；旧 recovery 不能抢回用户刚选择的 Session。关联 Session 不可用、目标普通读取失败、草稿读写失败或 fallback 二次缺失时，只要当前仍有完整 recovery 就保留当前对话，不会出现“有 ID 但没有内容”的半绑定状态。没有可信记忆时显示未选择状态，不自动切换列表首项。创建失败、目标加载失败和空列表都不会伪装成成功或自动创建。关闭右侧面板不会停止 Inline PromptBar；重开后主面板会主动读取 recovery 并恢复 SSE。记忆写入失败不会破坏已经打开的对话。

## 明确排除

- 不修改消息分支投影或 `/fork`。
- 不建立 State Root 实例身份协议；同号 Session 的跨实例操作隔离另见 Issue #67。
- 不修改 Session 备份恢复、Runtime lease、heartbeat、Source Dev launcher 或 Product Runtime Image。
- 不运行浏览器自动验收；需要用户使用两个不同 State Root 在同一 `localhost:3000` origin 上手工确认。
- Linux CI advisory 中既有的 `C:/...` fixture 路径失败、Bun worker 和工具环境失败归 Issue #15，本 PR 不引入跨平台路径解析重构。

## 验证

- 前序 PR recovery focused：14 files / 170 tests passed；本轮新增/复核合计 8 files / 284 tests passed，其中 harness 单独 183/183、其它 7 files 分拆 101/101，包含真实删除关联目标后的关系投影。8 文件并行调用曾触发 harness 内既有时间敏感断言；该用例在干净 PR 基线与当前 worktree 单独运行均通过。
- `bun run nuxt:prepare`：通过。
- `bun run typecheck`：通过（原始 head fe83fb9a 时点；monorepo 重放 head 见下）。
- `bun run docs:build`：通过；仅有既有 VitePress chunk size warning。
- `git diff --check`：通过。
- 未运行浏览器验证；测试使用隔离 State Root，不访问真实 `workspace/`、Session 备份或 lease。
- GitHub Full tests advisory 的失败继续归 Issue #15；不把完整 Vitest 或 advisory 失败写成全绿。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved conversation recovery and browser session remembering with safer session matching.
  * Added clearer prompts when conversations are available but none is selected.
  * Added separate, more reliable handling for inline conversations and main chat sessions.
  * Linked conversations now remain usable when related sessions are unavailable, with warnings shown where appropriate.
* **Bug Fixes**
  * Drafts are preserved when content is rejected or saving fails.
  * Session-related API errors now provide clearer, consistent responses for missing conversations and dependencies.
* **Documentation**
  * Expanded documentation covering session identity, recovery behavior, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Follow-up fixes (fe83fb9a..d684454a)

合并前审查（独立只读 review + 修复）在原 PR head 上确认并关闭以下缺陷：

### 行为修复
- **Remembered session 404 清理**：主面板初次 remembered target 确认缺失即按 ID+identity 安全清理浏览器记忆；Inline 恢复 helper 接受显式 expectedIdentity（此前初次恢复时绑定 identity 为 null 导致清理被跳过）。
- **SSE open 后才写记忆**：`saveLastSession`/`saveInlineEditorSession` 从同步 commit 段移至事件流 open 成功且 owner 仍有效之后（ADR 0018）；连接失败保留已提交 Session、不写记忆、走既有 error 投影；后台重连成功后恢复 ready 并补写记忆。
- **Deferred recovery**：`runRecovery()` 在前台存在不同 scope 的 deferred 时先收口旧 Promise（原先悬挂）；blocked-draft 拒绝分支补 `replayDeferred`。
- **握手超时**：SSE open 增加 15s 超时，服务端不返回 headers 时 start 拒绝并复用既有重连出口，Surface 不再永久 loading。

### HTTP 合同
- `AgentSessionIdSchema` 收窄为正的安全整数；workflow direct-chat 拒绝缺失/0/负数/浮点/unsafe sessionId，tree 路由改用 canonical parser；Profile 路由测试删除本地 validator 替换、改跑生产实现。

### 测试
- 新增/扩展：deferred scope 替换与 rejection、记忆清理不误删五类场景、open 前后记忆写入边界、registerReconnectRestoreWatcher 五个行为回归（含主/Inline 注册表隔离）、握手超时、HTTP 无效 ID 表格。focused 8 文件 172/172。

### 文档同步
- PROJECT-STATUS 与 Task 118 的清理合同由「只有二次 404 才清理」更新为「任一确认的主 Session 404 且 storage 中 ID+identity 仍匹配才清理」，与实现一致。

### 验证状态
- 原始 head：docs build 通过、focused tests 全绿。
- 全量套件在此前 head 运行：3502 passed / 2 failed——两例为 neuro-agent-harness 黑盒超时，纯净 PR head 同样复现，归因既有基线非本分支引入。
- 重放 head（e7f15026）typecheck：仅剩 1 个与 origin/master 逐字节一致的既有基线错误（profile-compile-worker-lifecycle.test.ts 的 userProfileRoot 字段在 master 类型中不存在）；其余清零。
- 文档链接：Task 118 ↔ ADR 0018 相对链接已按新布局修正（094ef7d6 / 77e6f0b1）。
- 浏览器人工验收与远端 CI 待执行。



