### PR TITLE
feat(agent): 优化审批面板与 workflow 气泡可视化

### DIFF
--- a/app/components/novel-ide/agent/AgentUserInputPrompt.vue
+++ b/app/components/novel-ide/agent/AgentUserInputPrompt.vue
@@ -64,12 +64,8 @@ const planSuggestionSelected = computed(() => Boolean(
     activeQuestion.value
     && isPlanSuggestion(activeQuestion.value, activeAnswer.value.selectedOptionIndex),
 ));
-const showNoteInput = computed(() => {
-    const question = activeQuestion.value;
-    if (!question) return false;
-    if (question.options.length === 0) return true;
-    return activeAnswer.value.selectedOptionIndex !== undefined;
-});
+/** 备注/回答输入区常显（Task 137）：未选选项时也直接展示，减少一次点击才发现入口的成本。 */
+const showNoteInput = computed(() => Boolean(activeQuestion.value));
 const primaryLabel = computed(() => {
     if (activeForm.value && !activeFormDraft.value.confirmed) return t("agent.userInput.confirmItem");
     if (allComplete.value) return t("agent.userInput.submitAll");
@@ -215,8 +211,8 @@ function handlePrimary(): void {
             <div class="min-w-0">
                 <div class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[11px] font-medium text-[var(--status-warning)]">
                     <span class="inline-flex items-center gap-1.5"><span class="i-lucide-message-square-more h-3.5 w-3.5"></span>{{ t("agent.userInput.pendingTitle") }}</span>
-                    <span class="tabular-nums">{{ activeIndex + 1 }} / {{ items.length }}</span>
-                    <span class="tabular-nums">{{ t("agent.userInput.answeredProgress", {answered: completedCount, total: items.length}) }}</span>
+                    <span class="rounded-full border border-[var(--status-warning-border)] bg-[var(--bg-input)] px-2 py-0.5 tabular-nums">{{ activeIndex + 1 }} / {{ items.length }}</span>
+                    <span class="rounded-full border border-[var(--status-warning-border)] bg-[var(--bg-input)] px-2 py-0.5 tabular-nums">{{ t("agent.userInput.answeredProgress", {answered: completedCount, total: items.length}) }}</span>
                 </div>
                 <div class="mt-0.5 text-xs font-medium text-[var(--text-main)]">{{ questionTypeLabel }}</div>
             </div>
@@ -260,24 +256,24 @@ function handlePrimary(): void {
 
                     <fieldset v-if="activeQuestion.options.length > 0" class="mt-3 space-y-1.5" :disabled="answerControlsDisabled">
                         <legend class="sr-only">{{ activeQuestion.question }}</legend>
-                        <label v-for="(option, index) in activeQuestion.options" :key="index" :for="optionId(index)" class="group flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--bg-hover)] has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-55">
+                        <label v-for="(option, index) in activeQuestion.options" :key="index" :for="optionId(index)" class="group flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--bg-hover)] has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-55" :class="activeAnswer.selectedOptionIndex === index ? 'bg-[var(--accent-bg)] shadow-[inset_2px_0_0_var(--accent-main)]' : ''">
                             <input :id="optionId(index)" type="radio" :name="`agent-pending-${activeItem.key}`" class="sr-only" :checked="activeAnswer.selectedOptionIndex === index" :disabled="answerControlsDisabled" @change="selectOption(index)">
                             <span class="w-5 shrink-0 pt-0.5 text-right text-xs tabular-nums text-[var(--text-muted)]">{{ index + 1 }}.</span>
                             <span class="min-w-0 flex-1">
                                 <span class="block text-[13px] font-semibold leading-5" :class="activeAnswer.selectedOptionIndex === index ? 'text-[var(--text-main)]' : 'text-[var(--text-secondary)]'">{{ option.label }}</span>
                                 <span v-if="option.description" class="block text-[11px] leading-4 text-[var(--text-muted)]">{{ option.description }}</span>
                             </span>
-                            <span class="mt-1 h-3 w-3 shrink-0 rounded-full border" :class="activeAnswer.selectedOptionIndex === index ? 'border-[var(--accent-main)] bg-[var(--accent-main)]' : 'border-[var(--border-color)] group-hover:border-[var(--text-muted)]'"></span>
+                            <span class="mt-0.5 h-4 w-4 shrink-0 rounded-full border" :class="activeAnswer.selectedOptionIndex === index ? 'border-[var(--accent-main)] bg-[var(--accent-main)] shadow-[inset_0_0_0_2px_var(--bg-main)]' : 'border-[var(--border-color)] group-hover:border-[var(--text-muted)]'"></span>
                         </label>
 
-                        <label v-if="activeItem.kind === 'question' || (activeItem.kind === 'approval' && activeQuestion.approvalAction === 'switch_mode' && activeQuestion.switchTargetMode === 'normal')" :for="optionId(NONE_OF_ABOVE_OPTION_INDEX)" class="group flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--bg-hover)] has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-55">
+                        <label v-if="activeItem.kind === 'question' || (activeItem.kind === 'approval' && activeQuestion.approvalAction === 'switch_mode' && activeQuestion.switchTargetMode === 'normal')" :for="optionId(NONE_OF_ABOVE_OPTION_INDEX)" class="group flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--bg-hover)] has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-55" :class="activeAnswer.selectedOptionIndex === NONE_OF_ABOVE_OPTION_INDEX ? 'bg-[var(--accent-bg)] shadow-[inset_2px_0_0_var(--accent-main)]' : ''">
                             <input :id="optionId(NONE_OF_ABOVE_OPTION_INDEX)" type="radio" :name="`agent-pending-${activeItem.key}`" class="sr-only" :checked="activeAnswer.selectedOptionIndex === NONE_OF_ABOVE_OPTION_INDEX" :disabled="answerControlsDisabled" @change="selectOption(NONE_OF_ABOVE_OPTION_INDEX)">
                             <span class="w-5 shrink-0 pt-0.5 text-right text-xs tabular-nums text-[var(--text-muted)]">{{ activeQuestion.options.length + 1 }}.</span>
                             <span class="min-w-0 flex-1">
                                 <span class="block text-[13px] font-semibold leading-5" :class="activeAnswer.selectedOptionIndex === NONE_OF_ABOVE_OPTION_INDEX ? 'text-[var(--text-main)]' : 'text-[var(--text-secondary)]'">{{ activeItem.kind === 'approval' ? t("agent.userInput.addSuggestion") : t("agent.userInput.otherAnswer") }}</span>
                                 <span class="block text-[11px] leading-4 text-[var(--text-muted)]">{{ activeItem.kind === 'approval' ? t("agent.userInput.suggestionDescription") : t("agent.userInput.otherAnswerDescription") }}</span>
                             </span>
-                            <span class="mt-1 h-3 w-3 shrink-0 rounded-full border" :class="activeAnswer.selectedOptionIndex === NONE_OF_ABOVE_OPTION_INDEX ? 'border-[var(--accent-main)] bg-[var(--accent-main)]' : 'border-[var(--border-color)] group-hover:border-[var(--text-muted)]'"></span>
+                            <span class="mt-0.5 h-4 w-4 shrink-0 rounded-full border" :class="activeAnswer.selectedOptionIndex === NONE_OF_ABOVE_OPTION_INDEX ? 'border-[var(--accent-main)] bg-[var(--accent-main)] shadow-[inset_0_0_0_2px_var(--bg-main)]' : 'border-[var(--border-color)] group-hover:border-[var(--text-muted)]'"></span>
                         </label>
                     </fieldset>
                 </div>

--- a/app/components/novel-ide/agent/AgentWorkflowBubble.vue
+++ b/app/components/novel-ide/agent/AgentWorkflowBubble.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import {computed, inject, onBeforeUnmount, ref, shallowRef, watch} from "vue";
 import JsonViewer from "nbook/app/components/common/JsonViewer.vue";
-import WorkflowMermaid from "nbook/app/components/workflow-preview/WorkflowMermaid.vue";
+import WorkflowRunVisuals from "nbook/app/components/workflow-preview/WorkflowRunVisuals.vue";
 import type {AgentToolCall} from "nbook/app/components/novel-ide/agent/agent-message";
 import {AGENT_REQUEST_USER_INPUT_CONTEXT_KEY} from "nbook/app/components/novel-ide/agent/request-user-input-context";
 import {useAgentJob} from "nbook/app/composables/useAgentJob";
@@ -41,6 +41,11 @@ const resumeSubmitting = ref(false);
 const resumeSubmitted = ref(false);
 const askDrafts = ref<Record<string, AskDraftValue>>({});
 const chartExpanded = ref(true);
+/** 信息折叠区（运行参数 / 内联脚本 / 执行元数据 / 返回值）的展开态，默认收起。 */
+const argsExpanded = ref(false);
+const scriptExpanded = ref(false);
+const metaExpanded = ref(false);
+const resultExpanded = ref(false);
 const catalogTitle = ref("");
 const catalogDescription = ref("");
 const nowTick = ref(Date.now());
@@ -135,6 +140,12 @@ const statusIcon = computed(() => {
 });
 
 const effectiveChart = computed(() => matchingRunState.value?.machineMermaid ?? details.value?.chartMermaid ?? "");
+/** active phase 上的 done/total 进度文本；无 progress 信息时为空。 */
+const progressText = computed(() => {
+    const progress = matchingRunState.value?.view.progress;
+    if (!progress?.total) return "";
+    return `${progress.done ?? 0}/${progress.total}`;
+});
 const runningNow = computed(() => matchingRunState.value?.runningNow ?? []);
 const pendingAsks = computed<PendingAsk[]>(() => matchingRunState.value?.view.pendingAsks ?? []);
 const pendingAskTitles = computed(() => pendingAsks.value.length > 0
@@ -416,14 +427,21 @@ onBeforeUnmount(() => {
                 </span>
             </div>
 
-            <details v-if="parsedArgs.args !== undefined" class="mt-3">
-                <summary class="cursor-pointer text-xs text-[var(--text-secondary)]">运行参数</summary>
-                <div class="mt-2"><JsonViewer :value="parsedArgs.args" :max-height="220" /></div>
-            </details>
-            <details v-if="parsedArgs.script" class="mt-3">
-                <summary class="cursor-pointer text-xs text-[var(--text-secondary)]">内联 workflow 脚本</summary>
-                <pre class="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-all rounded border border-[var(--border-color)] bg-[var(--bg-input)] p-2 font-mono text-[11px] leading-5 text-[var(--text-secondary)]">{{ parsedArgs.script }}</pre>
-            </details>
+            <!-- 运行参数 / 内联脚本：按钮式折叠卡片（与可视化区折叠样式统一，Task 137）。 -->
+            <div v-if="parsedArgs.args !== undefined" class="mt-3 overflow-hidden rounded-lg border border-[var(--border-color)]">
+                <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left hover:bg-[var(--bg-hover)]" @click="argsExpanded = !argsExpanded">
+                    <span class="text-xs font-medium text-[var(--text-main)]">运行参数</span>
+                    <span :class="argsExpanded ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="h-3.5 w-3.5 text-[var(--text-muted)]"></span>
+                </button>
+                <div v-if="argsExpanded" class="border-t border-[var(--border-color)] p-2"><JsonViewer :value="parsedArgs.args" :max-height="220" /></div>
+            </div>
+            <div v-if="parsedArgs.script" class="mt-3 overflow-hidden rounded-lg border border-[var(--border-color)]">
+                <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left hover:bg-[var(--bg-hover)]" @click="scriptExpanded = !scriptExpanded">
+                    <span class="text-xs font-medium text-[var(--text-main)]">内联 workflow 脚本</span>
+                    <span :class="scriptExpanded ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="h-3.5 w-3.5 text-[var(--text-muted)]"></span>
+                </button>
+                <pre v-if="scriptExpanded" class="max-h-64 overflow-auto whitespace-pre-wrap break-all border-t border-[var(--border-color)] bg-[var(--bg-input)] p-2 font-mono text-[11px] leading-5 text-[var(--text-secondary)]">{{ parsedArgs.script }}</pre>
+            </div>
         </div>
 
         <!-- 声明式工具审批由会话宿主统一提交，气泡不复制第二套批准接口。 -->
@@ -463,22 +481,34 @@ onBeforeUnmount(() => {
             </span>
         </div>
 
-        <!-- wf.chart 主视图：终态默认折叠，且限制高度避免撑爆聊天流。 -->
-        <div v-if="effectiveChart" class="overflow-hidden rounded-lg border border-[var(--border-color)] bg-[var(--bg-main)]">
+        <!-- 可视化区（Task 137 共享组件）：phase 步进条 + 视图 tab；终态默认折叠，限高避免撑爆聊天流。 -->
+        <div v-if="matchingRunState" class="overflow-hidden rounded-lg border border-[var(--border-color)] bg-[var(--bg-main)]">
             <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left hover:bg-[var(--bg-hover)]" @click="chartExpanded = !chartExpanded">
                 <span class="flex items-center gap-2 text-xs font-medium text-[var(--text-main)]">
                     <span class="i-lucide-git-branch h-3.5 w-3.5 text-[var(--accent-main)]"></span>
-                    Workflow 状态图
+                    Workflow 可视化
                 </span>
                 <span :class="chartExpanded ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="h-3.5 w-3.5 text-[var(--text-muted)]"></span>
             </button>
             <div v-if="chartExpanded" class="border-t border-[var(--border-color)] p-2">
-                <WorkflowMermaid :code="effectiveChart" :max-height="360" />
+                <WorkflowRunVisuals
+                    :phases="matchingRunState.phases"
+                    :progress-text="progressText"
+                    :machine-mermaid="effectiveChart || null"
+                    :flow-mermaid="matchingRunState.flowMermaid"
+                    :trace-mermaid="matchingRunState.traceMermaid"
+                    :relation-mermaid="matchingRunState.relationMermaid"
+                    :timeline="matchingRunState.timeline"
+                    :live="matchingRunState.live"
+                    default-view="machine"
+                    always-show-machine-tab
+                    :mermaid-max-height="360"
+                />
             </div>
         </div>
         <div v-else-if="status === 'running' || status === 'starting'" class="flex items-center gap-2 rounded border border-[var(--status-info-border)] bg-[var(--status-info-bg)] px-3 py-2 text-xs text-[var(--status-info)]">
             <span class="i-lucide-loader-circle h-3.5 w-3.5 animate-spin"></span>
-            等待 workflow 发布首个 wf.chart 状态节点…
+            正在连接 workflow run…
         </div>
 
         <!-- wf.ask waiting：从正式 Run VM 取得完整 ask 规格并原地续跑。 -->
@@ -516,30 +546,38 @@ onBeforeUnmount(() => {
         <div v-if="jobFeedError" class="rounded border border-[var(--status-warning-border)] bg-[var(--status-warning-bg)] px-3 py-2 text-xs text-[var(--status-warning)]">{{ jobFeedError }}</div>
         <div v-if="pollError" class="rounded border border-[var(--status-warning-border)] bg-[var(--status-warning-bg)] px-3 py-2 text-xs text-[var(--status-warning)]">{{ pollError }}；仍保留最近一次可用的 run 状态。</div>
 
-        <!-- Session 与 usage 默认折叠，避免终态卡片过长。 -->
-        <details v-if="hasMetadata" class="rounded border border-[var(--border-color)] bg-[var(--bg-main)] px-3 py-2">
-            <summary class="cursor-pointer text-xs text-[var(--text-secondary)]">
-                执行元数据 · {{ sessionRows.length }} sessions<span v-if="usage"> · {{ totalTokens.toLocaleString() }} tokens</span>
-            </summary>
-            <div v-if="usage" class="mt-2 flex flex-wrap gap-2 text-[11px] text-[var(--text-muted)]">
-                <span class="rounded border border-[var(--border-color)] bg-[var(--bg-input)] px-2 py-1">输入 {{ usage.inputTokens.toLocaleString() }}</span>
-                <span class="rounded border border-[var(--border-color)] bg-[var(--bg-input)] px-2 py-1">输出 {{ usage.outputTokens.toLocaleString() }}</span>
-            </div>
-            <div v-if="sessionRows.length" class="mt-2 space-y-1.5">
-                <div v-for="session in sessionRows" :key="session.sessionId" class="flex flex-wrap items-center gap-2 rounded border border-[var(--border-color)] bg-[var(--bg-input)] px-2 py-1.5 text-[11px]">
-                    <span class="font-mono text-[var(--accent-main)]">#{{ session.sessionId }}</span>
-                    <span class="text-[var(--text-main)]">{{ session.title || session.profileKey }}</span>
-                    <span v-if="session.title && session.profileKey" class="font-mono text-[var(--text-muted)]">{{ session.profileKey }}</span>
-                    <span v-if="session.tokens" class="ml-auto text-[var(--text-muted)]">{{ session.tokens.totalTokens.toLocaleString() }} tokens</span>
+        <!-- 执行元数据（Session 与 usage）：按钮式折叠卡片，默认收起避免终态卡片过长。 -->
+        <div v-if="hasMetadata" class="overflow-hidden rounded-lg border border-[var(--border-color)] bg-[var(--bg-main)]">
+            <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left hover:bg-[var(--bg-hover)]" @click="metaExpanded = !metaExpanded">
+                <span class="text-xs font-medium text-[var(--text-main)]">
+                    执行元数据 · {{ sessionRows.length }} sessions<span v-if="usage"> · {{ totalTokens.toLocaleString() }} tokens</span>
+                </span>
+                <span :class="metaExpanded ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="h-3.5 w-3.5 shrink-0 text-[var(--text-muted)]"></span>
+            </button>
+            <div v-if="metaExpanded" class="border-t border-[var(--border-color)] px-3 py-2">
+                <div v-if="usage" class="flex flex-wrap gap-2 text-[11px] text-[var(--text-muted)]">
+                    <span class="rounded border border-[var(--border-color)] bg-[var(--bg-input)] px-2 py-1">输入 {{ usage.inputTokens.toLocaleString() }}</span>
+                    <span class="rounded border border-[var(--border-color)] bg-[var(--bg-input)] px-2 py-1">输出 {{ usage.outputTokens.toLocaleString() }}</span>
+                </div>
+                <div v-if="sessionRows.length" class="mt-2 space-y-1.5">
+                    <div v-for="session in sessionRows" :key="session.sessionId" class="flex flex-wrap items-center gap-2 rounded border border-[var(--border-color)] bg-[var(--bg-input)] px-2 py-1.5 text-[11px]">
+                        <span class="font-mono text-[var(--accent-main)]">#{{ session.sessionId }}</span>
+                        <span class="text-[var(--text-main)]">{{ session.title || session.profileKey }}</span>
+                        <span v-if="session.title && session.profileKey" class="font-mono text-[var(--text-muted)]">{{ session.profileKey }}</span>
+                        <span v-if="session.tokens" class="ml-auto text-[var(--text-muted)]">{{ session.tokens.totalTokens.toLocaleString() }} tokens</span>
+                    </div>
                 </div>
             </div>
-        </details>
+        </div>
 
-        <!-- Workflow 自定义返回值独立折叠。 -->
-        <details v-if="effectiveResult !== undefined" class="rounded border border-[var(--border-color)] bg-[var(--bg-main)] px-3 py-2">
-            <summary class="cursor-pointer text-xs text-[var(--text-secondary)]">Workflow 返回值</summary>
-            <div class="mt-2"><JsonViewer :value="effectiveResult" :max-height="260" /></div>
-        </details>
+        <!-- Workflow 自定义返回值：按钮式折叠卡片。 -->
+        <div v-if="effectiveResult !== undefined" class="overflow-hidden rounded-lg border border-[var(--border-color)] bg-[var(--bg-main)]">
+            <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left hover:bg-[var(--bg-hover)]" @click="resultExpanded = !resultExpanded">
+                <span class="text-xs font-medium text-[var(--text-main)]">Workflow 返回值</span>
+                <span :class="resultExpanded ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="h-3.5 w-3.5 text-[var(--text-muted)]"></span>
+            </button>
+            <div v-if="resultExpanded" class="border-t border-[var(--border-color)] p-2"><JsonViewer :value="effectiveResult" :max-height="260" /></div>
+        </div>
 
         <div v-if="status === 'not_started' && props.toolCall.result" class="whitespace-pre-wrap break-all rounded border border-[var(--border-color)] bg-[var(--bg-main)] p-2 text-xs text-[var(--text-secondary)]">{{ props.toolCall.result }}</div>
     </div>

--- a/app/components/novel-ide/agent/AgentWorkflowBubble.vue
+++ b/app/components/novel-ide/agent/AgentWorkflowBubble.vue
@@ -481,8 +481,9 @@ onBeforeUnmount(() => {
             </span>
         </div>
 
-        <!-- 可视化区（Task 137 共享组件）：phase 步进条 + 视图 tab；终态默认折叠，限高避免撑爆聊天流。 -->
-        <div v-if="matchingRunState" class="overflow-hidden rounded-lg border border-[var(--border-color)] bg-[var(--bg-main)]">
+        <!-- 可视化区（Task 137 共享组件）：phase 步进条 + 视图 tab；终态默认折叠，限高避免撑爆聊天流。
+             run 不可查询时仍用 details 里的 chartMermaid 展示状态图（旧行为保留），其余视图自然为空态。 -->
+        <div v-if="matchingRunState || effectiveChart" class="overflow-hidden rounded-lg border border-[var(--border-color)] bg-[var(--bg-main)]">
             <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left hover:bg-[var(--bg-hover)]" @click="chartExpanded = !chartExpanded">
                 <span class="flex items-center gap-2 text-xs font-medium text-[var(--text-main)]">
                     <span class="i-lucide-git-branch h-3.5 w-3.5 text-[var(--accent-main)]"></span>
@@ -492,14 +493,14 @@ onBeforeUnmount(() => {
             </button>
             <div v-if="chartExpanded" class="border-t border-[var(--border-color)] p-2">
                 <WorkflowRunVisuals
-                    :phases="matchingRunState.phases"
+                    :phases="matchingRunState?.phases ?? []"
                     :progress-text="progressText"
                     :machine-mermaid="effectiveChart || null"
-                    :flow-mermaid="matchingRunState.flowMermaid"
-                    :trace-mermaid="matchingRunState.traceMermaid"
-                    :relation-mermaid="matchingRunState.relationMermaid"
-                    :timeline="matchingRunState.timeline"
-                    :live="matchingRunState.live"
+                    :flow-mermaid="matchingRunState?.flowMermaid ?? ''"
+                    :trace-mermaid="matchingRunState?.traceMermaid ?? ''"
+                    :relation-mermaid="matchingRunState?.relationMermaid ?? ''"
+                    :timeline="matchingRunState?.timeline ?? []"
+                    :live="matchingRunState?.live ?? []"
                     default-view="machine"
                     always-show-machine-tab
                     :mermaid-max-height="360"

--- a/app/components/workflow-preview/WorkflowRunPanel.vue
+++ b/app/components/workflow-preview/WorkflowRunPanel.vue
@@ -292,7 +292,9 @@ onBeforeUnmount(() => {
         <!-- 主体：可切换的可视化视图（共享组件）+ 人话事件流 -->
         <div class="flex flex-wrap gap-4">
             <div class="min-w-0 flex-1 basis-[460px]">
+                <!-- key=runId：切换 run 时重挂载，tab 回到默认视图（对齐旧版 runId watcher 的重置行为）。 -->
                 <WorkflowRunVisuals
+                    :key="props.runId"
                     :phases="state?.phases ?? []"
                     :progress-text="progressText"
                     :machine-mermaid="state?.machineMermaid ?? null"

--- a/app/components/workflow-preview/WorkflowRunPanel.vue
+++ b/app/components/workflow-preview/WorkflowRunPanel.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import {computed, onBeforeUnmount, ref, shallowRef, watch} from "vue";
-import WorkflowMermaid from "nbook/app/components/workflow-preview/WorkflowMermaid.vue";
 import WorkflowSessionTree from "nbook/app/components/workflow-preview/WorkflowSessionTree.vue";
-import WorkflowTimeline from "nbook/app/components/workflow-preview/WorkflowTimeline.vue";
-import WorkflowAgentCards from "nbook/app/components/workflow-preview/WorkflowAgentCards.vue";
+import WorkflowRunVisuals from "nbook/app/components/workflow-preview/WorkflowRunVisuals.vue";
 import {useAgentJob} from "nbook/app/composables/useAgentJob";
 import {resolveApiErrorMessage, resolveApiErrorStatus} from "nbook/app/utils/api-error";
 import {shouldPollWorkflowRun} from "nbook/app/components/novel-ide/agent/workflow-bubble";
@@ -55,17 +53,8 @@ const expandedSessions = ref<number[]>([]);
 const styleModeInput = ref("工笔细描");
 /** ask 应答草稿：key → 值 */
 const askDrafts = ref<Record<string, AskDraftValue>>({});
-/** 主视图切换：状态机 / 对话流 / 时间线 / 直播卡片 / 关系图 */
-type ViewKey = "machine" | "flow" | "timeline" | "cards" | "relation";
-const activeView = ref<ViewKey>(props.mode === "formal" ? "machine" : "flow");
-/** 正式 run 以状态图为主；demo 仍只在实际产生 machine 图时显示该 tab。 */
-const viewTabs = computed<{key: ViewKey; label: string}[]>(() => [
-    ...(props.mode === "formal" || state.value?.machineMermaid ? [{key: "machine" as ViewKey, label: "状态机"}] : []),
-    {key: "flow", label: "对话流"},
-    {key: "timeline", label: "时间线"},
-    {key: "cards", label: "直播卡片"},
-    {key: "relation", label: "关系图"},
-]);
+/** 可视化区默认视图：正式 run 以状态图为主；demo 以对话流为主（machine tab 有图时才显示）。 */
+const defaultVisualView = computed<"machine" | "flow">(() => props.mode === "formal" ? "machine" : "flow");
 /** 轮询打点的"现在"（算运行中 activity 已耗时用；不能在模板里直接 Date.now()——不响应） */
 const nowTick = ref(Date.now());
 /** 正在被调用的 session id 集合（参与者 chip 脉冲高亮） */
@@ -218,7 +207,6 @@ watch([() => props.runId, runApiBase], () => {
     askDrafts.value = {};
     expandedSessions.value = [];
     runUnavailable = false;
-    activeView.value = props.mode === "formal" ? "machine" : "flow";
     const expectedRevision = pollRevision;
     const expectedRunId = props.runId;
     const expectedApiBase = runApiBase.value;
@@ -266,23 +254,7 @@ onBeforeUnmount(() => {
             {{ jobError || job?.preview }}
         </div>
 
-        <!-- phase 步进条：workflow 走到哪一步、哪里需要人，一眼可见 -->
-        <div v-if="state?.phases.length" class="mb-3 flex flex-wrap items-center gap-1.5">
-            <template v-for="(phase, i) in state.phases" :key="phase.key">
-                <div class="flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs"
-                    :class="{
-                        'border-[var(--status-success-border)] bg-[var(--status-success-bg)] text-[var(--status-success)]': phase.status === 'done',
-                        'border-[var(--status-info-border)] bg-[var(--status-info-bg)] text-[var(--status-info)]': phase.status === 'active',
-                        'border-[var(--border-color)] bg-[var(--bg-main)] text-[var(--text-muted)]': phase.status === 'pending',
-                    }">
-                    <span>{{ phase.status === 'done' ? '✔' : phase.status === 'active' ? '●' : '○' }}</span>
-                    <span>{{ phase.title }}</span>
-                    <span v-if="phase.status === 'active' && progressText" class="opacity-80">{{ progressText }}</span>
-                    <span v-if="phase.askTitles.length" title="本阶段有用户参与点">🙋</span>
-                </div>
-                <span v-if="i < state.phases.length - 1" class="text-[var(--text-muted)]">→</span>
-            </template>
-        </div>
+        <!-- phase 步进条与视图 tab 已抽入 WorkflowRunVisuals（Task 137，气泡共用）。 -->
 
         <!-- 正在运行的 activity：脉冲高亮 + 已耗时 -->
         <div v-if="state?.runningNow.length" class="mb-3 flex flex-wrap items-center gap-2">
@@ -317,39 +289,21 @@ onBeforeUnmount(() => {
             <button class="mt-2 rounded border border-[var(--accent-main)] bg-[var(--accent-bg)] px-4 py-1 text-xs text-[var(--accent-text)]" @click="submitAsks">应答并继续</button>
         </div>
 
-        <!-- 主体：可切换的可视化视图 + 人话事件流 -->
+        <!-- 主体：可切换的可视化视图（共享组件）+ 人话事件流 -->
         <div class="flex flex-wrap gap-4">
             <div class="min-w-0 flex-1 basis-[460px]">
-                <!-- 视图切换 tab -->
-                <div class="mb-2 flex items-center gap-1">
-                    <button v-for="tab in viewTabs" :key="tab.key"
-                        class="rounded-t border-b-2 px-3 py-1 text-xs transition-colors"
-                        :class="activeView === tab.key
-                            ? 'border-[var(--accent-main)] text-[var(--accent-text)]'
-                            : 'border-transparent text-[var(--text-muted)] hover:text-[var(--text-secondary)]'"
-                        @click="activeView = tab.key">{{ tab.label }}</button>
-                </div>
-                <template v-if="activeView === 'machine'">
-                    <div class="mb-1 text-xs text-[var(--text-muted)]">状态图（零预置只增不删，随代码执行长出来；边上 ①②③=执行顺序（终图即流程记录），〔名字〕=在此干活的 agent，橙=有执行线停留，绿=走过）</div>
-                    <WorkflowMermaid v-if="state?.machineMermaid" :code="state.machineMermaid" />
-                    <div v-else class="rounded border border-[var(--status-info-border)] bg-[var(--status-info-bg)] px-3 py-2 text-xs text-[var(--status-info)]">等待 workflow 发布 wf.chart 状态节点…</div>
-                </template>
-                <template v-else-if="activeView === 'flow'">
-                    <div class="mb-1 text-xs text-[var(--text-muted)]">参与者对话流（编排器 ⇄ 各 agent session ⇄ 用户；writer↔critic 这类循环在这里一目了然）</div>
-                    <WorkflowMermaid v-if="state?.flowMermaid" :code="state.flowMermaid" />
-                </template>
-                <template v-else-if="activeView === 'timeline'">
-                    <div class="mb-1 text-xs text-[var(--text-muted)]">泳道时间线（每个 agent 一条泳道，条形=一次调用；并发交错、耗时长短直观可见）</div>
-                    <WorkflowTimeline :lanes="state?.timeline ?? []" />
-                </template>
-                <template v-else-if="activeView === 'cards'">
-                    <div class="mb-1 text-xs text-[var(--text-muted)]">直播卡片（每个 agent 的当前状态与最近一问一答，像聊天室成员列表）</div>
-                    <WorkflowAgentCards :cards="state?.live ?? []" />
-                </template>
-                <template v-else>
-                    <div class="mb-1 text-xs text-[var(--text-muted)]">实时生长关系图（创建 agent 长节点、每次调用长一条边；橙色虚线=正在进行）</div>
-                    <WorkflowMermaid v-if="state?.relationMermaid" :code="state.relationMermaid" />
-                </template>
+                <WorkflowRunVisuals
+                    :phases="state?.phases ?? []"
+                    :progress-text="progressText"
+                    :machine-mermaid="state?.machineMermaid ?? null"
+                    :flow-mermaid="state?.flowMermaid ?? ''"
+                    :trace-mermaid="state?.traceMermaid ?? ''"
+                    :relation-mermaid="state?.relationMermaid ?? ''"
+                    :timeline="state?.timeline ?? []"
+                    :live="state?.live ?? []"
+                    :default-view="defaultVisualView"
+                    :always-show-machine-tab="props.mode === 'formal'"
+                />
             </div>
             <div class="min-w-0 flex-1 basis-[320px]">
                 <div class="mb-1 text-xs text-[var(--text-muted)]">正在发生什么（{{ logs.length }}）</div>
@@ -365,12 +319,6 @@ onBeforeUnmount(() => {
                 </ul>
             </div>
         </div>
-
-        <!-- 工程视图：Activity 级执行图（收起） -->
-        <details v-if="state?.traceMermaid" class="mt-3">
-            <summary class="cursor-pointer text-xs text-[var(--text-secondary)]">执行图（Activity 级工程视图：虚线橙=进行中，绿=缓存命中，体育场=用户参与点）</summary>
-            <div class="mt-2"><WorkflowMermaid :code="state.traceMermaid" /></div>
-        </details>
 
         <!-- 完成后的动作区 -->
         <div v-if="props.mode === 'demo' && state && (state.view.status === 'completed' || state.view.status === 'failed')" class="mt-3 flex flex-wrap items-center gap-2">

--- a/app/components/workflow-preview/WorkflowRunVisuals.vue
+++ b/app/components/workflow-preview/WorkflowRunVisuals.vue
@@ -52,12 +52,12 @@ const viewTabs = computed<{key: ViewKey; label: string}[]>(() => [
     {key: "trace", label: "执行图"},
 ]);
 
-/** 状态机 tab 被隐藏时，激活视图不能停在上面。 */
+/** 状态机 tab 被隐藏时，激活视图不能停在上面（immediate：挂载时就兜底，避免无 tab 激活落到末尾 else）。 */
 watch(showMachineTab, (visible) => {
     if (!visible && activeView.value === "machine") {
         activeView.value = "flow";
     }
-});
+}, {immediate: true});
 </script>
 
 <template>

--- a/app/components/workflow-preview/WorkflowRunVisuals.vue
+++ b/app/components/workflow-preview/WorkflowRunVisuals.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import {computed, ref, watch} from "vue";
+import WorkflowMermaid from "nbook/app/components/workflow-preview/WorkflowMermaid.vue";
+import WorkflowTimeline from "nbook/app/components/workflow-preview/WorkflowTimeline.vue";
+import WorkflowAgentCards from "nbook/app/components/workflow-preview/WorkflowAgentCards.vue";
+import type {LiveCardVm, PhaseVm, TimelineLaneVm} from "nbook/server/agent/workflow/workflow-run-vm";
+
+/**
+ * Workflow run 可视化区（Task 137）：Phase 步进条 + 视图 tab。
+ * preview 面板与 Agent 聊天气泡共用；各 tab 内容懒渲染（只渲染激活 tab），
+ * 避免轮询快照刷新时同时重渲染多张 Mermaid 图。
+ */
+type ViewKey = "machine" | "flow" | "timeline" | "cards" | "relation" | "trace";
+
+const props = withDefaults(defineProps<{
+    phases: PhaseVm[];
+    /** active phase 上的 done/total 进度文本；无 progress 信息时为空。 */
+    progressText?: string;
+    /** 状态图（wf.chart）；无 chart 事件为 null，保留 tab 显示占位。 */
+    machineMermaid: string | null;
+    flowMermaid: string;
+    traceMermaid: string;
+    relationMermaid: string;
+    timeline: TimelineLaneVm[];
+    live: LiveCardVm[];
+    /** 初始激活视图；变化时（如切换 run）重置。 */
+    defaultView?: ViewKey;
+    /** demo 只在实际产生 machine 图时显示状态机 tab；正式 run 与气泡恒显示。 */
+    alwaysShowMachineTab?: boolean;
+    /** Mermaid 图容器最大高度；不传则不限高（preview 页行为）。 */
+    mermaidMaxHeight?: number;
+}>(), {
+    progressText: "",
+    defaultView: "machine",
+    alwaysShowMachineTab: false,
+    mermaidMaxHeight: undefined,
+});
+
+const activeView = ref<ViewKey>(props.defaultView);
+watch(() => props.defaultView, (next) => {
+    activeView.value = next;
+});
+
+/** 状态机 tab 是否展示：恒显模式或有图时展示。 */
+const showMachineTab = computed(() => props.alwaysShowMachineTab || Boolean(props.machineMermaid));
+const viewTabs = computed<{key: ViewKey; label: string}[]>(() => [
+    ...(showMachineTab.value ? [{key: "machine" as ViewKey, label: "状态机"}] : []),
+    {key: "flow", label: "对话流"},
+    {key: "timeline", label: "时间线"},
+    {key: "cards", label: "直播卡片"},
+    {key: "relation", label: "关系图"},
+    {key: "trace", label: "执行图"},
+]);
+
+/** 状态机 tab 被隐藏时，激活视图不能停在上面。 */
+watch(showMachineTab, (visible) => {
+    if (!visible && activeView.value === "machine") {
+        activeView.value = "flow";
+    }
+});
+</script>
+
+<template>
+    <div>
+        <!-- phase 步进条：workflow 走到哪一步、哪里需要人，一眼可见 -->
+        <div v-if="phases.length" class="mb-3 flex flex-wrap items-center gap-1.5">
+            <template v-for="(phase, i) in phases" :key="phase.key">
+                <div class="flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs"
+                    :class="{
+                        'border-[var(--status-success-border)] bg-[var(--status-success-bg)] text-[var(--status-success)]': phase.status === 'done',
+                        'border-[var(--status-info-border)] bg-[var(--status-info-bg)] text-[var(--status-info)]': phase.status === 'active',
+                        'border-[var(--border-color)] bg-[var(--bg-main)] text-[var(--text-muted)]': phase.status === 'pending',
+                    }">
+                    <span>{{ phase.status === 'done' ? '✔' : phase.status === 'active' ? '●' : '○' }}</span>
+                    <span>{{ phase.title }}</span>
+                    <span v-if="phase.status === 'active' && progressText" class="opacity-80">{{ progressText }}</span>
+                    <span v-if="phase.askTitles.length" title="本阶段有用户参与点">🙋</span>
+                </div>
+                <span v-if="i < phases.length - 1" class="text-[var(--text-muted)]">→</span>
+            </template>
+        </div>
+
+        <!-- 视图切换 tab：只渲染激活视图，Mermaid 图不随轮询重复渲染 -->
+        <div class="mb-2 flex flex-wrap items-center gap-1">
+            <button v-for="tab in viewTabs" :key="tab.key" type="button"
+                class="rounded-t border-b-2 px-3 py-1 text-xs transition-colors"
+                :class="activeView === tab.key
+                    ? 'border-[var(--accent-main)] text-[var(--accent-text)]'
+                    : 'border-transparent text-[var(--text-muted)] hover:text-[var(--text-secondary)]'"
+                @click="activeView = tab.key">{{ tab.label }}</button>
+        </div>
+        <template v-if="activeView === 'machine' && showMachineTab">
+            <div class="mb-1 text-xs text-[var(--text-muted)]">状态图（零预置只增不删，随代码执行长出来；边上 ①②③=执行顺序（终图即流程记录），〔名字〕=在此干活的 agent，橙=有执行线停留，绿=走过）</div>
+            <WorkflowMermaid v-if="machineMermaid" :code="machineMermaid" :max-height="mermaidMaxHeight" />
+            <div v-else class="rounded border border-[var(--status-info-border)] bg-[var(--status-info-bg)] px-3 py-2 text-xs text-[var(--status-info)]">等待 workflow 发布首个 wf.chart 状态节点…</div>
+        </template>
+        <template v-else-if="activeView === 'flow'">
+            <div class="mb-1 text-xs text-[var(--text-muted)]">参与者对话流（编排器 ⇄ 各 agent session ⇄ 用户；writer↔critic 这类循环在这里一目了然）</div>
+            <WorkflowMermaid v-if="flowMermaid" :code="flowMermaid" :max-height="mermaidMaxHeight" />
+        </template>
+        <template v-else-if="activeView === 'timeline'">
+            <div class="mb-1 text-xs text-[var(--text-muted)]">泳道时间线（每个 agent 一条泳道，条形=一次调用；并发交错、耗时长短直观可见）</div>
+            <WorkflowTimeline :lanes="timeline" />
+        </template>
+        <template v-else-if="activeView === 'cards'">
+            <div class="mb-1 text-xs text-[var(--text-muted)]">直播卡片（每个 agent 的当前状态与最近一问一答，像聊天室成员列表）</div>
+            <WorkflowAgentCards :cards="live" />
+        </template>
+        <template v-else-if="activeView === 'relation'">
+            <div class="mb-1 text-xs text-[var(--text-muted)]">实时生长关系图（创建 agent 长节点、每次调用长一条边；橙色虚线=正在进行）</div>
+            <WorkflowMermaid v-if="relationMermaid" :code="relationMermaid" :max-height="mermaidMaxHeight" />
+        </template>
+        <template v-else>
+            <div class="mb-1 text-xs text-[var(--text-muted)]">执行图（Activity 级工程视图：虚线橙=进行中，绿=缓存命中，体育场=用户参与点）</div>
+            <WorkflowMermaid v-if="traceMermaid" :code="traceMermaid" :max-height="mermaidMaxHeight" />
+        </template>
+    </div>
+</template>

--- a/docs/tasks/137-agent-ui-approval-workflow-bubble/README.md
+++ b/docs/tasks/137-agent-ui-approval-workflow-bubble/README.md
@@ -15,6 +15,8 @@
 
 ## User Request / Topic
 
+GitHub Issue：#50（主需求）。跟进：#51（直播卡片展开完整对话）、#52（Mermaid 主题适配）。
+
 1. **审批界面不好看**。`request_user_input` 类型也不好看。"其他选项"的输入栏应该默认展示。
 2. **Workflow 气泡（`run_workflow`）不直观**。运行参数看起来点不了，整体信息层级太平。需要展示 workflow 内各个 Agent 的消息。
 
@@ -29,15 +31,16 @@
 - Header 进度数字改为 pill 样式
 
 ### 问题二：Workflow 气泡
-- **新增 Agent 直播卡片**：消费 `matchingRunState.value?.live`（`LiveCardVm[]`），可复用 `WorkflowAgentCards.vue`
-- **新增 Phase 步进条**：消费 `matchingRunState.value?.phases`（`PhaseVm[]`）
-- **Mermaid 多图 Tab**：把单状态图升级为 4 种图的 tab 切换（状态图/Trace/序列图/关系图）
-- **泳道时间线**：消费 `matchingRunState.value?.timeline`，可复用 `WorkflowTimeline.vue`
-- **折叠样式统一**：运行参数 `<details>` → 按钮式折叠卡片
+- **抽共享组件 `WorkflowRunVisuals.vue`**：Phase 步进条 + 视图 tab + 各视图内容，气泡与 `WorkflowRunPanel.vue` 共用
+- **新增 Agent 直播卡片**：消费 `matchingRunState.value?.live`（`LiveCardVm[]`），复用 `WorkflowAgentCards.vue`，作为共享组件的 `cards` tab
+- **新增 Phase 步进条**：消费 `matchingRunState.value?.phases`（`PhaseVm[]`）；workflow 未声明 phases 时为空数组，不渲染
+- **视图 tab 懒渲染**：tab 含状态机 / 对话流 / 时间线 / 直播卡片 / 关系图 / 执行图（Trace）；只渲染激活 tab（`v-if`），否则 500ms 轮询会每拍重渲染 4 张 Mermaid 图
+- **空态策略**：`machineMermaid` 为 null（无 chart 事件）时保留 tab + 占位文案
+- **折叠样式统一**：运行参数、执行元数据、Workflow 返回值三处 `<details>` 全部改为按钮式折叠卡片
 
 ## Current State
 
-计划已制定完毕，等待实施。
+实施完成，本地验证通过，待 PR。
 
 ## ADR / Decisions / Discussion
 
@@ -45,6 +48,9 @@
 2. **后端数据已就绪**：`WorkflowDemoRunState` 已提供 `live`、`phases`、`timeline`、`flowMermaid`、`traceMermaid`、`relationMermaid` 等全部数据，不需要后端改动。
 3. **`WorkflowPreview.vue` 已有参考实现**：`WorkflowAgentCards.vue` 和 `WorkflowTimeline.vue` 已独立为组件，可直接在气泡中复用。
 4. **Timeline 复杂度**：`WorkflowTimeline.vue` 是纯 CSS 版（非 Canvas），适合在气泡中使用。
+5. **完整消息查看妥协（用户确认）**：直播卡片只展示最近一问一答摘要（`buildLive` 截断 40 字符），本轮不做完整对话查看；跟进 issue #51。
+6. **Mermaid 深色硬编码接受现状（用户确认）**：`workflow-run-vm.ts` 的 hex 颜色与 `render-mermaid.ts` 的 `theme:"neutral"` 本轮不动，浅色主题下对比度问题跟进 issue #52。
+7. **共享组件而非复制（用户确认）**：tab 切换 + Phase 步进条抽为 `WorkflowRunVisuals.vue` 供 RunPanel 与气泡共用，避免两份实现漂移；trace 从 RunPanel 的 `<details>` 升级为统一 tab。
 
 ## Verification / Test
 
@@ -54,8 +60,26 @@
 
 ## Implementation Walkthrough
 
--
+分支 `feat/i50-t137-agent-bubble-visuals`（worktree `wt/agent-bubble-visuals`）。
+
+变更文件：
+
+- `app/components/novel-ide/agent/AgentUserInputPrompt.vue`：`showNoteInput` 常显；radio 指示器 h-4 w-4 + 选中内环（inset shadow）；选项卡片选中态加左侧 accent 色条 + accent 底色；header 两个进度数字改 pill。
+- `app/components/workflow-preview/WorkflowRunVisuals.vue`（新建）：Phase 步进条 + 6 视图 tab（状态机/对话流/时间线/直播卡片/关系图/执行图），只渲染激活 tab；machine 图缺失时保留 tab + 占位。
+- `app/components/workflow-preview/WorkflowRunPanel.vue`：删除自有 tab / 步进条 / trace `<details>`，左栏改用共享组件；logs、ask 卡、session 树、rerun 不变。
+- `app/components/novel-ide/agent/AgentWorkflowBubble.vue`：wf.chart 块换成共享组件（`chartExpanded` 折叠语义保留，作用于整个可视化区）；运行参数 / 内联脚本 / 执行元数据 / 返回值四处 `<details>` 统一改按钮式折叠卡片。
+
+与计划的出入：
+
+1. 折叠统一范围除计划内 3 处外，顺带统一了「内联 workflow 脚本」（第 4 处 `<details>`），否则同一卡片内两种折叠样式并存。
+2. 可视化区外层容器仅在 `matchingRunState` 存在时渲染；未连接上 run 时的占位文案由「等待 workflow 发布首个 wf.chart 状态节点…」改为「正在连接 workflow run…」（机器图占位文案移入共享组件内部）。
+
+验证：
+
+- `bunx vitest run agent-pending-resolution.test.ts workflow-bubble.test.ts`：19 passed。
+- `bun run typecheck`：通过（0 error；worktree 首次需先 `nuxt prepare` + `bun run generate` 生成 tsconfig 与 prisma client）。
+- 手动浏览器验证待用户确认后进行。
 
 ## TODO / Follow-ups
 
--
+- 产品级跟进已开 issue：#51（直播卡片展开完整对话）、#52（Mermaid 主题适配）。

--- a/docs/tasks/137-agent-ui-approval-workflow-bubble/README.md
+++ b/docs/tasks/137-agent-ui-approval-workflow-bubble/README.md
@@ -72,7 +72,13 @@ GitHub Issue：#50（主需求）。跟进：#51（直播卡片展开完整对�
 与计划的出入：
 
 1. 折叠统一范围除计划内 3 处外，顺带统一了「内联 workflow 脚本」（第 4 处 `<details>`），否则同一卡片内两种折叠样式并存。
-2. 可视化区外层容器仅在 `matchingRunState` 存在时渲染；未连接上 run 时的占位文案由「等待 workflow 发布首个 wf.chart 状态节点…」改为「正在连接 workflow run…」（机器图占位文案移入共享组件内部）。
+2. 可视化区外层容器在未连上 run 但 details 带 `chartMermaid` 时仍展示（保留旧回退行为）；未连接且无任何图时的占位文案由「等待 workflow 发布首个 wf.chart 状态节点…」改为「正在连接 workflow run…」（机器图占位文案移入共享组件内部）。
+
+自查修复（提交后 diff 复审发现，已补第二个提交）：
+
+1. 气泡可视化区条件从 `v-if="matchingRunState"` 改为 `matchingRunState || effectiveChart`——run 不可查询（服务重启 404）时旧版仍展示 details 里的状态图，初版改丢了该回退。
+2. `WorkflowRunVisuals` 的 showMachineTab watch 加 `immediate`——否则 defaultView=machine 且 tab 隐藏时无 tab 激活、内容落到末尾 else（trace）。
+3. RunPanel 给共享组件加 `:key="runId"`——恢复旧版切换 run 时 tab 重置回默认视图的行为。
 
 验证：
 


### PR DESCRIPTION
Closes #50

## 改动

**审批面板**
- 备注/回答输入区常显，不再要求先选选项
- 选项指示器放大（h-4 w-4）+ 选中内环；选中卡片加左侧 accent 色条
- header 进度数字改 pill 胶囊样式

**Workflow 气泡**
- 抽共享组件 `WorkflowRunVisuals.vue`（phase 步进条 + 状态机/对话流/时间线/直播卡片/关系图/执行图 6 个 tab，只渲染激活 tab），preview 面板与聊天气泡共用
- 气泡从单状态图升级为完整可视化区，保留原自动折叠语义
- 运行参数 / 内联脚本 / 执行元数据 / 返回值四处 `<details>` 统一为按钮式折叠卡片

## 验证

- `bun run typecheck` 通过
- `agent-pending-resolution.test.ts` / `workflow-bubble.test.ts` 19 个测试通过
- 手动浏览器验证建议：preview 页各 tab 行为不变；审批面板明暗主题；`run_workflow` 气泡 tab 切换与折叠

产品级跟进：#51（直播卡片展开完整对话）、#52（Mermaid 主题适配）

任务文档：`docs/tasks/137-agent-ui-approval-workflow-bubble/README.md`