### PR TITLE
refactor(dir-layout): 目录约定三层结构 + 测试临时根统一 .agent/tmp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ product/
 # 外部工具产生的调试 trace（与运行时 .nbook/agent/traces 无关）
 .traces/
 .agent/manual-retrieval-e2e-build-check/
-.agent/workspace
 /workspace/
 /logs/
 /coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ product/
 /logs/
 /coverage/
 /.agent/
+/.worktree/
 docs/.vitepress/dist
 docs/.vitepress/cache
 assets/workspace/.nbook/agent/profiles/.compiled/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,10 +47,10 @@
 
 1. 想法 / bug / 需求先开 GitHub Issue（`type:*` + `status:*` 标签）；维护者用 `gh issue create` 直接开即可，不必走 Issue Form（表单面向外部贡献者）。`PROJECT-STATUS.md` 不再新增 TODO 清单。
 2. 重大任务继续按 `docs/tasks/README.md` 建任务目录：issue 是需求层，task 是文档层，两者互补不替代。
-3. 开工前 `git fetch origin`，然后 `git worktree add .agent/workspace/wt/<slug> -b <branch> origin/master`（worktree 固定在 `wt/` 子目录，与临时文件区分；存量 worktree 不迁移）。新 worktree 没有 `node_modules`，首次使用前必须 `bun install`。
+3. 开工前 `git fetch origin`，然后 `git worktree add .worktree/<slug> -b <branch> origin/master`（worktree 固定在仓库根 `.worktree/` 目录，与 `.agent` 临时区区分；存量 worktree 不迁移）。新 worktree 没有 `node_modules`，首次使用前必须 `bun install`。
 4. 在 worktree 内开发；完成后 push 分支并 `gh pr create`。PR 完整覆盖 issue 时正文用 `Closes #N`（merge 会自动关闭 issue）；只覆盖一部分时用 `Refs #N`，避免 issue 被提前关闭。
 5. **到此停下，向用户报告验证结果与 PR 链接。Agent 不得自行合并 PR、关闭 issue 或做其它收尾动作。** Agent 可以自审或跑代码审查并把结论附在报告里，但「审查完成」的判定与收尾许可都来自用户；浏览器验收同样由用户执行或授权。
-6. 收尾（仅在用户许可后，一次做完）：确认 CI 通过且本地验证（typecheck + 相关聚焦测试）通过（现状 CI 没有 required check，见 issue #15，本地验证是实际门禁）→ `gh pr merge --squash --delete-branch`（squash 提交信息 = PR 标题，Conventional Commit 格式）→ issue 应随 `Closes` 自动关闭，未关闭时手动 `gh issue close` 并留言说明 → 主工作区立刻 `git fetch && git merge --ff-only origin/master`（有在途改动先提交或 stash）→ `git worktree remove .agent/workspace/wt/<slug>` 并 `git branch -D <branch>`（`--delete-branch` 删不掉仍被 worktree 占用的本地分支，不手动清理会残留）。收尾链任一步失败时报告断点，从断点继续，不要重头执行（已完成的步骤如 merge 不可重复）。
+6. 收尾（仅在用户许可后，一次做完）：确认 CI 通过且本地验证（typecheck + 相关聚焦测试）通过（现状 CI 没有 required check，见 issue #15，本地验证是实际门禁）→ `gh pr merge --squash --delete-branch`（squash 提交信息 = PR 标题，Conventional Commit 格式）→ issue 应随 `Closes` 自动关闭，未关闭时手动 `gh issue close` 并留言说明 → 主工作区立刻 `git fetch && git merge --ff-only origin/master`（有在途改动先提交或 stash）→ `git worktree remove .worktree/<slug>` 并 `git branch -D <branch>`（`--delete-branch` 删不掉仍被 worktree 占用的本地分支，不手动清理会残留）。收尾链任一步失败时报告断点，从断点继续，不要重头执行（已完成的步骤如 merge 不可重复）。
 7. 远端 `master` 被任何 worktree 或 agent 更新后（不限于自己的收尾），主工作区必须立刻 `git fetch && git merge --ff-only origin/master`，防止主工作区停在旧提交产生分叉。
 8. Windows 上 `node_modules` 深路径可能让 `git worktree remove` 报 `Filename too long`：先 `git config core.longpaths true` 重试；注册已清除但目录残留时，在 PowerShell 里用 robocopy 镜像空目录清掉（Git Bash 会把 `/MIR` 误转成路径）。
 
@@ -193,7 +193,8 @@
 
 - 可读取 node_modules 下的源代码
 - 可以使用 get_file_contents、search_code、issue_read 搜寻 github 项目
-- .agent/workspace 为你可随意操作的目录（.agent 目录不是），你可以再此编写临时文件、clone 代码等
+- `.agent` 为你可随意操作的目录，可以在此编写临时文件、clone 代码等（运行时业务临时目录如 `manager-product-build`、`product-runtime-acceptance` 也放这里；**不要**在 `.worktree/` 或快照目录里做这类操作）
+- 测试临时根统一放 `.agent/tmp/<test-name>-<uuid>/`（新测试用 `createTestTmpRoot`），由 vitest globalSetup 在每次 run 起点按 24h 窗口 + owner marker 兜底清理，无需手工清理
 - 可以通过编写测试脚本并运行来测试数据
 - 如果要写 commit message 的时候，可以从 docs/tasks PROJECT-STATUS.md 获取信息，查看他们的最新变更。提交信息要丰富，覆盖所有相关 tasks。重点关心新功能
 

--- a/packages/neuro-book-manager/src/product.ts
+++ b/packages/neuro-book-manager/src/product.ts
@@ -35,7 +35,7 @@ export async function installSourceDependencies(root: string, bun = "bun"): Prom
 /**
  * 从源码执行统一 `nuxt:build` Builder，并把已验证镜像移入 Manager staging。
  *
- * Builder 输出先放在 Source Root 内被 Git 忽略的 `.agent/workspace`，既满足 Builder
+ * Builder 输出先放在 Source Root 内被 Git 忽略的 `.agent`，既满足 Builder
  * 同盘原子切换合同，也不会提前覆盖 Installation Root 当前 `.output`。
  */
 export async function buildSourceProduct(input: {
@@ -50,7 +50,7 @@ export async function buildSourceProduct(input: {
 }): Promise<StagedProduct> {
     const sourceRoot = input.sourceRoot ?? input.root;
     const operationId = `manager-${randomUUID()}`;
-    const buildOutput = join(sourceRoot, ".agent", "workspace", "manager-product-build", operationId, ".output");
+    const buildOutput = join(sourceRoot, ".agent", "manager-product-build", operationId, ".output");
     const stagedOutput = join(input.staging, ".output");
     await removePath(stagedOutput);
     await removePath(dirname(buildOutput));

--- a/scripts/build/local-product-publisher.test.ts
+++ b/scripts/build/local-product-publisher.test.ts
@@ -31,7 +31,7 @@ describe("LocalProductPublisher", {timeout: 30_000}, () => {
         const root = await sourceFixture();
         const builder = new ProductRuntimeImageBuilder(root);
         const candidate = await candidateImage(builder, "explicit-output", "explicit");
-        const outputRoot = join(root, ".agent", "workspace", "manager-build", ".output");
+        const outputRoot = join(root, ".agent", "tmp", "manager-build", ".output");
         await mkdir(outputRoot, {recursive: true});
 
         const published = await new LocalProductPublisher(root, builder).publish({
@@ -73,7 +73,7 @@ describe("LocalProductPublisher", {timeout: 30_000}, () => {
         const root = await sourceFixture();
         const builder = new ProductRuntimeImageBuilder(root);
         const candidate = await candidateImage(builder, "occupied-output", "candidate");
-        const outputRoot = join(root, ".agent", "workspace", "occupied", ".output");
+        const outputRoot = join(root, ".agent", "tmp", "occupied", ".output");
         await mkdir(outputRoot, {recursive: true});
         await writeFile(join(outputRoot, "owned.txt"), "caller", "utf8");
 

--- a/scripts/build/nuxt-output-contract.test.ts
+++ b/scripts/build/nuxt-output-contract.test.ts
@@ -48,7 +48,7 @@ describe("Nuxt raw Product output", () => {
     });
 
     it("保留 Builder 候选目录并使用 Source digest 派生稳定 build ID", async () => {
-        const candidate = resolve(".agent", "workspace", "nuxt-output-contract", ".output");
+        const candidate = resolve(".agent", "tmp", "nuxt-output-contract", ".output");
         const sourceDigest = `sha256:${"a".repeat(64)}`;
         const {stdout} = await execFileAsync("bun", ["-e", configProbe], {
             cwd: process.cwd(),
@@ -71,12 +71,12 @@ describe("Nuxt raw Product output", () => {
     });
 
     it.each([
-        ["只设置 output root", resolve(".agent", "workspace", "nuxt-output-only"), "", "同时注入"],
-        ["只设置 image root", "", resolve(".agent", "workspace", "nuxt-image-only"), "同时注入"],
+        ["只设置 output root", resolve(".agent", "tmp", "nuxt-output-only"), "", "同时注入"],
+        ["只设置 image root", "", resolve(".agent", "tmp", "nuxt-image-only"), "同时注入"],
         [
             "注入不一致的两个 root",
-            resolve(".agent", "workspace", "nuxt-output-mismatch"),
-            resolve(".agent", "workspace", "nuxt-image-mismatch"),
+            resolve(".agent", "tmp", "nuxt-output-mismatch"),
+            resolve(".agent", "tmp", "nuxt-image-mismatch"),
             "不一致",
         ],
     ])("%s 时拒绝 raw Product build", async (_label, outputRoot, imageRoot, expectedMessage) => {
@@ -96,7 +96,7 @@ describe("Nuxt raw Product output", () => {
         ["缺少", ""],
         ["无效", "sha256:bad"],
     ])("%s Source digest 时拒绝 raw Product build", async (_label, sourceDigest) => {
-        const candidate = resolve(".agent", "workspace", "nuxt-output-digest");
+        const candidate = resolve(".agent", "tmp", "nuxt-output-digest");
         await expect(execFileAsync("bun", ["-e", configProbe], {
             cwd: process.cwd(),
             env: {

--- a/scripts/build/product-bundle-plugins.test.ts
+++ b/scripts/build/product-bundle-plugins.test.ts
@@ -56,7 +56,7 @@ describe("Product bundle plugins", () => {
     });
 
     it("为code splitting后的Web提取CommonJS入口保留命名导出", async () => {
-        const workspaceRoot = resolve(".agent", "workspace");
+        const workspaceRoot = resolve(".agent", "tmp");
         await mkdir(workspaceRoot, {recursive: true});
         const root = await mkdtemp(join(workspaceRoot, "readability-interop-"));
         const sourceRoot = join(root, "source");

--- a/scripts/build/product-command-bundle.test.ts
+++ b/scripts/build/product-command-bundle.test.ts
@@ -18,7 +18,7 @@ afterEach(async () => {
 
 describe("Product command metafile", () => {
     it("按 entryPoint 建立入口，不依赖输出文件名", () => {
-        const commandRoot = resolve(".agent", "workspace", "product-command-metafile", "commands");
+        const commandRoot = resolve(".agent", "tmp", "product-command-metafile", "commands");
         const metafile = buildMetafile(commandRoot);
 
         const entries = resolveProductCommandEntries(metafile, commandRoot);
@@ -30,7 +30,7 @@ describe("Product command metafile", () => {
     });
 
     it("按 commands root 解析 esbuild 返回的相对 output key 与 entryPoint", () => {
-        const commandRoot = resolve(".agent", "workspace", "product-command-metafile-relative", "commands");
+        const commandRoot = resolve(".agent", "tmp", "product-command-metafile-relative", "commands");
         const metafile = buildMetafile(commandRoot, true);
         for (const output of Object.values(metafile.outputs)) {
             output.entryPoint = relative(commandRoot, output.entryPoint!);
@@ -45,7 +45,7 @@ describe("Product command metafile", () => {
     });
 
     it("拒绝 metafile entry output 逃逸 commands root", () => {
-        const commandRoot = resolve(".agent", "workspace", "product-command-metafile", "commands");
+        const commandRoot = resolve(".agent", "tmp", "product-command-metafile", "commands");
         const metafile = buildMetafile(commandRoot);
         const [firstOutput, definition] = Object.entries(metafile.outputs)[0]!;
         delete metafile.outputs[firstOutput];
@@ -56,7 +56,7 @@ describe("Product command metafile", () => {
     });
 
     it("拒绝相对 metafile output 通过上级目录逃逸", () => {
-        const commandRoot = resolve(".agent", "workspace", "product-command-metafile-relative-escape", "commands");
+        const commandRoot = resolve(".agent", "tmp", "product-command-metafile-relative-escape", "commands");
         const metafile = buildMetafile(commandRoot, true);
         const [firstOutput, definition] = Object.entries(metafile.outputs)[0]!;
         delete metafile.outputs[firstOutput];

--- a/scripts/build/product-runtime-contract.test.ts
+++ b/scripts/build/product-runtime-contract.test.ts
@@ -6,7 +6,7 @@ describe("Product 临时验收实例合同", () => {
     it("只复制 verified .output，并通过 bundle commands 运行", async () => {
         const source = await readFile(resolve("scripts", "deploy", "product-runtime.mjs"), "utf8");
 
-        expect(source).toContain('".agent", "workspace", "product-runtime-acceptance"');
+        expect(source).toContain('".agent", "product-runtime-acceptance"');
         expect(source).toContain("ProductRuntimeImageBuilder");
         expect(source).toContain("openVerified");
         expect(source).toContain('resolve(stageRoot, ".output")');

--- a/scripts/deploy/product-browser-smoke.ts
+++ b/scripts/deploy/product-browser-smoke.ts
@@ -117,7 +117,7 @@ function parseOptions(args: string[]): SmokeOptions {
         url: new URL(url).href,
         expectedVersion,
         browserExecutable: resolve(browserExecutable),
-        screenshot: resolve(values.get("--screenshot") ?? ".agent/workspace/product-browser-smoke-failure.png"),
+        screenshot: resolve(values.get("--screenshot") ?? ".agent/product-browser-smoke-failure.png"),
     };
 }
 

--- a/scripts/deploy/product-runtime.mjs
+++ b/scripts/deploy/product-runtime.mjs
@@ -12,7 +12,7 @@ import {PRODUCT_BUN_RUNTIME_ARGS, PRODUCT_RUNTIME_COMMAND_BOOTSTRAP} from "../..
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const BUILD_OUTPUT_ROOT = resolve(REPO_ROOT, process.env.NEURO_BOOK_OUTPUT_DIR?.trim() || ".output");
-const ACCEPTANCE_ROOT = resolve(REPO_ROOT, ".agent", "workspace", "product-runtime-acceptance");
+const ACCEPTANCE_ROOT = resolve(REPO_ROOT, ".agent", "product-runtime-acceptance");
 const ACCEPTANCE_POINTER = resolve(ACCEPTANCE_ROOT, "current.json");
 const OWNER_FILE = ".nbook-product-acceptance.json";
 const LEASE_FILE = ".nbook-product-acceptance-lease";
@@ -37,7 +37,7 @@ if (command === "stage") {
  * 把当前已验证 Runtime Image 复制为短生命周期验收实例。
  *
  * 该命令故意不重建、不投影 Source，也不接受任意目录作为输入；产品正确性唯一
- * 来源是 Builder 已写入 ready marker 的 `.output`。实例位于 `.agent/workspace`，
+ * 来源是 Builder 已写入 ready marker 的 `.output`。实例位于 `.agent`，
  * 不再污染仓库根 `product/`。
  */
 async function stageProduct() {
@@ -203,7 +203,7 @@ function requestedOperationId() {
     return operationId;
 }
 
-/** 支持显式验收目录，但永远限制在 `.agent/workspace`。 */
+/** 支持显式验收目录，但永远限制在 `.agent`。 */
 function resolveStageRoot(operationId) {
     const configured = process.env.NEURO_BOOK_PRODUCT_STAGE_DIR?.trim();
     const stageRoot = configured
@@ -211,7 +211,7 @@ function resolveStageRoot(operationId) {
         : resolve(ACCEPTANCE_ROOT, operationId);
     assertContained(ACCEPTANCE_ROOT, stageRoot, "Product 验收目录");
     if (stageRoot === ACCEPTANCE_ROOT) {
-        throw new Error("Product 验收目录不能是 `.agent/workspace/product-runtime-acceptance` 根。");
+        throw new Error("Product 验收目录不能是 `.agent/product-runtime-acceptance` 根。");
     }
     return stageRoot;
 }
@@ -388,11 +388,11 @@ function run(commandName, args, options) {
     });
 }
 
-/** 防止环境变量或 pointer 越过 `.agent/workspace`。 */
+/** 防止环境变量或 pointer 越过 `.agent`。 */
 function assertContained(root, target, label) {
     const relativePath = relative(resolve(root), resolve(target));
     if (relativePath === "" || (!relativePath.startsWith(`..${sep}`) && relativePath !== ".." && !isAbsolute(relativePath))) {
         return;
     }
-    throw new Error(`${label} 逃逸 .agent/workspace：${target}`);
+    throw new Error(`${label} 逃逸 .agent：${target}`);
 }

--- a/server/agent/profiles/catalog.test.ts
+++ b/server/agent/profiles/catalog.test.ts
@@ -55,7 +55,7 @@ describe("AgentProfileCatalog", {timeout: 15_000}, () => {
         applicationRootBeforeTest = process.env.NEURO_BOOK_APPLICATION_ROOT;
         productImageRootBeforeTest = process.env.NEURO_BOOK_PRODUCT_IMAGE_ROOT;
         productBuildBeforeTest = process.env.NEURO_BOOK_PRODUCT_BUILD;
-        root = resolve(".agent", "workspace", "agent-profile-catalog-test", randomUUID());
+        root = resolve(".agent", "tmp", "agent-profile-catalog-test", randomUUID());
         systemRoot = join(root, "assets", ".nbook", "agent", "profiles");
         userRoot = join(root, "workspace", ".nbook", "agent", "profiles");
         await mkdir(systemRoot, {recursive: true});

--- a/server/agent/profiles/leader-assets-profile.test.ts
+++ b/server/agent/profiles/leader-assets-profile.test.ts
@@ -768,7 +768,7 @@ describe("assets builtin v3 profiles", () => {
     });
 
     it("writer writing presets 使用用户目录覆盖系统同名文件", async () => {
-        const root = resolve(".agent", "workspace", "writer-preset-test", randomUUID());
+        const root = resolve(".agent", "tmp", "writer-preset-test", randomUUID());
         const systemStyleRoot = join(root, "system", "styles");
         const userStyleRoot = join(root, "user", "styles");
         const systemReferenceRoot = join(root, "system", "references");
@@ -1044,7 +1044,7 @@ describe("assets builtin v3 profiles", () => {
     });
 
     it("leader.default Project home 初始化默认人设资源并可通过 resource-preset 校验", async () => {
-        const projectRoot = resolve(".agent", "workspace", "leader-default-home-test", randomUUID());
+        const projectRoot = resolve(".agent", "tmp", "leader-default-home-test", randomUUID());
         await mkdir(projectRoot, {recursive: true});
         try {
             const projectRef = projectWorkspaceRef(basename(projectRoot));

--- a/server/agent/profiles/profile-build-coordinator.test.ts
+++ b/server/agent/profiles/profile-build-coordinator.test.ts
@@ -12,7 +12,7 @@ describe("ProfileBuildCoordinator", () => {
     let userRoot: string;
 
     beforeEach(async () => {
-        root = resolve(".agent", "workspace", "profile-build-coordinator-test", randomUUID());
+        root = resolve(".agent", "tmp", "profile-build-coordinator-test", randomUUID());
         userRoot = join(root, "workspace", ".nbook", "agent", "profiles");
         await mkdir(userRoot, {recursive: true});
     });

--- a/server/agent/profiles/profile-compile-worker-preview.test.ts
+++ b/server/agent/profiles/profile-compile-worker-preview.test.ts
@@ -8,7 +8,7 @@ import {withIsolatedWorkspaceAssets, type IsolatedWorkspaceAssets} from "nbook/s
 
 describe("profile compile worker preview 与 lifecycle", () => {
     // 原「源码覆盖编译不写入全局 profile module cache」用例已删除（Task 125）。
-    // 它守的 `.agent/workspace/profile-module-cache` 全仓再无任何写入方，断言恒真；
+    // 它守的 `.agent/profile-module-cache` 全仓再无任何写入方，断言恒真；
     // 而且它按 cwd 相对解析，实际是在 rm/mkdir 真实仓库目录。dry-run 不写真实
     // 用户源码与 `.compiled` 由本文件后面的 preview 用例覆盖。
 

--- a/server/agent/profiles/workbench-service.test.ts
+++ b/server/agent/profiles/workbench-service.test.ts
@@ -32,18 +32,18 @@ describe("profile workbench service", () => {
 
     it("拒绝越界 fileName", async () => {
         const catalog = new AgentProfileCatalog(
-            resolve(".agent", "workspace", "profile-workbench-invalid-system"),
-            resolve(".agent", "workspace", "profile-workbench-invalid-user"),
+            resolve(".agent", "tmp", "profile-workbench-invalid-system"),
+            resolve(".agent", "tmp", "profile-workbench-invalid-user"),
         );
 
         await expect(saveProfileSource(catalog, {
             fileName: "../bad.profile.tsx",
             source: "",
-        }, workbenchRoots(resolve(".agent", "workspace", "profile-workbench-invalid")))).rejects.toThrow("相对路径");
+        }, workbenchRoots(resolve(".agent", "tmp", "profile-workbench-invalid")))).rejects.toThrow("相对路径");
     });
 
     it("从模板创建的 profile 编译后可被 catalog 加载", async () => {
-        const root = resolve(".agent", "workspace", "profile-workbench-test", randomUUID());
+        const root = resolve(".agent", "tmp", "profile-workbench-test", randomUUID());
         const userRoot = join(root, "workspace", ".nbook", "agent", "profiles");
         await mkdir(userRoot, {recursive: true});
         const catalog = new AgentProfileCatalog(join(root, "assets", ".nbook", "agent", "profiles"), userRoot);
@@ -72,7 +72,7 @@ describe("profile workbench service", () => {
     }, 30_000);
 
     it("轻量 draft 读取不触发 runtime catalog", async () => {
-        const root = resolve(".agent", "workspace", "profile-workbench-test", randomUUID());
+        const root = resolve(".agent", "tmp", "profile-workbench-test", randomUUID());
         const userRoot = join(root, "workspace", ".nbook", "agent", "profiles");
         const roots = {
             ...workbenchRoots(userRoot),
@@ -108,7 +108,7 @@ describe("profile workbench service", () => {
     }, 30_000);
 
     it("删除用户 profile 后触发全量 build 以移除 manifest entry", async () => {
-        const root = resolve(".agent", "workspace", "profile-workbench-test", randomUUID());
+        const root = resolve(".agent", "tmp", "profile-workbench-test", randomUUID());
         const userRoot = join(root, "workspace", ".nbook", "agent", "profiles");
         const fileName = "agent.deleted.profile.tsx";
         const enqueued: Array<{fileName?: string; reason: string}> = [];
@@ -259,7 +259,7 @@ export default defineAgentProfile({
     }, 30_000);
 
     it("source-draft 是未保存源码预览入口，不写入真实用户 profile 文件", async () => {
-        const root = resolve(".agent", "workspace", "profile-workbench-test", randomUUID());
+        const root = resolve(".agent", "tmp", "profile-workbench-test", randomUUID());
         const userRoot = join(root, "workspace", ".nbook", "agent", "profiles");
         await mkdir(userRoot, {recursive: true});
         try {

--- a/server/agent/test/global-setup.ts
+++ b/server/agent/test/global-setup.ts
@@ -1,4 +1,6 @@
 import {randomUUID} from "node:crypto";
+import {fileURLToPath} from "node:url";
+import {dirname, resolve} from "node:path";
 import {
     createSharedSystemAssetsSnapshot,
     removeFixtureTree,
@@ -6,22 +8,30 @@ import {
     TEST_RUN_ID_ENV,
     TEST_SYSTEM_ASSETS_SNAPSHOT_ENV,
 } from "nbook/server/workspace-files/test-workspace-fixture";
+import {sweepStaleTmpRoots} from "nbook/server/workspace-files/test-tmp-sweep";
 
 /** 本次 run 建立的共享 snapshot；teardown 时删除。 */
 let snapshotRoot: string | null = null;
 
+/** 仓库根：`server/agent/test/global-setup.ts` 向上三级。 */
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
 /**
  * Vitest run 级准备。
  *
- * 先保守回收上一次运行留下的 fixture 残留，再建立一份 run 级共享只读
- * system assets snapshot，通过环境变量传给各测试 fork。这样单次 run 只投影
- * 一份 system 模板，而不是每个用例复制一份完整 `.nbook`。
+ * 先保守回收上一次运行留下的 fixture 残留与 `.agent/tmp/` 测试临时残留，再建立一份
+ * run 级共享只读 system assets snapshot，通过环境变量传给各测试 fork。这样单次 run
+ * 只投影一份 system 模板，而不是每个用例复制一份完整 `.nbook`。
  */
 export async function setup(): Promise<void> {
     process.env[TEST_RUN_ID_ENV] = randomUUID();
     const sweep = await sweepStaleFixtureRoots();
     if (sweep.removed.length > 0 || sweep.failures.length > 0) {
         console.info(`[fixture] 回收残留 root ${sweep.removed.length} 个，保留 ${sweep.retained.length} 个，失败 ${sweep.failures.length} 个`);
+    }
+    const tmpSweep = await sweepStaleTmpRoots(REPO_ROOT);
+    if (tmpSweep.removed.length > 0 || tmpSweep.failures.length > 0) {
+        console.info(`[test-tmp] 回收残留目录 ${tmpSweep.removed.length} 个，保留 ${tmpSweep.retained.length} 个，失败 ${tmpSweep.failures.length} 个`);
     }
     snapshotRoot = await createSharedSystemAssetsSnapshot();
     process.env[TEST_SYSTEM_ASSETS_SNAPSHOT_ENV] = snapshotRoot;

--- a/server/agent/tools/approval.test.ts
+++ b/server/agent/tools/approval.test.ts
@@ -236,7 +236,7 @@ describe("approval helpers", () => {
 
     it("用户 resolution 工具集合包含动态用户输入工具", () => {
         const harness = new NeuroAgentHarness({
-            repo: new JsonlSessionRepository(resolve(".agent", "workspace", "approval-test")),
+            repo: new JsonlSessionRepository(resolve(".agent", "tmp", "approval-test")),
         });
 
         expect(harness.tools.approvalToolKeys()).not.toContain("request_user_input");
@@ -253,7 +253,7 @@ function messageText(message: Message): string {
 
 function requestUserInputSchema() {
     const harness = new NeuroAgentHarness({
-        repo: new JsonlSessionRepository(resolve(".agent", "workspace", "approval-test")),
+        repo: new JsonlSessionRepository(resolve(".agent", "tmp", "approval-test")),
     });
     const tool = harness.tools.get("request_user_input");
     if (!tool) {

--- a/server/agent/variables/definition-artifact-publish.test.ts
+++ b/server/agent/variables/definition-artifact-publish.test.ts
@@ -159,7 +159,7 @@ describe("Variable definition 原子发布", () => {
 });
 
 async function createFixture(key: string): Promise<{root: string}> {
-    const root = resolve(".agent", "workspace", "variable-publish-test", randomUUID());
+    const root = resolve(".agent", "tmp", "variable-publish-test", randomUUID());
     roots.push(root);
     await mkdir(root, {recursive: true});
     await writeDefinition(root, key);

--- a/server/agent/variables/variables.test.ts
+++ b/server/agent/variables/variables.test.ts
@@ -22,7 +22,7 @@ import type {ReadyProjectSessionRef} from "nbook/server/workspace-files/project-
 
 describe("Agent variable system", () => {
     it("未绑定Project的Session始终使用Workspace Root存储global变量", async () => {
-        const workspaceRoot = resolve(".agent", "workspace", "variable-global-root-test", randomUUID());
+        const workspaceRoot = resolve(".agent", "tmp", "variable-global-root-test", randomUUID());
         await mkdir(workspaceRoot, {recursive: true});
         try {
             const repo = new JsonlSessionRepository(workspaceRoot);
@@ -128,7 +128,7 @@ describe("Agent variable system", () => {
     });
 
     it("读取子路径时会使用注册根 default 的子字段", async () => {
-        const root = resolve(".agent", "workspace", "variable-default-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-default-test", randomUUID());
         await mkdir(root, {recursive: true});
         const repo = new JsonlSessionRepository(root);
         const snapshot = await repo.createSession({
@@ -160,7 +160,7 @@ describe("Agent variable system", () => {
     });
 
     it("session variable_patch 跟随 active path reduce", async () => {
-        const root = resolve(".agent", "workspace", "variable-session-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-session-test", randomUUID());
         await mkdir(root, {recursive: true});
         const repo = new JsonlSessionRepository(root);
         const snapshot = await repo.createSession({
@@ -200,7 +200,7 @@ describe("Agent variable system", () => {
     });
 
     it("patch 后值不符合注册 schema 时阻塞写入", async () => {
-        const root = resolve(".agent", "workspace", "variable-schema-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-schema-test", randomUUID());
         await mkdir(root, {recursive: true});
         const repo = new JsonlSessionRepository(root);
         const snapshot = await repo.createSession({
@@ -238,7 +238,7 @@ describe("Agent variable system", () => {
     });
 
     it("变量文件 JSON 损坏时返回 storage_error，而不是 not_registered", async () => {
-        const root = resolve(".agent", "workspace", "variable-storage-error-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-storage-error-test", randomUUID());
         const projectRoot = resolve(root, "project-a");
         await mkdir(resolve(projectRoot, ".nbook", "agent"), {recursive: true});
         await writeFile(resolve(projectRoot, ".nbook", "agent", "variables.json"), "{ broken", "utf8");
@@ -277,7 +277,7 @@ describe("Agent variable system", () => {
     });
 
     it("project.* 固定使用invocation捕获的Current Project，client overlay不能重绑定", async () => {
-        const root = resolve(".agent", "workspace", "variable-project-capture-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-project-capture-test", randomUUID());
         const projectA = resolve(root, "project-a");
         const projectB = resolve(root, "project-b");
         await Promise.all([
@@ -329,7 +329,7 @@ describe("Agent variable system", () => {
     });
 
     it("variable_patch schema mismatch 会抛错，交给 harness 生成 error tool result", async () => {
-        const root = resolve(".agent", "workspace", "variable-tool-error-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-tool-error-test", randomUUID());
         await mkdir(root, {recursive: true});
         const repo = new JsonlSessionRepository(root);
         const snapshot = await repo.createSession({
@@ -367,7 +367,7 @@ describe("Agent variable system", () => {
     });
 
     it("Agent patch 必须先在同一 invocation 读取变量", async () => {
-        const root = resolve(".agent", "workspace", "variable-read-before-patch-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-read-before-patch-test", randomUUID());
         await mkdir(root, {recursive: true});
         const repo = new JsonlSessionRepository(root);
         const snapshot = await repo.createSession({
@@ -422,7 +422,7 @@ describe("Agent variable system", () => {
     });
 
     it("client.* patch ack 后同一 invocation 的新 accessor 能 read-after-write", async () => {
-        const root = resolve(".agent", "workspace", "variable-client-overlay-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-client-overlay-test", randomUUID());
         await mkdir(root, {recursive: true});
         const repo = new JsonlSessionRepository(root);
         const snapshot = await repo.createSession({
@@ -485,7 +485,7 @@ describe("Agent variable system", () => {
     });
 
     it("global/project 变量文件已写但 audit 失败时返回明确半提交错误", async () => {
-        const root = resolve(".agent", "workspace", "variable-audit-failure-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-audit-failure-test", randomUUID());
         await mkdir(root, {recursive: true});
         const repo = new JsonlSessionRepository(root);
         const snapshot = await repo.createSession({
@@ -567,7 +567,7 @@ describe("Agent variable system", () => {
             path: "project.definitions.ts",
             message: "project definition 已过期",
         }]);
-        const root = resolve(".agent", "workspace", "variable-schema-issue-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-schema-issue-test", randomUUID());
         await mkdir(root, {recursive: true});
         const repo = new JsonlSessionRepository(root);
         const snapshot = await repo.createSession({
@@ -591,7 +591,7 @@ describe("Agent variable system", () => {
     });
 
     it("project.* 缺少本轮 Project Workspace 时返回 unavailable", async () => {
-        const root = resolve(".agent", "workspace", "variable-project-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-project-test", randomUUID());
         await mkdir(root, {recursive: true});
         const repo = new JsonlSessionRepository(root);
         const snapshot = await repo.createSession({
@@ -627,7 +627,7 @@ describe("Agent variable system", () => {
     });
 
     it("Workspace Root / Project definition 只加载 hash 匹配的 .compiled artifact", async () => {
-        const root = resolve(".agent", "workspace", "variable-definition-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-definition-test", randomUUID());
         await mkdir(root, {recursive: true});
         const definitionPath = resolve(root, "definitions.ts");
         await writeFile(definitionPath, [
@@ -670,7 +670,7 @@ describe("Agent variable system", () => {
     });
 
     it("variable definition full compile 使用内容寻址文件名且不读取旧固定产物", async () => {
-        const root = resolve(".agent", "workspace", "variable-definition-prune-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-definition-prune-test", randomUUID());
         await mkdir(resolve(root, ".compiled"), {recursive: true});
         await writeFile(resolve(root, "definitions.ts"), [
             "import {Type, defineWorkspaceRootVariable} from \"nbook/variable-sdk\";",
@@ -696,7 +696,7 @@ describe("Agent variable system", () => {
     });
 
     it("variable definition manifest 未变化时保留 generatedAt", async () => {
-        const root = resolve(".agent", "workspace", "variable-definition-generated-at-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-definition-generated-at-test", randomUUID());
         const definitionPath = resolve(root, "definitions.ts");
         const manifestPath = resolve(root, ".compiled", "manifest.json");
         await mkdir(root, {recursive: true});
@@ -732,7 +732,7 @@ describe("Agent variable system", () => {
     }, 15_000);
 
     it("skipFresh 会在 type artifact 缺失时重新编译 variable definition", async () => {
-        const root = resolve(".agent", "workspace", "variable-definition-skip-type-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-definition-skip-type-test", randomUUID());
         const definitionPath = resolve(root, "definitions.ts");
         await mkdir(root, {recursive: true});
         await writeFile(definitionPath, [
@@ -760,7 +760,7 @@ describe("Agent variable system", () => {
     }, 15_000);
 
     it("只读 Product variable definition 新鲜时零写入，过期时要求重建", async () => {
-        const root = resolve(".agent", "workspace", "variable-definition-readonly-test", randomUUID());
+        const root = resolve(".agent", "tmp", "variable-definition-readonly-test", randomUUID());
         const stagingRoot = resolve(root, "runtime-staging");
         const definitionPath = resolve(root, "definitions.ts");
         const manifestPath = resolve(root, ".compiled", "manifest.json");
@@ -804,7 +804,7 @@ describe("Agent variable system", () => {
     });
 
     it("Product variable definition只记录.output/server自包含依赖", async () => {
-        const productRoot = resolve(".agent", "workspace", "variable-product-context-test", randomUUID());
+        const productRoot = resolve(".agent", "tmp", "variable-product-context-test", randomUUID());
         const outputRoot = join(productRoot, ".output", "server");
         const authoringRoot = join(outputRoot, "authoring");
         const definitionRoot = join(outputRoot, "assets", "workspace", ".nbook", "agent", "variables");
@@ -854,8 +854,8 @@ describe("Agent variable system", () => {
 
     it("不同物理 Product root 生成相同 variable artifact", async () => {
         const roots = [
-            resolve(".agent", "workspace", "variable-product-determinism-a", randomUUID()),
-            resolve(".agent", "workspace", "variable-product-determinism-b", randomUUID()),
+            resolve(".agent", "tmp", "variable-product-determinism-a", randomUUID()),
+            resolve(".agent", "tmp", "variable-product-determinism-b", randomUUID()),
         ];
         const previousCwd = process.cwd();
         const previousImageRoot = process.env.NEURO_BOOK_PRODUCT_IMAGE_ROOT;

--- a/server/agent/workflow/book-deconstruct.workflow.test.ts
+++ b/server/agent/workflow/book-deconstruct.workflow.test.ts
@@ -17,7 +17,7 @@ import {
 describe("book-deconstruct workflow", () => {
     const catalog = new WorkflowCatalog(
         resolve("assets", "workspace", ".nbook", "agent", "workflows"),
-        resolve(".agent", "workspace", "book-deconstruct-test", "no-user-root"),
+        resolve(".agent", "tmp", "book-deconstruct-test", "no-user-root"),
     );
 
     /** 从 catalog 取定义；缺失时让测试以明确错误失败。 */

--- a/server/agent/workflow/chapter-write-review-revise.workflow.test.ts
+++ b/server/agent/workflow/chapter-write-review-revise.workflow.test.ts
@@ -18,7 +18,7 @@ import {
 describe("chapter-write-review-revise workflow", () => {
     const catalog = new WorkflowCatalog(
         resolve("assets", "workspace", ".nbook", "agent", "workflows"),
-        resolve(".agent", "workspace", "chapter-wrr-test", "no-user-root"),
+        resolve(".agent", "tmp", "chapter-wrr-test", "no-user-root"),
     );
     const chapterPath = "manuscript/001-volume/001-chapter/index.md";
     const chapterBody = "# 第一章 星陨遗迹\n薇洛丝在遗迹深处解开了封印。";

--- a/server/agent/workflow/character-qa-fanout.workflow.test.ts
+++ b/server/agent/workflow/character-qa-fanout.workflow.test.ts
@@ -17,7 +17,7 @@ import {
 describe("character-qa-fanout workflow", () => {
     const catalog = new WorkflowCatalog(
         resolve("assets", "workspace", ".nbook", "agent", "workflows"),
-        resolve(".agent", "workspace", "character-qa-fanout-test", "no-user-root"),
+        resolve(".agent", "tmp", "character-qa-fanout-test", "no-user-root"),
     );
 
     /** 从 catalog 取定义；缺失时让测试以明确错误失败。 */

--- a/server/agent/workflow/consistency-audit.workflow.test.ts
+++ b/server/agent/workflow/consistency-audit.workflow.test.ts
@@ -17,7 +17,7 @@ import {
 describe("consistency-audit workflow", () => {
     const catalog = new WorkflowCatalog(
         resolve("assets", "workspace", ".nbook", "agent", "workflows"),
-        resolve(".agent", "workspace", "consistency-audit-test", "no-user-root"),
+        resolve(".agent", "tmp", "consistency-audit-test", "no-user-root"),
     );
 
     /** 从 catalog 取定义；缺失时让测试以明确错误失败。 */

--- a/server/agent/workflow/workflow-builtins.test.ts
+++ b/server/agent/workflow/workflow-builtins.test.ts
@@ -17,7 +17,7 @@ import {
 describe("bundled workflows", () => {
     const catalog = new WorkflowCatalog(
         resolve("assets", "workspace", ".nbook", "agent", "workflows"),
-        resolve(".agent", "workspace", "workflow-builtins-test", "no-user-root"),
+        resolve(".agent", "tmp", "workflow-builtins-test", "no-user-root"),
     );
 
     /** 从 catalog 取定义；缺失时让测试以明确错误失败。 */

--- a/server/agent/workflow/workflow-catalog.test.ts
+++ b/server/agent/workflow/workflow-catalog.test.ts
@@ -15,7 +15,7 @@ import {
  * WorkflowCatalog：双根覆盖 + workflow.ts 转译加载 + 内联编译边界。
  */
 describe("WorkflowCatalog", () => {
-    const root = resolve(".agent", "workspace", "workflow-catalog-test", randomUUID());
+    const root = resolve(".agent", "tmp", "workflow-catalog-test", randomUUID());
     const systemRoot = join(root, "system");
     const userRoot = join(root, "user");
     const projectRoot = join(root, "project");

--- a/server/api/agent/workflow/runs.post.test.ts
+++ b/server/api/agent/workflow/runs.post.test.ts
@@ -42,7 +42,7 @@ type RouteFixture = {
 };
 
 describe("POST /api/agent/workflow/runs", () => {
-    const testRoot = resolve(".agent", "workspace", "workflow-runs-post-test");
+    const testRoot = resolve(".agent", "tmp", "workflow-runs-post-test");
     const cleanupRoots: string[] = [];
 
     beforeAll(async () => {

--- a/server/low-code-form/low-code-form.test.ts
+++ b/server/low-code-form/low-code-form.test.ts
@@ -543,7 +543,7 @@ describe("low-code form", () => {
             }],
         });
 
-        const projectWorkspace = projectWorkspaceForTest(path.resolve(".agent", "workspace", "low-code-form-context"));
+        const projectWorkspace = projectWorkspaceForTest(path.resolve(".agent", "tmp", "low-code-form-context"));
         const dto = await resolveLowCodeForm(form, context({scope: "project", projectWorkspace}));
         const result = await applyLowCodeResourceMutations(form, [{
             type: "create",
@@ -578,7 +578,7 @@ describe("low-code form", () => {
             }],
         });
 
-        const projectWorkspace = projectWorkspaceForTest(path.resolve(".agent", "workspace", "low-code-form-context"));
+        const projectWorkspace = projectWorkspaceForTest(path.resolve(".agent", "tmp", "low-code-form-context"));
         const dto = await resolveLowCodeForm(form, context({scope: "project", projectWorkspace}));
         const result = await applyLowCodeResourceMutations(form, [{
             type: "create",

--- a/server/utils/runtime-artifact-compiler-context.test.ts
+++ b/server/utils/runtime-artifact-compiler-context.test.ts
@@ -39,7 +39,7 @@ describe("runtime artifact compiler context", () => {
     });
 
     it("Product build只使用Authoring Kit编译上下文，artifact require继续指向Product runtime", async () => {
-        const root = resolve(".agent", "workspace", "artifact-context-test", randomUUID());
+        const root = resolve(".agent", "tmp", "artifact-context-test", randomUUID());
         roots.push(root);
         const outputRoot = join(root, ".output", "server");
         const authoringRoot = join(outputRoot, "authoring");
@@ -73,7 +73,7 @@ describe("runtime artifact compiler context", () => {
     });
 
     it("Product缺少自包含tsconfig时拒绝回退Source根", async () => {
-        const root = resolve(".agent", "workspace", "artifact-context-missing-test", randomUUID());
+        const root = resolve(".agent", "tmp", "artifact-context-missing-test", randomUUID());
         roots.push(root);
         const outputRoot = join(root, ".output", "server");
         await mkdir(outputRoot, {recursive: true});
@@ -88,7 +88,7 @@ describe("runtime artifact compiler context", () => {
     });
 
     it("Product identity验证失败时拒绝回退完整Source checkout", async () => {
-        const root = resolve(".agent", "workspace", "artifact-context-unverified-test", randomUUID());
+        const root = resolve(".agent", "tmp", "artifact-context-unverified-test", randomUUID());
         roots.push(root);
         const outputRoot = join(root, ".output", "server");
         const authoringRoot = join(outputRoot, "authoring");
@@ -109,7 +109,7 @@ describe("runtime artifact compiler context", () => {
     });
 
     it("没有显式 Product identity 时始终使用 Source Dev", async () => {
-        const root = resolve(".agent", "workspace", "artifact-context-source-test", randomUUID());
+        const root = resolve(".agent", "tmp", "artifact-context-source-test", randomUUID());
         roots.push(root);
         const outputRoot = join(root, ".output", "server");
         await mkdir(outputRoot, {recursive: true});

--- a/server/workspace-files/project-workspace-path-policy.test.ts
+++ b/server/workspace-files/project-workspace-path-policy.test.ts
@@ -11,7 +11,7 @@ import {
     type ProjectWorkspacePathConsumer,
 } from "nbook/server/workspace-files/project-workspace-path-policy";
 
-const workspaceRoot = absoluteFsPath(path.resolve(".agent", "workspace", "path-policy"));
+const workspaceRoot = absoluteFsPath(path.resolve(".agent", "tmp", "path-policy"));
 const ref = projectWorkspaceRef("project");
 const workspace = resolvedProjectWorkspace(
     ref,

--- a/server/workspace-files/system-assets-preflight.test.ts
+++ b/server/workspace-files/system-assets-preflight.test.ts
@@ -16,7 +16,7 @@ describe("Product system assets preflight", () => {
     });
 
     it("只读 Product Root 的新鲜 system assets 零写入，过期时明确拒绝", async () => {
-        const root = resolve(".agent", "workspace", "system-assets-preflight-test", randomUUID());
+        const root = resolve(".agent", "tmp", "system-assets-preflight-test", randomUUID());
         const applicationRoot = join(root, "product");
         const stateRoot = join(root, "state");
         const systemNbookRoot = join(applicationRoot, ".output", "server", "assets", "workspace", ".nbook");

--- a/server/workspace-files/test-tmp-sweep.test.ts
+++ b/server/workspace-files/test-tmp-sweep.test.ts
@@ -1,0 +1,141 @@
+import {access, lstat, mkdir, readFile, rm, symlink, utimes, writeFile} from "node:fs/promises";
+import {randomUUID} from "node:crypto";
+import {resolve} from "node:path";
+import {afterEach, describe, expect, it} from "vitest";
+import {
+    createTestTmpRoot,
+    sweepStaleTmpRoots,
+    TMP_MARKER_FILE,
+    TMP_MARKER_SCHEMA_VERSION,
+    type TestTmpRootMarker,
+} from "nbook/server/workspace-files/test-tmp-sweep";
+
+/** 仓库根：`server/workspace-files/` 向上两级。 */
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..");
+const TMP_ROOT = resolve(REPO_ROOT, ".agent", "tmp");
+
+/** 本次测试创建的临时根；afterEach 清理，失败中断时由下次 run 的 sweep 兜底。 */
+const cleanedRoots: string[] = [];
+
+afterEach(async () => {
+    await Promise.all(cleanedRoots.splice(0).map((root) => rm(root, {recursive: true, force: true})));
+});
+
+async function tmpDir(name: string): Promise<string> {
+    const root = resolve(TMP_ROOT, `${name}-${randomUUID()}`);
+    await mkdir(root, {recursive: true});
+    cleanedRoots.push(root);
+    return root;
+}
+
+/** 造一个带 marker 的假 tmp root，用于 sweep 判定测试。 */
+async function fakeTmpRoot(marker: Partial<TestTmpRootMarker>): Promise<string> {
+    const root = await tmpDir("sweep-case");
+    const full: TestTmpRootMarker = {
+        schemaVersion: TMP_MARKER_SCHEMA_VERSION,
+        createdAt: new Date().toISOString(),
+        pid: process.pid,
+        runId: "test-run",
+        purpose: "sweep-test",
+        ...marker,
+    };
+    await writeFile(resolve(root, TMP_MARKER_FILE), JSON.stringify(full), "utf8");
+    return root;
+}
+
+/** 把目录 mtime 改到 25 小时前，模拟「无 marker 目录超窗」。 */
+async function ageDir(root: string): Promise<void> {
+    const old = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    await utimes(root, old, old);
+}
+
+/** 找一个几乎不可能存活的 PID，用来模拟「owner 已死」。 */
+function deadPid(): number {
+    for (let candidate = 999_999; candidate > 900_000; candidate -= 7919) {
+        try {
+            process.kill(candidate, 0);
+        } catch (error) {
+            if (typeof error === "object" && error !== null && "code" in error && error.code === "ESRCH") {
+                return candidate;
+            }
+        }
+    }
+    throw new Error("找不到可用于测试的死亡 PID");
+}
+
+describe("测试临时根 sweep 兜底清理", () => {
+    it("sweep 只回收「无 marker 超窗」与「有 marker 超窗且 owner 已死」的 root", async () => {
+        const dayMs = 24 * 60 * 60 * 1000;
+        const old = new Date(Date.now() - 3 * dayMs).toISOString();
+        const aliveOwner = await fakeTmpRoot({createdAt: old, pid: process.pid});
+        const withinWindow = await fakeTmpRoot({createdAt: new Date().toISOString(), pid: deadPid()});
+        const schemaMismatch = await fakeTmpRoot({createdAt: old, pid: deadPid(), schemaVersion: 999});
+        const markedReclaimable = await fakeTmpRoot({createdAt: old, pid: deadPid()});
+        // 无 marker 的存量测试目录：靠 mtime 超窗回收。
+        const noMarkerReclaimable = await tmpDir("no-marker");
+        await ageDir(noMarkerReclaimable);
+        // 无 marker 但 mtime 仍在窗口内：保留（可能是并行 run 的活动目录）。
+        const noMarkerFresh = await tmpDir("no-marker");
+
+        const report = await sweepStaleTmpRoots(REPO_ROOT);
+
+        for (const root of [markedReclaimable, noMarkerReclaimable]) {
+            expect(report.removed).toContain(root);
+            await expect(access(root)).rejects.toMatchObject({code: "ENOENT"});
+        }
+        // 其余都必须原样保留：无法证明安全就不删。
+        for (const [root, reason] of [
+            [aliveOwner, "owner_alive"],
+            [withinWindow, "within_window"],
+            [schemaMismatch, "schema_mismatch"],
+            [noMarkerFresh, "within_window"],
+        ] as const) {
+            await expect(access(root)).resolves.toBeUndefined();
+            expect(report.retained).toContainEqual({root, reason});
+        }
+    });
+
+    it("sweep 对 .agent/tmp 下的 symlink 与普通文件一律保留（unreadable）", async () => {
+        const target = await tmpDir("symlink-target");
+        const linkRoot = resolve(TMP_ROOT, `sweep-symlink-${randomUUID()}`);
+        await symlink(target, linkRoot, "junction");
+        cleanedRoots.push(linkRoot);
+
+        const fileRoot = resolve(TMP_ROOT, `sweep-file-${randomUUID()}`);
+        await writeFile(fileRoot, "not a dir\n", "utf8");
+        cleanedRoots.push(fileRoot);
+
+        const report = await sweepStaleTmpRoots(REPO_ROOT);
+
+        expect(report.removed).not.toContain(linkRoot);
+        expect(report.removed).not.toContain(fileRoot);
+        expect(report.retained).toContainEqual({root: linkRoot, reason: "unreadable"});
+        expect(report.retained).toContainEqual({root: fileRoot, reason: "unreadable"});
+        await expect(lstat(linkRoot)).resolves.toBeDefined();
+        await expect(access(fileRoot)).resolves.toBeUndefined();
+    });
+
+    it("createTestTmpRoot 创建带 owner marker 的临时根，purpose 可指定", async () => {
+        const root = await createTestTmpRoot(REPO_ROOT, "create-test", "purpose-check");
+        try {
+            expect(root.startsWith(resolve(TMP_ROOT, "create-test-"))).toBe(true);
+            const marker = JSON.parse(await readFile(resolve(root, TMP_MARKER_FILE), "utf8")) as TestTmpRootMarker;
+            expect(marker.schemaVersion).toBe(TMP_MARKER_SCHEMA_VERSION);
+            expect(marker.pid).toBe(process.pid);
+            expect(marker.purpose).toBe("purpose-check");
+        } finally {
+            await rm(root, {recursive: true, force: true});
+        }
+    });
+
+    it("sweep 不越界：只扫 .agent/tmp，不动 .agent 下其它临时目录", async () => {
+        const outside = resolve(REPO_ROOT, ".agent", "outside-tmp-dir");
+        await mkdir(outside, {recursive: true});
+        cleanedRoots.push(outside);
+        await writeFile(resolve(outside, "keep.txt"), "keep\n", "utf8");
+
+        await sweepStaleTmpRoots(REPO_ROOT);
+
+        await expect(access(resolve(outside, "keep.txt"))).resolves.toBeUndefined();
+    });
+});

--- a/server/workspace-files/test-tmp-sweep.ts
+++ b/server/workspace-files/test-tmp-sweep.ts
@@ -1,0 +1,160 @@
+import {lstat, mkdir, mkdtemp, readdir, readFile, writeFile} from "node:fs/promises";
+import {resolve} from "node:path";
+import {randomUUID} from "node:crypto";
+import {isProcessAlive, TEST_RUN_ID_ENV} from "nbook/server/workspace-files/test-workspace-fixture";
+import {removeFixtureTree} from "nbook/server/workspace-files/test-workspace-fixture";
+
+/**
+ * 测试临时根的兜底清理（.agent/tmp）。
+ *
+ * 约定：测试临时目录统一放 `<repoRoot>/.agent/tmp/<name>-<uuid>/`，由 vitest
+ * globalSetup 在每次 run 起点 sweep 上一次 run 的残留。正常路径由各测试自己清理，
+ * 这里只负责被强杀/中断后无法走到清理代码的残留。
+ */
+export const TMP_ROOT_REL = ".agent/tmp";
+/** owner marker 文件名。 */
+export const TMP_MARKER_FILE = ".nbook-tmp.json";
+/** marker 结构版本；sweep 只回收版本一致的 root。 */
+export const TMP_MARKER_SCHEMA_VERSION = 1;
+/** 保守回收窗口：超过该时长且（无 marker 或 owner 已死）的目录才允许回收。 */
+export const TMP_STALE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/** 测试临时根目录的 owner marker。 */
+export type TestTmpRootMarker = {
+    /** marker 结构版本；不一致一律保留并报告，不回收。 */
+    schemaVersion: number;
+    /** 创建时刻 ISO 字符串；用于保守回收窗口判定。 */
+    createdAt: string;
+    /** 创建进程 PID；仍存活时绝不回收。 */
+    pid: number;
+    /** 单次 Vitest run 标识；用于把同一 run 的 root 归组诊断。 */
+    runId: string;
+    /** 用途标签，仅用于诊断。 */
+    purpose: string;
+};
+
+/** sweep 判定保留某个 root 的原因。 */
+export type TmpSweepRetainReason = "no_marker" | "schema_mismatch" | "owner_alive" | "within_window" | "unreadable";
+
+export type TmpSweepReport = {
+    /** 已成功回收的 root 绝对路径。 */
+    removed: string[];
+    /** 无法证明可安全回收的 root 及原因。 */
+    retained: {root: string; reason: TmpSweepRetainReason}[];
+    /** 回收过程中的失败项；不阻断本次 run。 */
+    failures: {root: string; message: string}[];
+};
+
+/** 解析 `.agent/tmp` 在仓库中的绝对路径。 */
+export function resolveTmpRoot(repoRoot: string): string {
+    return resolve(repoRoot, TMP_ROOT_REL);
+}
+
+/**
+ * 新建测试临时根（新测试的推荐入口）：在 `<repoRoot>/.agent/tmp/<name>-` 下
+ * `mkdtemp` 并写 owner marker。
+ *
+ * 存量测试的 `resolve(".agent", "tmp", ...)` 直接 mkdir 写法不要求迁移到本函数：
+ * sweep 对无 marker 目录按 mtime 超窗兜底回收。
+ */
+export async function createTestTmpRoot(repoRoot: string, name: string, purpose?: string): Promise<string> {
+    const tmpRoot = resolveTmpRoot(repoRoot);
+    await mkdir(tmpRoot, {recursive: true});
+    const root = await mkdtemp(resolve(tmpRoot, `${name}-`));
+    await writeTmpMarker(root, {
+        schemaVersion: TMP_MARKER_SCHEMA_VERSION,
+        createdAt: new Date().toISOString(),
+        pid: process.pid,
+        runId: process.env[TEST_RUN_ID_ENV] ?? randomUUID(),
+        purpose: purpose ?? `test-${name}`,
+    });
+    return root;
+}
+
+/**
+ * 回收上一次运行留下的测试临时 root。
+ *
+ * 安全优先：判定链上任何一步无法证明安全，一律保留并报告，绝不删除。
+ * - 有 marker：必须是真实目录 → marker 可读且 schema 一致 → 超过保守窗口 → owner 进程已死。
+ * - 无 marker：目录 mtime 超过保守窗口即可回收（存量测试不写 marker，严格要求 marker
+ *   会让残留永不回收，止不住目录暴涨）；窗口内的目录可能是并行 run 的活动目录，保留。
+ */
+export async function sweepStaleTmpRoots(repoRoot: string, now: number = Date.now()): Promise<TmpSweepReport> {
+    const report: TmpSweepReport = {removed: [], retained: [], failures: []};
+    const tmpRoot = resolveTmpRoot(repoRoot);
+    const entries = await readdir(tmpRoot, {withFileTypes: true}).catch(() => []);
+    for (const entry of entries) {
+        const root = resolve(tmpRoot, entry.name);
+        const stats = await lstat(root).catch(() => null);
+        if (!stats || stats.isSymbolicLink() || !stats.isDirectory()) {
+            report.retained.push({root, reason: "unreadable"});
+            continue;
+        }
+        const marker = await readTmpMarker(root);
+        if (marker === null) {
+            if (now - stats.mtimeMs < TMP_STALE_WINDOW_MS) {
+                report.retained.push({root, reason: "within_window"});
+                continue;
+            }
+        } else {
+            if (marker.schemaVersion !== TMP_MARKER_SCHEMA_VERSION) {
+                report.retained.push({root, reason: "schema_mismatch"});
+                continue;
+            }
+            const createdAt = Date.parse(marker.createdAt);
+            if (!Number.isFinite(createdAt) || now - createdAt < TMP_STALE_WINDOW_MS) {
+                report.retained.push({root, reason: "within_window"});
+                continue;
+            }
+            if (isProcessAlive(marker.pid)) {
+                report.retained.push({root, reason: "owner_alive"});
+                continue;
+            }
+        }
+        try {
+            await removeFixtureTree(root);
+            report.removed.push(root);
+        } catch (error) {
+            report.failures.push({root, message: error instanceof Error ? error.message : String(error)});
+        }
+    }
+    return report;
+}
+
+/** 写入 owner marker。 */
+async function writeTmpMarker(root: string, marker: TestTmpRootMarker): Promise<void> {
+    await writeFile(resolve(root, TMP_MARKER_FILE), `${JSON.stringify(marker, null, 4)}\n`, "utf8");
+}
+
+/** 读取并逐字段窄化 owner marker；任何字段不合法都返回 null，交由调用方保留目录。 */
+async function readTmpMarker(root: string): Promise<TestTmpRootMarker | null> {
+    const text = await readFile(resolve(root, TMP_MARKER_FILE), "utf8").catch(() => null);
+    if (text === null) {
+        return null;
+    }
+    let value: unknown;
+    try {
+        // marker 是磁盘上的外部数据，解析前形态未知，这里是 unknown 的正当用法。
+        value = JSON.parse(text) as unknown;
+    } catch {
+        return null;
+    }
+    if (typeof value !== "object" || value === null) {
+        return null;
+    }
+    const candidate = value as Partial<Record<keyof TestTmpRootMarker, unknown>>;
+    if (typeof candidate.schemaVersion !== "number"
+        || typeof candidate.createdAt !== "string"
+        || typeof candidate.pid !== "number"
+        || typeof candidate.runId !== "string"
+        || typeof candidate.purpose !== "string") {
+        return null;
+    }
+    return {
+        schemaVersion: candidate.schemaVersion,
+        createdAt: candidate.createdAt,
+        pid: candidate.pid,
+        runId: candidate.runId,
+        purpose: candidate.purpose,
+    };
+}

--- a/server/workspace-files/test-workspace-fixture.ts
+++ b/server/workspace-files/test-workspace-fixture.ts
@@ -487,7 +487,7 @@ async function readFixtureMarker(root: string): Promise<TestWorkspaceFixtureMark
  * 判断 owner 进程是否仍活跃。
  * ESRCH 表示进程不存在；EPERM 表示存在但无权限，视为存活。无法判定一律视为存活。
  */
-function isProcessAlive(pid: number): boolean {
+export function isProcessAlive(pid: number): boolean {
     if (!Number.isInteger(pid) || pid <= 0) {
         return true;
     }

--- a/shared/product-runtime-contract.test.ts
+++ b/shared/product-runtime-contract.test.ts
@@ -43,7 +43,7 @@ describe("Product Runtime Contract", () => {
     });
 
     it("验证 bootstrap 与所有合同入口实际存在", async () => {
-        const root = resolve(".agent", "workspace", "product-contract-test", randomUUID());
+        const root = resolve(".agent", "tmp", "product-contract-test", randomUUID());
         roots.push(root);
         const contract = contractFixture();
         const entries = new Set([


### PR DESCRIPTION
## 概述

目录约定从 `.agent/workspace` 收拢为三层结构：worktree 迁至 `.worktree/<slug>`、临时区直接用 `.agent`、测试临时根统一 `.agent/tmp/`，并新增全局兜底清理解决测试临时目录暴涨。

## 内容

- **worktree**：`.agent/workspace/wt/<slug>` → `.worktree/<slug>`（AGENTS.md 开发循环与收尾命令同步；存量 4 个 worktree 不迁移）
- **临时区**：`.agent/workspace` → `.agent`（Manager build 输出、product 验收实例、browser-smoke 截图默认路径改 `.agent` 直接子目录）
- **测试临时根**：约 24 文件 64 处 `resolve(".agent", "workspace", ...)` 统一为 `resolve(".agent", "tmp", ...)`（`docs/` 历史记录与 `assets/workspace` 内置 skill 文档中的旧路径引用为历史/用户内容，保留不动）
- **兜底清理**：新增 `server/workspace-files/test-tmp-sweep.ts`——`createTestTmpRoot` 写 owner marker，`sweepStaleTmpRoots` 按「24h 窗口 + marker PID 存活 + 无 marker 超窗回收」兜底删除，挂在 vitest globalSetup run 起点（被强杀进程到不了 teardown，靠下次 run 起点回收）
- `test-workspace-fixture.ts` 导出 `isProcessAlive`；`.gitignore` 新增 `/.worktree/`

## 验证

- typecheck 全绿
- 聚焦测试（19 文件批量）：除 `definition-artifact-publish` 的 5s 超时边界测试在并发负载下超时外全绿——该 flaky 在未改动 master 上同样出现，单独重跑全部通过，与本次改动无关
- sweep 行为验证：构造超窗 + 死 PID 残留目录被回收、窗口内目录保留

Closes #58