### PR TITLE
fix(agent): surface stop request failures

### DIFF
--- a/app/components/novel-ide/agent/AgentChatSurface.vue
+++ b/app/components/novel-ide/agent/AgentChatSurface.vue
@@ -1671,7 +1671,7 @@ const stopRun = async (): Promise<void> => {
         await agentApi.abortSession(activeSessionId.value, {reason: "user abort"});
         await syncActiveSessionRecovery();
     } catch (error) {
-        console.error("停止 Agent 运行失败", error);
+        notification.error(resolveApiErrorMessage(error, t("agent.chatSurface.stopRunFailed")));
     }
 };
 

--- a/app/i18n/locales/en-US.ts
+++ b/app/i18n/locales/en-US.ts
@@ -1995,6 +1995,7 @@ const enUS = {
             reconnectFailed: "Failed to reconnect Agent event stream",
             userTerminated: "User chose to stop this run.",
             stopped: "Stop requested",
+            stopRunFailed: "Failed to stop Agent run",
             submitAnswersFailed: "Failed to submit answers",
             cancelUserInputFailed: "Failed to cancel user input",
             switchModeFailed: "Failed to switch Agent mode",

--- a/app/i18n/locales/zh-CN.ts
+++ b/app/i18n/locales/zh-CN.ts
@@ -1993,6 +1993,7 @@ const zhCN = {
             reconnectFailed: "重新连接 Agent 事件流失败",
             userTerminated: "用户选择终止本轮。",
             stopped: "已请求停止",
+            stopRunFailed: "停止 Agent 运行失败",
             submitAnswersFailed: "提交问题答案失败",
             cancelUserInputFailed: "取消等待用户输入失败",
             switchModeFailed: "切换 Agent 模式失败",


### PR DESCRIPTION
## 概述

停止 Agent 运行失败时不再只写浏览器控制台，而是显示本地化错误通知，并保留真实运行状态供用户重试。

## 验证

- bun run typecheck: passed

- git diff --check: passed

## 范围

Refs Task 142。无 API、数据库或持久化合同变化。