### PR TITLE
fix(agent): harden session recovery

### DIFF
--- a/app/components/novel-ide/agent/AgentChatSurface.vue
+++ b/app/components/novel-ide/agent/AgentChatSurface.vue
@@ -1328,6 +1328,21 @@ const loadActiveSystemPrompt = async (refresh = false): Promise<void> => {
 };
 
 let linkedAgentRelationsRequestId = 0;
+const unavailableLinkedAgentWarningKeys = new Set<string>();
+
+const notifyUnavailableLinkedAgents = (targetSessionId: number, count: number | undefined): void => {
+    if (!count || count < 1) {
+        return;
+    }
+    const key = `${String(targetSessionId)}:${String(count)}`;
+    if (unavailableLinkedAgentWarningKeys.has(key)) {
+        return;
+    }
+    unavailableLinkedAgentWarningKeys.add(key);
+    notification.warning(t("agent.chatSurface.linkedUnavailableMessage", {count}), {
+        title: t("agent.chatSurface.linkedUnavailableTitle"),
+    });
+};
 
 /**
  * 只刷新关联 Agent 面板数据，不触碰当前对话消息流。
@@ -1345,6 +1360,7 @@ const refreshLinkedAgentRelations = async (): Promise<void> => {
             return;
         }
         session.applyRelations(relations);
+        notifyUnavailableLinkedAgents(targetSessionId, relations.unavailableLinkedAgents);
     } catch (error) {
         if (requestId !== linkedAgentRelationsRequestId || activeSessionId.value !== targetSessionId) {
             return;
@@ -2579,6 +2595,7 @@ const sessionStream = useAgentSessionStream({
     applyRecoverySideEffects: async (recovery, result, owner) => {
         if (!owner.isCurrent()) return;
         syncSessionModelState(recovery.summary);
+        notifyUnavailableLinkedAgents(recovery.summary.sessionId, recovery.unavailableLinkedAgents);
         if (result.historyWindowReset) {
             await nextTick();
             if (!owner.isCurrent()) return;
@@ -2970,6 +2987,7 @@ async function resetWorkspaceSessionState(attempt?: AgentSurfaceActivationAttemp
     inlineEditorSessionLoading.value = false;
     sessionStream.stop();
     inlineEditorStream.stop();
+    unavailableLinkedAgentWarningKeys.clear();
     const drafts = ensureComposerDraftSession();
     if (drafts) {
         drafts.update(inputText.value);

--- a/app/components/novel-ide/agent/useAgentSessionStream.test.ts
+++ b/app/components/novel-ide/agent/useAgentSessionStream.test.ts
@@ -136,6 +136,134 @@ describe("useAgentSessionStream", () => {
         stream.stop();
     });
 
+    it("同一连接内自动 recovery 失败后不重复请求同一原因", async () => {
+        const session = useAgentSession();
+        session.applyRecovery({
+            ...recovery(1, 1),
+            history: {entries: [userEntry("existing", "保留当前正文")], previousCursor: null},
+        });
+        let emit!: (event: AgentSessionEventDto) => void | Promise<void>;
+        const getSessionRecovery = vi.fn(async () => {
+            throw new Error("recovery failed");
+        });
+        const onError = vi.fn();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery,
+                subscribeSessionEvents: vi.fn(async (_sessionId, _cursor, onEvent, signal, options) => {
+                    emit = onEvent;
+                    options?.onOpen?.();
+                    await untilAbort(signal);
+                }),
+            },
+            onError,
+        });
+
+        await stream.start(1);
+        await emit(control(2, {type: "snapshot_required", reason: "trimmed"}));
+        await emit(control(2, {type: "snapshot_required", reason: "trimmed again"}));
+
+        expect(getSessionRecovery).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(session.durableEntries.value.map((entry) => entry.id)).toEqual(["existing"]);
+        expect(session.needsRecovery.value).toBe(false);
+        expect(session.connectionStatus.value).toBe("connected");
+        stream.stop();
+    });
+
+    it("同一连接内不同自动 recovery 原因可以分别尝试", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        let emit!: (event: AgentSessionEventDto) => void | Promise<void>;
+        const getSessionRecovery = vi.fn()
+            .mockRejectedValueOnce(new Error("snapshot recovery failed"))
+            .mockResolvedValueOnce(recovery(1, 2));
+        const onError = vi.fn();
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery,
+                subscribeSessionEvents: vi.fn(async (_sessionId, _cursor, onEvent, signal, options) => {
+                    emit = onEvent;
+                    options?.onOpen?.();
+                    await untilAbort(signal);
+                }),
+            },
+            onError,
+        });
+
+        await stream.start(1);
+        await emit(control(2, {type: "snapshot_required", reason: "trimmed"}));
+        await emit(control(2, {type: "session_projection_invalidated", reason: "linked_agent_changed"}));
+
+        expect(getSessionRecovery).toHaveBeenCalledTimes(2);
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(session.lastSeq.value).toBe(2);
+        stream.stop();
+    });
+
+    it("手动强制 recovery 可在自动失败后重试", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        let emit!: (event: AgentSessionEventDto) => void | Promise<void>;
+        const getSessionRecovery = vi.fn()
+            .mockRejectedValueOnce(new Error("automatic recovery failed"))
+            .mockResolvedValueOnce(recovery(1, 4));
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery,
+                subscribeSessionEvents: vi.fn(async (_sessionId, _cursor, onEvent, signal, options) => {
+                    emit = onEvent;
+                    options?.onOpen?.();
+                    await untilAbort(signal);
+                }),
+            },
+        });
+
+        await stream.start(1);
+        await emit(control(2, {type: "snapshot_required", reason: "trimmed"}));
+        await expect(stream.refreshRecovery("manual_refresh")).resolves.toBe(true);
+
+        expect(getSessionRecovery).toHaveBeenCalledTimes(2);
+        expect(session.lastSeq.value).toBe(4);
+        stream.stop();
+    });
+
+    it("重新连接后允许相同自动 recovery 原因再次尝试", async () => {
+        const session = useAgentSession();
+        session.applyRecovery(recovery(1, 1));
+        let emit!: (event: AgentSessionEventDto) => void | Promise<void>;
+        const getSessionRecovery = vi.fn()
+            .mockRejectedValueOnce(new Error("first connection failed"))
+            .mockResolvedValueOnce(recovery(1, 5));
+        const stream = useAgentSessionStream({
+            session,
+            activeSessionId: ref(1),
+            api: {
+                getSessionRecovery,
+                subscribeSessionEvents: vi.fn(async (_sessionId, _cursor, onEvent, signal, options) => {
+                    emit = onEvent;
+                    options?.onOpen?.();
+                    await untilAbort(signal);
+                }),
+            },
+        });
+
+        await stream.start(1);
+        await emit(control(2, {type: "snapshot_required", reason: "trimmed"}));
+        await stream.reconnectNow();
+        await emit(control(2, {type: "snapshot_required", reason: "trimmed again"}));
+
+        expect(getSessionRecovery).toHaveBeenCalledTimes(2);
+        expect(session.lastSeq.value).toBe(5);
+        stream.stop();
+    });
+
     it("活动连接应用 recovery 后从返回 cursor 重新订阅", async () => {
         const session = useAgentSession();
         session.applyRecovery(recovery(1, 5));
@@ -371,6 +499,8 @@ describe("useAgentSessionStream", () => {
 
         expect(session.durableEntries.value.map((entry) => entry.id)).toEqual(["existing"]);
         expect(session.historyError.value).toBe("cursor 已失效");
+        expect(session.needsRecovery.value).toBe(false);
+        expect(session.connectionStatus.value).toBe("idle");
         expect(applyRecoverySideEffects).not.toHaveBeenCalled();
     });
 

--- a/app/components/novel-ide/agent/useAgentSessionStream.ts
+++ b/app/components/novel-ide/agent/useAgentSessionStream.ts
@@ -96,9 +96,24 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
     let recoveryPromise: {sessionId: number; promise: Promise<boolean>} | null = null;
     let recoveryGeneration = 0;
     let connectionGeneration = 0;
+    let automaticRecoveryConnectionGeneration = -1;
     let stopped = false;
     let backoffSessionId: number | null = null;
+    const attemptedAutomaticRecoveryReasons = new Set<AgentSessionStreamRecoveryReason>();
     const reconnectBackoff = new SseReconnectBackoff();
+
+    const resetAutomaticRecoveryAttempts = (generation = connectionGeneration): void => {
+        automaticRecoveryConnectionGeneration = generation;
+        attemptedAutomaticRecoveryReasons.clear();
+    };
+
+    const restoreConnectionStatusAfterRecoveryFailure = (targetSessionId: number): void => {
+        const activeController = controller.value;
+        const streamAlive = activeController !== null
+            && !activeController.signal.aborted
+            && sessionId.value === targetSessionId;
+        options.session.applyConnectionStatus(streamAlive ? "connected" : "idle");
+    };
 
     const clearReconnectTimer = (): void => {
         if (!reconnectTimer) {
@@ -162,6 +177,7 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
         if (behavior.force) {
             recoveryGeneration += 1;
             recoveryPromise = null;
+            resetAutomaticRecoveryAttempts();
         }
         const generation = recoveryGeneration;
         const isCurrent = (): boolean => generation === recoveryGeneration
@@ -186,6 +202,7 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
                 if (!isCurrent()) {
                     return false;
                 }
+                resetAutomaticRecoveryAttempts();
                 reconnectBackoff.reset();
                 reconnectAttempt.value = 0;
                 const activeController = controller.value;
@@ -206,6 +223,8 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
                 if (!isCurrent()) {
                     return false;
                 }
+                options.session.clearRecoveryRequest();
+                restoreConnectionStatusAfterRecoveryFailure(targetSessionId);
                 if (behavior.reportError) {
                     options.onError?.(error, translate("agent.chatSurface.syncSessionFailed", "同步 Agent session 失败"));
                     return false;
@@ -224,6 +243,33 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
 
     /** 普通恢复共用当前 single-flight，当前错误由 stream 的错误出口处理。 */
     const syncRecovery = async (reason: AgentSessionStreamRecoveryReason): Promise<boolean> => {
+        return runRecovery(reason, {force: false, reportError: true});
+    };
+
+    /**
+     * SSE 自动恢复按连接代与原因限流。正在进行的 single-flight 可以继续复用，
+     * 但一次真实失败后，同一连接不会被相同控制事件持续打回 recovery。
+     */
+    const syncAutomaticRecovery = async (
+        reason: AgentSessionStreamRecoveryReason,
+        generation: number,
+    ): Promise<boolean> => {
+        const targetSessionId = options.activeSessionId.value;
+        if (!targetSessionId || generation !== connectionGeneration) {
+            return false;
+        }
+        if (automaticRecoveryConnectionGeneration !== generation) {
+            resetAutomaticRecoveryAttempts(generation);
+        }
+        if (recoveryPromise?.sessionId === targetSessionId) {
+            return recoveryPromise.promise;
+        }
+        if (attemptedAutomaticRecoveryReasons.has(reason)) {
+            options.session.clearRecoveryRequest();
+            restoreConnectionStatusAfterRecoveryFailure(targetSessionId);
+            return false;
+        }
+        attemptedAutomaticRecoveryReasons.add(reason);
         return runRecovery(reason, {force: false, reportError: true});
     };
 
@@ -261,7 +307,7 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
             } else if (reasons.includes("linked_agent_changed")) {
                 reason = "linked_agent_changed";
             }
-            await syncRecovery(reason);
+            await syncAutomaticRecovery(reason, generation);
         }
     };
 
@@ -279,6 +325,7 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
         controller.value?.abort();
         const nextController = new AbortController();
         const nextConnectionGeneration = ++connectionGeneration;
+        resetAutomaticRecoveryAttempts(nextConnectionGeneration);
         controller.value = nextController;
         sessionId.value = targetSessionId;
         stopped = false;
@@ -350,6 +397,7 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
         reconnectBackoff.reset();
         reconnectAttempt.value = 0;
         connectionGeneration += 1;
+        resetAutomaticRecoveryAttempts();
         controller.value?.abort();
         controller.value = null;
         sessionId.value = null;
@@ -361,6 +409,7 @@ export function useAgentSessionStream(options: AgentSessionStreamOptions) {
         stopped = true;
         clearReconnectTimer();
         connectionGeneration += 1;
+        resetAutomaticRecoveryAttempts();
         controller.value?.abort();
         controller.value = null;
         sessionId.value = null;

--- a/app/i18n/locales/en-US.ts
+++ b/app/i18n/locales/en-US.ts
@@ -1991,6 +1991,8 @@ const enUS = {
             syncSessionFailed: "Failed to sync Agent session",
             loadSessionFailed: "Failed to load Agent session",
             refreshLinkedFailed: "Failed to refresh linked Agents",
+            linkedUnavailableTitle: "Linked conversations unavailable",
+            linkedUnavailableMessage: "{count} linked conversation(s) are unavailable. You can keep using the current conversation.",
             runFailed: "Agent run failed",
             reconnectFailed: "Failed to reconnect Agent event stream",
             userTerminated: "User chose to stop this run.",

--- a/app/i18n/locales/zh-CN.ts
+++ b/app/i18n/locales/zh-CN.ts
@@ -1989,6 +1989,8 @@ const zhCN = {
             syncSessionFailed: "同步 Agent session 失败",
             loadSessionFailed: "加载 Agent session 失败",
             refreshLinkedFailed: "刷新关联 Agent 失败",
+            linkedUnavailableTitle: "关联对话不可用",
+            linkedUnavailableMessage: "有 {count} 个关联对话已不可用，当前对话仍可继续。",
             runFailed: "Agent 运行失败",
             reconnectFailed: "重新连接 Agent 事件流失败",
             userTerminated: "用户选择终止本轮。",

--- a/server/agent/harness/neuro-agent-harness.test.ts
+++ b/server/agent/harness/neuro-agent-harness.test.ts
@@ -7310,6 +7310,72 @@ describe("NeuroAgentHarness", () => {
         ]);
     });
 
+    it("关联 Session 文件缺失时保留主 Session，并分别统计 owned 与 owner 方向", async () => {
+        const parentWithMissingChild = await harness.createAgent({
+            profileKey: "leader.default",
+            initial: {},
+        });
+        const missingChild = await harness.createAgent({
+            profileKey: "leader.default",
+            initial: {},
+            parentSessionId: parentWithMissingChild.sessionId,
+        });
+        await harness.getSessionRelations(parentWithMissingChild.sessionId);
+        await rm(join(root, ".nbook", "agent", "sessions", `${String(missingChild.sessionId)}.jsonl`));
+
+        await expect(harness.getSessionRelations(parentWithMissingChild.sessionId)).resolves.toEqual({
+            sessionId: parentWithMissingChild.sessionId,
+            linkedAgents: [],
+            linkedByAgents: [],
+            unavailableLinkedAgents: 1,
+        });
+        await expect(harness.getSessionRecovery(parentWithMissingChild.sessionId)).resolves.toMatchObject({
+            summary: expect.objectContaining({sessionId: parentWithMissingChild.sessionId}),
+            linkedAgents: [],
+            linkedByAgents: [],
+            unavailableLinkedAgents: 1,
+        });
+
+        const missingOwner = await harness.createAgent({
+            profileKey: "leader.default",
+            initial: {},
+        });
+        const childWithMissingOwner = await harness.createAgent({
+            profileKey: "leader.default",
+            initial: {},
+            parentSessionId: missingOwner.sessionId,
+        });
+        await harness.getSessionRelations(childWithMissingOwner.sessionId);
+        await rm(join(root, ".nbook", "agent", "sessions", `${String(missingOwner.sessionId)}.jsonl`));
+
+        await expect(harness.getSessionRelations(childWithMissingOwner.sessionId)).resolves.toEqual({
+            sessionId: childWithMissingOwner.sessionId,
+            linkedAgents: [],
+            linkedByAgents: [],
+            unavailableLinkedAgents: 1,
+        });
+        await expect(harness.getSessionRecovery(childWithMissingOwner.sessionId)).resolves.toMatchObject({
+            summary: expect.objectContaining({sessionId: childWithMissingOwner.sessionId}),
+            linkedAgents: [],
+            linkedByAgents: [],
+            unavailableLinkedAgents: 1,
+        });
+    });
+
+    it("主 Session 自身缺失时 recovery 仍返回 SESSION_NOT_FOUND", async () => {
+        const created = await harness.createAgent({
+            profileKey: "leader.default",
+            initial: {},
+        });
+        await rm(join(root, ".nbook", "agent", "sessions", `${String(created.sessionId)}.jsonl`));
+
+        await expect(harness.getSessionRecovery(created.sessionId)).rejects.toMatchObject({
+            name: "AgentSessionNotFoundError",
+            code: "SESSION_NOT_FOUND",
+            sessionId: created.sessionId,
+        });
+    });
+
     it("relation index rebuild 期间创建 child 不会丢失 pending link", async () => {
         const parent = await harness.createAgent({
             profileKey: "leader.default",

--- a/server/agent/harness/neuro-agent-harness.ts
+++ b/server/agent/harness/neuro-agent-harness.ts
@@ -47,6 +47,7 @@ import {compileProfileSystemPrompt, validateProfileTurnPlan} from "nbook/server/
 import {JsonlSessionRepository} from "nbook/server/agent/session/session-repo";
 import {buildAgentHistoryPage} from "nbook/server/agent/session/history-query";
 import {buildAgentDialogueContent} from "nbook/server/agent/session/dialogue-content";
+import {projectRelatedSessions} from "nbook/server/agent/session/relation-projection";
 import {SessionWriteExecutor} from "nbook/server/agent/session/write-plan";
 import type {AppendManySessionEntryDraft, SessionWriteEntryBatch, SessionWritePlan, SessionWriteResult, SessionWriteTimingSink} from "nbook/server/agent/session/write-plan";
 import {ToolSessionWriteSink} from "nbook/server/agent/session/tool-session-write-sink";
@@ -161,7 +162,6 @@ import type {
     AgentCommandRequestDto,
     AgentCommandResult,
     AgentFollowUpQueueStateDto,
-    AgentLinkedSessionDto,
     AgentPendingApprovalDto,
     AgentRuntimeStreamEventDto,
     AgentSessionContextUsageDto,
@@ -2622,6 +2622,9 @@ export class NeuroAgentHarness {
             tree: this.repo.tree(snapshot),
             linkedAgents: relations.linkedAgents,
             linkedByAgents: relations.linkedByAgents,
+            ...(relations.unavailableLinkedAgents
+                ? {unavailableLinkedAgents: relations.unavailableLinkedAgents}
+                : {}),
             pendingUserInputs: await Promise.all(projection.pendingApprovals.map((pending) => this.pendingApprovalDto(snapshot, pending, true))),
             steerQueue: projectQueuedMessages(this.steerQueues.get(sessionId) ?? []),
             followUpQueue: this.publicFollowUpQueue(followUpQueue),
@@ -2677,35 +2680,29 @@ export class NeuroAgentHarness {
     ): Promise<AgentSessionRelationsDto> {
         const index = await this.relationIndex();
         const sessionId = projection.snapshot.metadata.sessionId;
-        const linkedAgents: AgentLinkedSessionDto[] = [];
-        for (const linked of this.currentOwnedLinks(sessionId, index)) {
-            const linkedSnapshot = await measureAgentTimingStep(timing, "readSession", () => this.repo.readSession(linked.targetSessionId));
-            const linkedProjection = await this.resolveSessionRuntimeProjection(linked.targetSessionId, linkedSnapshot, timing);
-            linkedAgents.push(linkedProjection.summary);
-        }
+        const linkedAgents = await projectRelatedSessions(
+            this.currentOwnedLinks(sessionId, index).map((linked) => linked.targetSessionId),
+            async (linkedSessionId) => {
+                const linkedSnapshot = await measureAgentTimingStep(timing, "readSession", () => this.repo.readSession(linkedSessionId));
+                const linkedProjection = await this.resolveSessionRuntimeProjection(linkedSessionId, linkedSnapshot, timing);
+                return linkedProjection.summary;
+            },
+        );
+        const linkedByAgents = await projectRelatedSessions(
+            this.currentOwnerLinks(sessionId, index).map((linked) => linked.ownerSessionId),
+            async (ownerSessionId) => {
+                const ownerSnapshot = await measureAgentTimingStep(timing, "readSession", () => this.repo.readSession(ownerSessionId));
+                const ownerProjection = await this.resolveSessionRuntimeProjection(ownerSessionId, ownerSnapshot, timing);
+                return ownerProjection.summary;
+            },
+        );
+        const unavailableLinkedAgents = linkedAgents.unavailable + linkedByAgents.unavailable;
         return {
             sessionId,
-            linkedAgents,
-            linkedByAgents: await this.linkedByAgentsFromIndex(sessionId, index, timing),
+            linkedAgents: linkedAgents.items,
+            linkedByAgents: [...linkedByAgents.items].sort((left, right) => right.updatedAt - left.updatedAt),
+            ...(unavailableLinkedAgents > 0 ? {unavailableLinkedAgents} : {}),
         };
-    }
-
-    /**
-     * 返回哪些 session 仍记录了指向目标 session 的 agent link。
-     * 索引按全局sessionId建立；关系不依赖Current Project归属。
-     */
-    private async linkedByAgentsFromIndex(
-        sessionId: number,
-        index: SessionRelationIndex,
-        timing?: AgentOperationTiming,
-    ): Promise<AgentLinkedSessionDto[]> {
-        const linkedByAgents: AgentLinkedSessionDto[] = [];
-        for (const linked of this.currentOwnerLinks(sessionId, index)) {
-            const ownerSnapshot = await measureAgentTimingStep(timing, "readSession", () => this.repo.readSession(linked.ownerSessionId));
-            const ownerProjection = await this.resolveSessionRuntimeProjection(linked.ownerSessionId, ownerSnapshot, timing);
-            linkedByAgents.push(ownerProjection.summary);
-        }
-        return linkedByAgents.sort((left, right) => right.updatedAt - left.updatedAt);
     }
 
     private async relationIndex(): Promise<SessionRelationIndex> {

--- a/server/agent/session/relation-projection.test.ts
+++ b/server/agent/session/relation-projection.test.ts
@@ -1,0 +1,32 @@
+import {describe, expect, it} from "vitest";
+import {projectRelatedSessions} from "nbook/server/agent/session/relation-projection";
+import {AgentSessionNotFoundError} from "nbook/server/agent/session/session-not-found-error";
+
+describe("projectRelatedSessions", () => {
+    it("只把关联目标自身的缺失投影为 unavailable", async () => {
+        const result = await projectRelatedSessions([2, 3], async (sessionId) => {
+            if (sessionId === 2) {
+                throw new AgentSessionNotFoundError(2);
+            }
+            return `session-${String(sessionId)}`;
+        });
+
+        expect(result).toEqual({
+            items: ["session-3"],
+            unavailable: 1,
+        });
+    });
+
+    it("Not Found 指向其它 Session 时继续抛出", async () => {
+        await expect(projectRelatedSessions([2], async () => {
+            throw new AgentSessionNotFoundError(3);
+        })).rejects.toBeInstanceOf(AgentSessionNotFoundError);
+    });
+
+    it("损坏、权限和其它 I/O 错误保持原样抛出", async () => {
+        const error = new Error("permission denied");
+        await expect(projectRelatedSessions([2], async () => {
+            throw error;
+        })).rejects.toBe(error);
+    });
+});

--- a/server/agent/session/relation-projection.ts
+++ b/server/agent/session/relation-projection.ts
@@ -1,0 +1,30 @@
+import {isAgentSessionNotFoundError} from "nbook/server/agent/session/session-not-found-error";
+
+export type RelatedSessionProjection<T> = Readonly<{
+    items: T[];
+    unavailable: number;
+}>;
+
+/**
+ * 读取关联 Session，并只把当前关联目标自身的缺失投影为局部不可用。
+ * 损坏、权限错误或指向其它 Session 的 Not Found 必须继续抛出。
+ */
+export async function projectRelatedSessions<T>(
+    sessionIds: readonly number[],
+    read: (sessionId: number) => Promise<T>,
+): Promise<RelatedSessionProjection<T>> {
+    const items: T[] = [];
+    let unavailable = 0;
+    for (const sessionId of sessionIds) {
+        try {
+            items.push(await read(sessionId));
+        } catch (error) {
+            if (isAgentSessionNotFoundError(error) && error.sessionId === sessionId) {
+                unavailable += 1;
+                continue;
+            }
+            throw error;
+        }
+    }
+    return {items, unavailable};
+}

--- a/shared/dto/agent-session.dto.ts
+++ b/shared/dto/agent-session.dto.ts
@@ -439,6 +439,8 @@ export type AgentSessionRelationsDto = {
     sessionId: number;
     linkedAgents: AgentLinkedSessionDto[];
     linkedByAgents: AgentLinkedSessionDto[];
+    /** 关联目标已不存在时的局部降级数量；主对话仍然可用。 */
+    unavailableLinkedAgents?: number;
 };
 
 export type AgentPendingUserInputDto = {
@@ -790,6 +792,8 @@ export type AgentSessionRecoveryDto = {
     tree: SessionTreeNode[];
     linkedAgents: AgentLinkedSessionDto[];
     linkedByAgents: AgentLinkedSessionDto[];
+    /** 关联目标已不存在时的局部降级数量；主对话仍然可用。 */
+    unavailableLinkedAgents?: number;
     pendingUserInputs: AgentPendingUserInputDto[];
     steerQueue: AgentQueuedMessageListDto;
     followUpQueue: AgentFollowUpQueueStateDto;


### PR DESCRIPTION
## 关联

- Issue：无 / None
- Task：Task 142（由 PR #69 创建）

## 用户可见结果

- 关联的子 Agent 对话缺失时，当前主对话不再被误判为整体失效；界面会提示缺失数量，主对话仍可继续。
- 自动恢复失败后不会在同一 SSE 连接中被相同事件反复触发；失败会退出“正在恢复”，保留当前正文，并允许手动刷新或重连后重试。

## 实现

- 新增严格的关联 Session 投影：只吞掉当前关联 ID 自身的 `SESSION_NOT_FOUND`，其它 ID、损坏、权限和 I/O 错误继续抛出。
- Recovery/Relations DTO 增加可选 `unavailableLinkedAgents`。
- SSE 自动恢复按连接代和原因限流；不同原因、强制刷新和重连仍可开启新尝试。
- 关联缺失警告按 Session 与数量去重，并补充中英文文案。
- 只手工移植并复核 #47 的最小关系投影思路；未引入 Session identity、ADR、CI 或其它范围。

## 验证

- `bun run test -- server/agent/session/relation-projection.test.ts app/components/novel-ide/agent/useAgentSessionStream.test.ts`：2 files / 22 tests passed。
- `bun run test -- server/agent/harness/neuro-agent-harness.test.ts`：1 file / 184 tests passed。
- `bun run typecheck`：通过。
- `git diff --check`：通过。

## 未运行与边界

- 未运行全仓测试、浏览器验收或真实 Provider；这些留到 Task 142 最终收口。
- 不合并或关闭 #47；不包含停止失败通知、Job/Workflow 持久化、Cache Root 或 Profile 窄屏修复。
- 无数据库、配置、安装或公开 API 破坏性变化；DTO 仅新增可选字段。