### PR TITLE
fix(agent): guard Composer keyboard submissions

### DIFF
--- a/app/components/common/form/ReferencePlainTextEditor.vue
+++ b/app/components/common/form/ReferencePlainTextEditor.vue
@@ -203,6 +203,9 @@ const editor = useEditor({
                     event.key === "Enter"
                     && !event.shiftKey
                     && !menuVisible.value
+                    // 输入法候选确认也会产生 Enter keydown，组合态必须交回编辑器。
+                    && !event.isComposing
+                    && event.keyCode !== 229
                     && (props.submitOnEnter || (props.submitOnModifierEnter && (event.ctrlKey || event.metaKey)))
                 ) {
                     event.preventDefault();

--- a/app/components/novel-ide/agent/AgentChatSurface.vue
+++ b/app/components/novel-ide/agent/AgentChatSurface.vue
@@ -1715,6 +1715,20 @@ async function resolveComposerAttachmentItems(
     });
 }
 
+/** 附件 metadata 失败时不能进入乐观消息或 Session invoke。 */
+async function prepareComposerAttachmentItems(
+    sessionId: number,
+    markdown: string,
+): Promise<AgentSessionAttachmentItemDto[] | null> {
+    try {
+        return await resolveComposerAttachmentItems(sessionId, markdown);
+    } catch (error) {
+        console.error("校验 Agent 消息图片附件失败", error);
+        notifyAgentError(error, "校验 Session 图片失败");
+        return null;
+    }
+}
+
 /** 等待 durable user entry 或 queue item，二者都是输入已接受的 SSE 旁证。 */
 function waitForOptimisticAdmission(
     clientMessageId: string,
@@ -1797,7 +1811,10 @@ const send = async (): Promise<void> => {
     }
 
     const prompt = inputText.value;
-    const attachmentItems = await resolveComposerAttachmentItems(sessionId, prompt);
+    const attachmentItems = await prepareComposerAttachmentItems(sessionId, prompt);
+    if (!attachmentItems) {
+        return;
+    }
     if (activeSessionId.value !== sessionId || inputText.value !== prompt) {
         return;
     }
@@ -1965,7 +1982,10 @@ const sendRunningMessage = async (mode: "steer" | "followup"): Promise<void> => 
     }
     const sessionId = activeSessionId.value;
     const prompt = inputText.value;
-    const attachmentItems = await resolveComposerAttachmentItems(sessionId, prompt);
+    const attachmentItems = await prepareComposerAttachmentItems(sessionId, prompt);
+    if (!attachmentItems) {
+        return;
+    }
     if (activeSessionId.value !== sessionId || inputText.value !== prompt) {
         return;
     }

--- a/app/components/novel-ide/agent/AgentChatSurface.vue
+++ b/app/components/novel-ide/agent/AgentChatSurface.vue
@@ -46,7 +46,7 @@ import {resolveApiErrorCode, resolveApiErrorMessage} from "nbook/app/utils/api-e
 import {formatCost, formatCostExact, usingCnyRate} from "nbook/app/utils/cost-format";
 import {promptCacheHitRate, type PromptCacheUsage} from "nbook/app/utils/prompt-cache";
 import type {ConfigBootstrapDto, ConfigModelSettingsDto} from "nbook/shared/dto/config.dto";
-import type {AgentQueuedMessageDto, AgentSessionAttachmentItemDto, AgentSessionInteractionDto, AgentSessionListPageDto, AgentSessionListQueryDto, AgentSessionRecoveryDto, AgentSessionSummaryDto, AgentMode} from "nbook/shared/dto/agent-session.dto";
+import type {AgentQueuedMessageDto, AgentSessionAttachmentItemDto, AgentSessionAttachmentResolveResultDto, AgentSessionInteractionDto, AgentSessionListPageDto, AgentSessionListQueryDto, AgentSessionRecoveryDto, AgentSessionSummaryDto, AgentMode} from "nbook/shared/dto/agent-session.dto";
 import {AgentModeSchema} from "nbook/shared/dto/agent-session.dto";
 import type {AgentCommandResult, InvokeAgentResult} from "nbook/shared/dto/agent-session.dto";
 import type {DropdownItem} from "nbook/app/components/common/dropdown.types";
@@ -180,6 +180,7 @@ let defaultProfileResolveRequest = 0;
 let inlineEditorSessionRequestId = 0;
 let inlineEditorRecoveryRequestId = 0;
 let sessionAttachmentRequestId = 0;
+let sessionAttachmentGeneration = 0;
 let historyAttachmentInsertRequestId = 0;
 let sessionAttachmentSearchTimer: ReturnType<typeof setTimeout> | null = null;
 let composerDraftWarning = "";
@@ -1070,9 +1071,10 @@ async function clearComposerAfterAccepted(
     }
 }
 
-/** 重置附件分页状态；Session 切换时旧请求通过 requestId 失效。 */
+/** 重置附件分页状态；目录请求通过 requestId、Composer metadata 请求通过 generation 失效。 */
 function resetSessionAttachments(): void {
     sessionAttachmentRequestId += 1;
+    sessionAttachmentGeneration += 1;
     sessionAttachments.value = [];
     knownSessionAttachments.value = [];
     sessionAttachmentUniqueTotal.value = 0;
@@ -1095,6 +1097,7 @@ function invalidateSessionAttachments(): void {
         return;
     }
     sessionAttachmentRequestId += 1;
+    sessionAttachmentGeneration += 1;
     sessionAttachmentLoading.value = false;
     knownSessionAttachments.value = [];
     void loadSessionAttachments(true);
@@ -1692,7 +1695,7 @@ const cycleAgentMode = async (): Promise<void> => {
 async function resolveComposerAttachmentItems(
     sessionId: number,
     markdown: string,
-): Promise<AgentSessionAttachmentItemDto[]> {
+): Promise<AgentSessionAttachmentItemDto[] | null> {
     const attachmentIds = [...new Set(parseAgentImageMarkdown(markdown).flatMap((part) => {
         if (part.type !== "image") {
             return [];
@@ -1703,7 +1706,24 @@ async function resolveComposerAttachmentItems(
     const byId = new Map(knownSessionAttachments.value.map((item) => [item.attachment.attachmentId, item]));
     const missingIds = attachmentIds.filter((attachmentId) => !byId.has(attachmentId));
     if (missingIds.length > 0) {
-        const resolved = await agentApi.resolveSessionAttachments(sessionId, missingIds);
+        const requestScopeKey = sessionScopeKey.value;
+        const requestSessionId = sessionId;
+        const requestGeneration = sessionAttachmentGeneration;
+        const isCurrent = (): boolean => sessionScopeKey.value === requestScopeKey
+            && activeSessionId.value === requestSessionId
+            && sessionAttachmentGeneration === requestGeneration;
+        let resolved: AgentSessionAttachmentResolveResultDto;
+        try {
+            resolved = await agentApi.resolveSessionAttachments(sessionId, missingIds);
+        } catch (error) {
+            if (!isCurrent()) {
+                return null;
+            }
+            throw error;
+        }
+        if (!isCurrent()) {
+            return null;
+        }
         rememberSessionAttachments(resolved.items);
         for (const item of resolved.items) {
             byId.set(item.attachment.attachmentId, item);

--- a/app/components/novel-ide/agent/AgentComposer.vue
+++ b/app/components/novel-ide/agent/AgentComposer.vue
@@ -272,20 +272,20 @@ const composerMenuRefreshKey = computed(() => [
 ].join(":"));
 const imageCapabilityWarning = computed(() => composerImages.value.length > 0 && !props.modelSupportsImages);
 
+/** 键盘提交和发送按钮必须共享同一份消息提交门禁。 */
+const messageSubmitBlocked = computed(() => (
+    composerReadonly.value
+    || pendingImageCount.value > 0
+    || imageUsage.value.unresolvedStable > 0
+    || Boolean(images.metadataError.value)
+    || Boolean(images.budgetError.value)
+));
+
 const sendDisabled = computed(() => {
-    if (composerReadonly.value) {
-        return !canStopReadonlyRun.value;
+    if (canStopReadonlyRun.value) {
+        return false;
     }
-    if (pendingImageCount.value > 0) {
-        return true;
-    }
-    if (imageUsage.value.unresolvedStable > 0) {
-        return true;
-    }
-    if (images.metadataError.value) {
-        return true;
-    }
-    if (images.budgetError.value) {
+    if (messageSubmitBlocked.value) {
         return true;
     }
     if (props.running) {
@@ -454,7 +454,7 @@ function updateComposerValue(value: string): void {
  * 处理回答备注输入提交。
  */
 function submitComposer(payload?: {ctrlKey?: boolean; metaKey?: boolean}): void {
-    if (composerReadonly.value || pendingImageCount.value > 0) {
+    if (messageSubmitBlocked.value) {
         return;
     }
     if (props.running && runInputText.value.trim()) {
@@ -476,7 +476,7 @@ function submitButton(event: MouseEvent): void {
         emit("stop");
         return;
     }
-    if (composerReadonly.value || pendingImageCount.value > 0) {
+    if (messageSubmitBlocked.value) {
         return;
     }
     if (props.running && !runInputText.value.trim()) {

--- a/docs/tasks/108-agent-image-attachment-references/README.md
+++ b/docs/tasks/108-agent-image-attachment-references/README.md
@@ -1003,3 +1003,8 @@ Task 108 与 Task 109 合并后完成最终串行复核：
 - 修复后，按钮和键盘提交共用 Agent Composer 的消息门禁；解析 Session Attachment metadata 失败时，prompt、steer 和 followup 都在创建乐观消息及调用 Session 前通过统一通知出口返回。
 - 本轮不修改 Attachment Authority、存储、DTO、图片 transaction 或 Provider hydration；不新增测试文件，沿用现有聚焦回归和根 typecheck，浏览器交互由用户验收。
 - 验证：既有 `useComposerImageTransaction`、Agent invocation reconciliation 和 Composer draft 聚焦测试共 3 files / 16 tests 通过；SFC 编译探针与 `bun run typecheck` 通过。浏览器图片门禁仍待用户验收。
+
+### 2026-08-04 Composer 附件迟到响应保护
+
+- Composer 解析 Session Attachment metadata 时捕获当前 `sessionScopeKey`、Session ID 和附件缓存 generation；Session 切换、Workspace scope 重置或附件缓存失效后，旧请求的成功与失败结果都会被丢弃，不写入新缓存、不创建消息，也不发送过期错误通知。
+- 当前 Session 的真实解析失败仍沿用既有 notification 出口；prompt、steer 和 followup 继续共享 `null` 提交终止语义。底层 HTTP 请求不取消，服务端仍以 Session Attachment Authority 的 fail-closed 合同为最终边界。

--- a/docs/tasks/108-agent-image-attachment-references/README.md
+++ b/docs/tasks/108-agent-image-attachment-references/README.md
@@ -996,3 +996,10 @@ Task 108 与 Task 109 合并后完成最终串行复核：
 - snapshot 端到端回归证明超过 64 MP 时返回 `limit_exceeded` 且注入 Adapter 零写入；归档竞态同时锁定 `invalid_input` 和“当前 Session 已归档，不能登记附件”，避免前置解码失败误通过。
 - 完整 `file-tools.test.ts` 为 49/49；Session Attachment、Codec 与前端/路由相邻回归通过。完整 Harness 图片相关旧失败已归零，余下两个失败位于模型恢复与 Variable SDK 在途改动，不属于 Attachment。
 - 没有增加 Attachment GC、统一媒体库、Provider 文本附件或浏览器自动验收。
+
+### 2026-08-04 Composer 键盘附件门禁补漏
+
+- 复查发现发送按钮已经按 pending、未解析稳定图片、metadata error 和预算超限阻止提交，但 Agent Composer 键盘入口只检查 pending 图片，违反本任务“metadata failure 阻止发送和历史保存”的既有合同。
+- 修复后，按钮和键盘提交共用 Agent Composer 的消息门禁；解析 Session Attachment metadata 失败时，prompt、steer 和 followup 都在创建乐观消息及调用 Session 前通过统一通知出口返回。
+- 本轮不修改 Attachment Authority、存储、DTO、图片 transaction 或 Provider hydration；不新增测试文件，沿用现有聚焦回归和根 typecheck，浏览器交互由用户验收。
+- 验证：既有 `useComposerImageTransaction`、Agent invocation reconciliation 和 Composer draft 聚焦测试共 3 files / 16 tests 通过；SFC 编译探针与 `bun run typecheck` 通过。浏览器图片门禁仍待用户验收。

--- a/docs/tasks/63-tool-approval-policy-system/README.md
+++ b/docs/tasks/63-tool-approval-policy-system/README.md
@@ -235,3 +235,34 @@ type UserInputFormSpec = {
 ### 计划差异
 
 - 代码范围、快捷键合同、文档边界和不新增测试均与批准计划一致。唯一额外步骤是在新 worktree 中生成 typecheck 所需的 Prisma client；生成物未纳入本次改动。
+
+## 2026-08-04 Composer 输入门禁补漏
+
+### 诊断
+
+- 复查 #45 合并后的真实调用链确认 Enter、steer 和 Ctrl/Meta+Enter followup 已恢复，但共享编辑器仍没有排除输入法组合态。Windows 中文输入法确认候选字也会产生 Enter keydown，可能被误判为提交。
+- 发送按钮已经阻止 pending 图片、未解析稳定图片、metadata error 和预算超限；`AgentComposer.submitComposer()` 只阻止 readonly 与 pending 图片，键盘入口因此可以绕过既有图片合同。
+- `AgentChatSurface` 在创建乐观消息前解析 Session 图片附件，但原解析异常不在错误出口内，失败时可能形成未处理 Promise。
+
+### 实现
+
+- `ReferencePlainTextEditor` 的提交门禁增加 `event.isComposing` 与 `keyCode === 229` 保护；普通 Enter、Shift+Enter、菜单选择和 Ctrl/Meta+Enter 合同不变。该组件被 Agent Composer 和 NovelPromptBar 共用，因此两条实际链路一起获得组合态保护。
+- `AgentComposer` 将 readonly、pending、未解析稳定图片、metadata error 和 budget error 收口为同一内部提交门禁，发送按钮与键盘 `send/steer/followup` 均消费该状态；停止按钮继续使用独立的 readonly-run 分支。
+- `AgentChatSurface` 为 prompt、steer 和 followup 共用附件解析错误出口。解析失败只发出通知并返回，不创建 `clientMessageId`、乐观消息、admission watcher 或 Session invoke。
+- 不扩展到 Markdown Studio/Monaco，不修改 API、DTO、数据库、图片事务模型或新增测试文件。
+
+### 复杂度取舍与计划差异
+
+1. 没有建立全局快捷键框架；组合态规则只放在本次实际复用的 `ReferencePlainTextEditor`，避免为未触发本问题的编辑器提前扩张范围。
+2. 没有复制图片门禁到多个调用点；按钮与键盘共享同一 computed 状态，后续新增客户端阻止条件只需维护一个边界。
+3. 继续遵守不新增测试的约束；通过现有聚焦测试、SFC 编译探针和 typecheck 验证，真实输入法与浏览器交互仍由用户验收。
+
+### Verification
+
+- `bun run generate`：通过，生成 SQLite 与 Project Prisma Client。
+- `bun run nuxt:prepare`：通过，生成 Vitest global setup 所需的 `.nuxt` tsconfig。
+- 既有聚焦回归：`useComposerImageTransaction.test.ts`、`agent-invocation-reconciliation.test.ts`、`agent-composer-draft.test.ts`，3 files / 16 tests 通过。
+- Vue SFC 编译探针：`ReferencePlainTextEditor.vue`、`AgentComposer.vue`、`AgentChatSurface.vue` 均通过。
+- `bun run typecheck`：通过，退出码 0。
+- 首次未执行 `nuxt prepare` 的测试尝试因仓库 global setup 找不到 tsconfig 失败；补齐生成文件后重跑通过，该失败不是本次代码断言失败。
+- 浏览器待验收：Windows 中文输入法选字、折叠/展开、空闲/运行中、Enter/Shift+Enter/Ctrl+Enter/Meta+Enter，以及图片校验失败时按钮与键盘入口一致阻止。

--- a/docs/tasks/63-tool-approval-policy-system/README.md
+++ b/docs/tasks/63-tool-approval-policy-system/README.md
@@ -240,7 +240,7 @@ type UserInputFormSpec = {
 
 ### 诊断
 
-- 复查 #45 合并后的真实调用链确认 Enter、steer 和 Ctrl/Meta+Enter followup 已恢复，但共享编辑器仍没有排除输入法组合态。Windows 中文输入法确认候选字也会产生 Enter keydown，可能被误判为提交。
+- 复查 https://github.com/notnotype/neuro-book/pull/45 合并后的真实调用链确认 Enter、steer 和 Ctrl/Meta+Enter followup 已恢复，但共享编辑器仍没有排除输入法组合态。Windows 中文输入法确认候选字也会产生 Enter keydown，可能被误判为提交。
 - 发送按钮已经阻止 pending 图片、未解析稳定图片、metadata error 和预算超限；`AgentComposer.submitComposer()` 只阻止 readonly 与 pending 图片，键盘入口因此可以绕过既有图片合同。
 - `AgentChatSurface` 在创建乐观消息前解析 Session 图片附件，但原解析异常不在错误出口内，失败时可能形成未处理 Promise。
 


### PR DESCRIPTION
## 关联 Issue / Related issue

Closes #56

## 解决的问题 / Problem

Agent 输入框的键盘提交入口需要和发送按钮使用同一套阻止条件。中文输入法确认候选字时不能误发送；图片仍在上传、附件 metadata 校验失败或预算超限时，键盘也不能绕过按钮门禁创建消息。

## 本次范围 / Scope

包含 / In scope:

- 在共享纯文本编辑器中识别输入法组合态，保留普通 Enter、Shift+Enter、菜单选择和 Ctrl/Meta+Enter 的既有语义。
- 统一 Agent Composer 的按钮与键盘提交门禁，覆盖只读、图片 pending、未解析图片、metadata error 和预算超限。
- 让 prompt、steer、followup 的附件 metadata 解析失败在乐观消息和 Session invoke 前通过通知返回。
- 更新 Task 63 与 Task 108 walkthrough。

不包含 / Out of scope:

- 消息 API、Session 状态、DTO、数据库、图片事务模型。
- Markdown Studio、Monaco 或其它编辑器的快捷键。
- 新增测试文件、浏览器自动化和发布配置。

## 用户可见结果与实现 / User-visible result and implementation

- 折叠 Composer 中普通 Enter 可发送；运行中展开 Composer 的 Ctrl/Meta+Enter 可发送 followup，Shift+Enter 仍插入换行。
- 输入法组合态的 Enter 交回输入法，不会误提交。
- 图片校验未完成或失败时，按钮和键盘入口一致阻止提交；附件解析失败不会创建 client message、乐观消息或 Session invoke。
- 实现集中在共享编辑器的组合态门禁、Agent Composer 的 computed 提交门禁，以及 AgentChatSurface 的附件解析错误出口。

## 验证 / Verification

实际执行的完整命令和结果 / Exact commands and results:

```text
bun install
通过

bun run generate
通过

bun run nuxt:prepare
通过

bunx vitest run app/components/novel-ide/agent/useComposerImageTransaction.test.ts app/components/novel-ide/agent/agent-invocation-reconciliation.test.ts app/components/novel-ide/agent/agent-composer-draft.test.ts
3 files passed, 16 tests passed

bun -e "import {parse, compileScript, compileTemplate} from '@vue/compiler-sfc'; const files = ['app/components/common/form/ReferencePlainTextEditor.vue', 'app/components/novel-ide/agent/AgentComposer.vue', 'app/components/novel-ide/agent/AgentChatSurface.vue']; for (const filename of files) { const source = await Bun.file(filename).text(); const {descriptor, errors} = parse(source, {filename}); if (errors.length) throw errors[0]; compileScript(descriptor, {id: filename}); if (descriptor.template) { const result = compileTemplate({source: descriptor.template.content, filename, id: filename}); if (result.errors.length) throw result.errors[0]; } } console.log('SFC compile probe passed');"
SFC compile probe passed

bun run typecheck
通过，退出码 0

git diff --check
git diff --cached --check
通过；仅有 Windows LF/CRLF 提示
```

未运行的检查及原因 / Checks not run and why:

- 未运行全量测试；本轮是局部输入门禁修复，按约束只跑既有相关聚焦回归。
- 未自动进行浏览器验收；Windows 中文输入法、折叠/展开和真实快捷键需由用户在浏览器中确认。

## 界面证据 / UI evidence

未附截图或录屏。根据仓库协作规定未自动启动浏览器；待用户验收 Windows 中文输入法选字、空闲/运行中、Enter/Shift+Enter/Ctrl+Enter/Meta+Enter，以及图片校验失败时按钮与键盘入口一致阻止。

## 文档与记录 / Documentation and records

- [x] 已确认不需要更新用户文档 / User documentation not needed
- [x] 已更新 Task walkthrough / Task walkthrough updated
- [x] 已确认不需要更新 Reference、ADR 与 `PROJECT-STATUS.md` / Reference, ADR, and `PROJECT-STATUS.md` not needed
- [x] 本 PR 不修改版本号或 `RELEASE.md` / Version and release notes unchanged

## 风险与边界 / Risks and boundaries

- 数据结构或迁移 / Data shape or migration: 无变化
- 配置、安装或发布 / Configuration, installation, or release: 无变化
- 安全与隐私 / Security and privacy: 无变化；未加入日志、截图或 fixture
- 已知限制与后续事项 / Known limitations and follow-ups: 浏览器交互验收仍待用户执行；未增加测试文件

## 提交者确认 / Contributor confirmation

- [x] 一个连贯目标之外没有夹带其它改动 / No unrelated changes
- [x] 我已审查并能解释全部改动 / All changes reviewed
- [x] 验证结果真实，聚焦测试没有被描述成全量测试 / Verification is accurate
- [x] 日志、截图和 fixture 不含密钥、小说正文、私人会话或未授权内容 / No sensitive artifacts