### PR TITLE
fix(bun): 隔离布局下 dev 模式报 ajv default 导出 500，改用 hoisted linker

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,6 @@
+[install]
+linker = "hoisted"
+
 [test]
 pathIgnorePatterns = [
     "product/**",


### PR DESCRIPTION
## 概述

Closes #71

在 bun 默认的隔离式 node_modules 布局（`.bun/<name>@<version>/`）下，Vite 依赖预打包无法解析传递的 CJS 依赖（如 `vanilla-jsoneditor` → `ajv@8.20.0`），浏览器直接加载原始 CJS 导致 `does not provide an export named "default"`，`bun dev` 打开首页即 500。

## 变更

`bunfig.toml` 增加：

```toml
[install]
linker = "hoisted"
```

经典平铺布局下 Vite 能正常预打包全部依赖，彻底规避该问题。

## 验证

- 默认隔离布局：`bun install` + `bun dev` → 首页 500（多次复现，含 `WARN Failed to resolve dependency: ajv`）。
- 应用本变更：`rm -rf node_modules && bun install` + `bun dev` → 首页正常渲染，控制台错误 0、4xx/5xx 0，跨多次重启稳定。
- 对 npm/pnpm 等平铺安装用户无行为变化。

## 备注

bun 1.3.x 的配置键是 `linker`，文档中常见的 `node-linker` 会被静默忽略（实测不生效），本 PR 用的是实际生效的键。
