### PR TITLE
feat(agent): persist job history

### DIFF
--- a/server/agent/harness/neuro-agent-harness.test.ts
+++ b/server/agent/harness/neuro-agent-harness.test.ts
@@ -28,6 +28,7 @@ import {AgentProfileCatalog} from "nbook/server/agent/profiles/catalog";
 import {createAssistantTextMessage, createTextToolResult, createUserMessage, messageText} from "nbook/server/agent/messages/message-utils";
 import type {StoredAgentMessage, StoredToolResultMessage} from "nbook/server/agent/messages/stored-types";
 import {storedMessageText} from "nbook/server/agent/messages/stored-message-presentation";
+import {encodeFollowUpQueue} from "nbook/server/agent/messages/stored-message-codec";
 import {HistorySet, Message, ModelContext, ProfilePrompt, Reminder, System} from "nbook/server/agent/profiles/profile-dsl";
 import type {AgentMessage, Message as RuntimeMessage, Usage} from "nbook/server/agent/messages/types";
 import type {AgentSessionEventDto} from "nbook/shared/dto/agent-session.dto";
@@ -8127,6 +8128,134 @@ describe("NeuroAgentHarness", () => {
             releaseTool.resolve();
             await running.catch(() => undefined);
         }
+    });
+
+    it("durable system follow-up 以稳定 deliveryId 在 queue 和 committed entry 双重去重", async () => {
+        const toolStarted = createDeferred();
+        const releaseTool = createDeferred();
+        harness.tools.register({
+            key: "durable_system_followup_gate",
+            name: "durable_system_followup_gate",
+            label: "Durable System Follow-up Gate",
+            description: "让 durable system follow-up 在当前 invocation 忙碌时排队。",
+            parameters: Type.Object({}),
+            async execute() {
+                toolStarted.resolve();
+                await releaseTool.promise;
+                return {
+                    content: [{type: "text", text: "released"}],
+                    details: {},
+                };
+            },
+        });
+        harness.profiles.register(defineAgentProfile({
+            manifest: {
+                key: "test.durable-system-followup",
+                name: "Durable System Follow-up",
+            },
+            initialSchema: Type.Object({}),
+            allowedToolKeys: ["durable_system_followup_gate"],
+            prepare() {
+                return {};
+            },
+        }), false);
+        faux.setResponses([
+            fauxAssistantMessage([
+                fauxToolCall("durable_system_followup_gate", {}, {id: "durable-system-followup-gate"}),
+            ], {stopReason: "toolUse"}),
+            fauxAssistantMessage("原始 invocation 完成"),
+            fauxAssistantMessage("durable system follow-up 已处理"),
+        ]);
+        const created = await harness.createAgent({
+            profileKey: "test.durable-system-followup",
+            initial: {},
+        });
+        const delivery = {
+            sessionId: created.sessionId,
+            text: "<system-reminder>后台 Job 完成</system-reminder>",
+            deliveryId: "delivery-job-1",
+            clientMessageId: "d0fe20a9-939f-40f0-8263-fd0bf6d5e640",
+        };
+
+        const running = harness.invokeAgent({
+            sessionId: created.sessionId,
+            mode: "prompt",
+            message: {text: "开始后台任务"},
+        });
+        try {
+            await toolStarted.promise;
+            await expect(harness.enqueueDurableSystemFollowUp(delivery)).resolves.toMatchObject({
+                state: "queued",
+                deliveryId: delivery.deliveryId,
+            });
+            await expect(harness.enqueueDurableSystemFollowUp(delivery)).resolves.toMatchObject({
+                state: "queued",
+                deliveryId: delivery.deliveryId,
+            });
+            const queued = harness.repo.reduce(await harness.repo.readSession(created.sessionId))
+                .customState[AGENT_FOLLOW_UP_QUEUE_STATE_KEY] as {items: Array<{id: string}>};
+            expect(queued.items).toEqual([expect.objectContaining({id: delivery.deliveryId})]);
+
+            releaseTool.resolve();
+            await running;
+            await harness.drainBackgroundTasks();
+
+            await expect(harness.enqueueDurableSystemFollowUp(delivery)).resolves.toMatchObject({
+                state: "persisted",
+                deliveryId: delivery.deliveryId,
+            });
+            const entries = (await harness.repo.readSession(created.sessionId)).entries;
+            expect(entries.filter((entry) => entry.type === "custom_message"
+                && entry.sourceQueueItemId === delivery.deliveryId)).toHaveLength(1);
+        } finally {
+            releaseTool.resolve();
+            await running.catch(() => undefined);
+        }
+    });
+
+    it("Harness 重启后自动 drain 已持久化的 ready follow-up queue", async () => {
+        const created = await harness.createAgent({
+            profileKey: "leader.default",
+            initial: {},
+        });
+        const deliveryId = "delivery-restart-1";
+        await harness.repo.appendEntry(created.sessionId, {
+            type: "custom",
+            key: AGENT_FOLLOW_UP_QUEUE_STATE_KEY,
+            value: encodeFollowUpQueue({
+                status: "ready",
+                items: [{
+                    id: deliveryId,
+                    clientMessageId: "2f9282c6-6dfc-4394-92fc-60a307d66a65",
+                    kind: "followup",
+                    message: {
+                        content: [{type: "text", text: "<system-reminder>重启后继续回流</system-reminder>"}],
+                    },
+                    caller: {kind: "system"},
+                    messageIdentity: "system",
+                    createdAt: 1,
+                }],
+            }),
+        });
+        await harness.dispose();
+        faux.setResponses([fauxAssistantMessage("重启回流已处理")]);
+        harness = new NeuroAgentHarness({
+            repo: new JsonlSessionRepository(root),
+            profiles: new AgentProfileCatalog(join(root, "system-profiles"), join(root, "user-profiles")),
+            modelResolver: () => faux.getModel(),
+            runtimeResolver: () => faux.runtime,
+            enableSessionSummarizer: false,
+        });
+
+        await harness.drainBackgroundTasks();
+
+        const snapshot = await harness.repo.readSession(created.sessionId);
+        expect(snapshot.entries.filter((entry) => entry.type === "custom_message"
+            && entry.sourceQueueItemId === deliveryId)).toHaveLength(1);
+        expect(harness.repo.reduce(snapshot).customState[AGENT_FOLLOW_UP_QUEUE_STATE_KEY]).toMatchObject({
+            status: "ready",
+            items: [],
+        });
     });
 
     it("idle system invocation 直接写入 custom_message，不伪装成用户消息", async () => {

--- a/server/agent/harness/neuro-agent-harness.ts
+++ b/server/agent/harness/neuro-agent-harness.ts
@@ -672,7 +672,8 @@ export class NeuroAgentHarness {
             }
             return false;
         });
-        // 后台任务启动恢复（PLAN-E）：上次进程遗留的 running/waiting job 标 interrupted 并给 owner 补发中断通知
+        this.startBackgroundTask("agent.followup.recover", this.recoverDurableFollowUps());
+        // 后台 Job durable 恢复：加载历史、迁移旧 active JSONL，并幂等恢复 pending 结果回流。
         void this.jobs.recoverInterrupted().catch((error) => {
             void appLogger.warn("agent.jobs.recoverFailed", {
                 error: error instanceof Error ? error.message : String(error),
@@ -1050,6 +1051,78 @@ export class NeuroAgentHarness {
             : {...input, clientMessageId: input.clientMessageId ?? randomUUID()};
         const {message, ...rest} = normalized;
         return this.invokeCore({...rest, source: {kind: "raw", message}});
+    }
+
+    /**
+     * 把内部系统结果可靠写入 Session 的 durable follow-up queue。
+     *
+     * accepted 只表示队列项已持久化，或同一 delivery 已经写成 Session custom_message；
+     * 不等待 Provider 回合完成。deliveryId 同时作为 queue item ID 与最终消息去重键。
+     */
+    async enqueueDurableSystemFollowUp(input: {
+        sessionId: number;
+        text: string;
+        deliveryId: string;
+        clientMessageId: string;
+    }): Promise<{state: "queued" | "persisted"; deliveryId: string; clientMessageId: string}> {
+        const result = await this.withSessionMutation(input.sessionId, async () => {
+            const snapshot = await this.repo.readSession(input.sessionId);
+            const committed = snapshot.entries.some((entry) => entry.type === "custom_message"
+                && entry.sourceQueueItemId === input.deliveryId);
+            if (committed) {
+                return {
+                    state: "persisted" as const,
+                    deliveryId: input.deliveryId,
+                    clientMessageId: input.clientMessageId,
+                };
+            }
+
+            const queue = this.followUpQueueState(input.sessionId, this.repo.reduce(snapshot));
+            const existing = queue.items.find((item) => item.id === input.deliveryId);
+            if (existing) {
+                const existingText = existing.message ? storedInputMarkdown(existing.message) : undefined;
+                if (existing.clientMessageId !== input.clientMessageId
+                    || existing.messageIdentity !== "system"
+                    || existingText !== input.text) {
+                    throw new Error(`durable system follow-up deliveryId 冲突：${input.deliveryId}`);
+                }
+                return {
+                    state: "queued" as const,
+                    deliveryId: input.deliveryId,
+                    clientMessageId: input.clientMessageId,
+                };
+            }
+
+            const item: StoredFollowUpQueueItem = {
+                id: input.deliveryId,
+                clientMessageId: input.clientMessageId,
+                kind: "followup",
+                message: {
+                    content: createStoredUserMessage(input.text).content,
+                },
+                caller: {kind: "system"},
+                messageIdentity: "system",
+                createdAt: Date.now(),
+            };
+            await this.setFollowUpQueueState(input.sessionId, queue.status === "paused"
+                ? {...queue, items: [...queue.items, item]}
+                : {status: "ready", items: [...queue.items, item]});
+            this.eventHub.publish({
+                sessionId: input.sessionId,
+                kind: "session",
+                event: {
+                    type: "follow_up_queued",
+                    item: projectQueuedMessage(item),
+                },
+            });
+            return {
+                state: "queued" as const,
+                deliveryId: input.deliveryId,
+                clientMessageId: input.clientMessageId,
+            };
+        });
+        this.startBackgroundTask("agent.followup.drain", this.drainFollowUps(input.sessionId));
+        return result;
     }
 
     /** 已完成 admission 的 queue 输入直接进入 core，禁止重新解码或保存 attachment。 */
@@ -6016,6 +6089,30 @@ export class NeuroAgentHarness {
             },
         });
         return item;
+    }
+
+    /** 启动时恢复所有 ready durable follow-up queue；每个 Session 独立 drain，互不阻塞。 */
+    private async recoverDurableFollowUps(): Promise<void> {
+        const summaries = await this.repo.listSessions();
+        for (const summary of summaries) {
+            try {
+                const snapshot = await this.repo.readSession(summary.sessionId);
+                const queue = this.readFollowUpQueueState(this.repo.reduce(snapshot));
+                if (!queue || queue.items.length === 0) {
+                    continue;
+                }
+                this.followUpQueues.set(summary.sessionId, queue);
+                this.startBackgroundTask(
+                    `agent.followup.recover.${String(summary.sessionId)}`,
+                    this.drainFollowUps(summary.sessionId),
+                );
+            } catch (error) {
+                void appLogger.warn("agent.followup.recoverFailed", {
+                    sessionId: summary.sessionId,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+            }
+        }
     }
 
     private async drainSteers(input: {

--- a/server/agent/jobs/agent-job-durable-store.test.ts
+++ b/server/agent/jobs/agent-job-durable-store.test.ts
@@ -1,0 +1,67 @@
+import {randomUUID} from "node:crypto";
+import {mkdir, readdir, rm, writeFile} from "node:fs/promises";
+import {resolve} from "node:path";
+import {describe, expect, it} from "vitest";
+import {
+    AgentJobDurableStore,
+    type DurableAgentJobRecord,
+} from "nbook/server/agent/jobs/agent-job-durable-store";
+
+describe("AgentJobDurableStore", () => {
+    it("以同目录临时文件、fsync 和原子替换保存最新记录", async () => {
+        const root = resolve(".agent", "agent-job-store-test", randomUUID());
+        const store = new AgentJobDurableStore(root);
+        const initial = record("job_store", "running");
+        await store.write(initial);
+        await store.write({
+            ...initial,
+            snapshot: {
+                ...initial.snapshot,
+                status: "completed",
+                endedAt: 2,
+                preview: "done",
+            },
+            result: {ok: true},
+            detail: {kind: "bash"},
+        });
+
+        await expect(store.read("job_store")).resolves.toMatchObject({
+            schemaVersion: 1,
+            snapshot: {jobId: "job_store", status: "completed", preview: "done"},
+            result: {ok: true},
+            detail: {kind: "bash"},
+        });
+        expect(await readdir(root)).toEqual(["job_store.json"]);
+
+        await store.delete("job_store");
+        await expect(store.read("job_store")).resolves.toBeNull();
+        await rm(root, {recursive: true, force: true});
+    });
+
+    it("拒绝损坏记录和不安全的 Job ID", async () => {
+        const root = resolve(".agent", "agent-job-store-test", randomUUID());
+        const store = new AgentJobDurableStore(root);
+        await expect(store.write(record("../escape", "running"))).rejects.toThrow("不能用于 durable 文件名");
+
+        await mkdir(root, {recursive: true});
+        await writeFile(resolve(root, "job_corrupt.json"), "{\"schemaVersion\":1}\n", "utf8");
+        await expect(store.read("job_corrupt")).rejects.toThrow();
+        await rm(root, {recursive: true, force: true});
+    });
+});
+
+function record(jobId: string, status: "running" | "completed"): DurableAgentJobRecord {
+    return {
+        schemaVersion: 1,
+        snapshot: {
+            jobId,
+            kind: "bash",
+            title: "test",
+            ownerSessionId: null,
+            status,
+            deliveryStatus: "not_required",
+            createdAt: 1,
+            ref: null,
+        },
+    };
+}

--- a/server/agent/jobs/agent-job-durable-store.ts
+++ b/server/agent/jobs/agent-job-durable-store.ts
@@ -1,0 +1,154 @@
+import {randomUUID} from "node:crypto";
+import {existsSync} from "node:fs";
+import {mkdir, open, readdir, readFile, rename, rm} from "node:fs/promises";
+import {basename, join} from "node:path";
+import {z} from "zod";
+import {
+    AgentJobSnapshotSchema,
+    type AgentJobSnapshot,
+    type JsonValue,
+} from "nbook/shared/dto/agent-job.dto";
+
+const DurableJsonValueSchema: z.ZodType<JsonValue> = z.lazy(() => z.union([
+    z.null(),
+    z.boolean(),
+    z.number(),
+    z.string(),
+    z.array(DurableJsonValueSchema),
+    z.record(z.string(), DurableJsonValueSchema),
+]));
+
+const DurableAgentJobDeliverySchema = z.object({
+    deliveryId: z.string().min(1),
+    clientMessageId: z.string().uuid(),
+    message: z.string().optional(),
+    /** accepted 后的私有 admission 证据；queued 需要在重启时重新触发 drain。 */
+    acceptedState: z.enum(["queued", "persisted"]).optional(),
+}).strict();
+
+const DurableAgentJobRecordSchema = z.object({
+    schemaVersion: z.literal(1),
+    snapshot: AgentJobSnapshotSchema,
+    result: DurableJsonValueSchema.optional(),
+    detail: DurableJsonValueSchema.optional(),
+    workflowRun: DurableJsonValueSchema.optional(),
+    delivery: DurableAgentJobDeliverySchema.optional(),
+}).strict();
+
+export type DurableAgentJobDelivery = z.infer<typeof DurableAgentJobDeliverySchema>;
+
+export type DurableAgentJobRecord = {
+    schemaVersion: 1;
+    snapshot: AgentJobSnapshot;
+    result?: JsonValue;
+    detail?: JsonValue;
+    workflowRun?: JsonValue;
+    delivery?: DurableAgentJobDelivery;
+};
+
+/**
+ * 每 Job 一个私有 JSON 文件的 durable store。
+ *
+ * 写入先在目标目录创建临时文件，fsync 文件后再原子 rename；目录 fsync 在平台支持时补做。
+ */
+export class AgentJobDurableStore {
+    constructor(readonly root: string) {}
+
+    get enabled(): boolean {
+        return this.root.length > 0;
+    }
+
+    async write(record: DurableAgentJobRecord): Promise<void> {
+        if (!this.enabled) {
+            return;
+        }
+        const parsed = DurableAgentJobRecordSchema.parse(record);
+        const target = this.pathFor(parsed.snapshot.jobId);
+        await mkdir(this.root, {recursive: true});
+        const temporary = join(this.root, `.${basename(target)}.${randomUUID()}.tmp`);
+        let handle: Awaited<ReturnType<typeof open>> | null = null;
+        try {
+            handle = await open(temporary, "wx", 0o600);
+            await handle.writeFile(`${JSON.stringify(parsed)}\n`, "utf8");
+            await handle.sync();
+            await handle.close();
+            handle = null;
+            await rename(temporary, target);
+            await this.syncDirectoryBestEffort();
+        } catch (error) {
+            await handle?.close().catch(() => undefined);
+            await rm(temporary, {force: true}).catch(() => undefined);
+            throw error;
+        }
+    }
+
+    async read(jobId: string): Promise<DurableAgentJobRecord | null> {
+        if (!this.enabled) {
+            return null;
+        }
+        const path = this.pathFor(jobId);
+        if (!existsSync(path)) {
+            return null;
+        }
+        const parsed = DurableAgentJobRecordSchema.parse(JSON.parse(await readFile(path, "utf8")));
+        if (parsed.snapshot.jobId !== jobId) {
+            throw new Error(`Agent Job durable 文件身份不匹配：${jobId}`);
+        }
+        return parsed;
+    }
+
+    async listJobIds(): Promise<string[]> {
+        if (!this.enabled || !existsSync(this.root)) {
+            return [];
+        }
+        const entries = await readdir(this.root, {withFileTypes: true});
+        return entries
+            .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+            .map((entry) => entry.name.slice(0, -".json".length))
+            .filter((jobId) => isSafeJobId(jobId))
+            .sort();
+    }
+
+    async delete(jobId: string): Promise<void> {
+        if (!this.enabled) {
+            return;
+        }
+        await rm(this.pathFor(jobId), {force: true});
+        await this.syncDirectoryBestEffort();
+    }
+
+    private pathFor(jobId: string): string {
+        if (!isSafeJobId(jobId)) {
+            throw new Error(`Agent Job ID 不能用于 durable 文件名：${jobId}`);
+        }
+        return join(this.root, `${jobId}.json`);
+    }
+
+    private async syncDirectoryBestEffort(): Promise<void> {
+        let handle: Awaited<ReturnType<typeof open>> | null = null;
+        try {
+            handle = await open(this.root, "r");
+            await handle.sync();
+        } catch (error) {
+            if (!isUnsupportedDirectorySync(error)) {
+                throw error;
+            }
+        } finally {
+            await handle?.close().catch(() => undefined);
+        }
+    }
+}
+
+function isSafeJobId(jobId: string): boolean {
+    return /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/u.test(jobId);
+}
+
+function isUnsupportedDirectorySync(error: unknown): boolean {
+    if (!(error instanceof Error) || !("code" in error)) {
+        return false;
+    }
+    return error.code === "EISDIR"
+        || error.code === "EPERM"
+        || error.code === "EINVAL"
+        || error.code === "EBADF";
+}

--- a/server/agent/jobs/agent-job-manager.test.ts
+++ b/server/agent/jobs/agent-job-manager.test.ts
@@ -1,8 +1,12 @@
-import {mkdir, readFile, rm, writeFile} from "node:fs/promises";
+import {mkdir, readFile, readdir, rm, writeFile} from "node:fs/promises";
 import {randomUUID} from "node:crypto";
 import {resolve} from "node:path";
 import {describe, expect, it, vi} from "vitest";
 import {AgentJobManager} from "nbook/server/agent/jobs/agent-job-manager";
+import {
+    AgentJobDurableStore,
+    type DurableAgentJobRecord,
+} from "nbook/server/agent/jobs/agent-job-durable-store";
 
 describe("AgentJobManager", () => {
     it("启动回执精确指向首次 running 发布，不受同步执行器后续事件污染", async () => {
@@ -187,21 +191,23 @@ describe("AgentJobManager", () => {
         }
     });
 
-    it("结果回流使用普通 prompt invocation，且 waitIdle 等到投递完成", async () => {
+    it("结果回流进入 durable system follow-up queue，且 waitIdle 等到入队完成", async () => {
         let releaseDelivery: (() => void) | undefined;
         const delivery = new Promise<void>((resolve) => {
             releaseDelivery = resolve;
         });
-        const invokeAgent = vi.fn(async () => {
+        const enqueueDurableSystemFollowUp = vi.fn(async (input: {
+            deliveryId: string;
+            clientMessageId: string;
+        }) => {
             await delivery;
             return {
-                sessionId: 7,
-                invocationId: "job-followup",
-                status: "completed" as const,
-                finalMessage: "received",
+                state: "queued" as const,
+                deliveryId: input.deliveryId,
+                clientMessageId: input.clientMessageId,
             };
         });
-        const jobs = new AgentJobManager(() => ({invokeAgent}) as never, "");
+        const jobs = new AgentJobManager(() => ({enqueueDurableSystemFollowUp}) as never, "");
         jobs.spawn({
             kind: "bash",
             title: "background task",
@@ -213,16 +219,14 @@ describe("AgentJobManager", () => {
         const idle = jobs.waitIdle().then(() => {
             idleResolved = true;
         });
-        await vi.waitFor(() => expect(invokeAgent).toHaveBeenCalledOnce());
+        await vi.waitFor(() => expect(enqueueDurableSystemFollowUp).toHaveBeenCalledOnce());
 
         expect(idleResolved).toBe(false);
-        expect(invokeAgent).toHaveBeenCalledWith({
+        expect(enqueueDurableSystemFollowUp).toHaveBeenCalledWith({
             sessionId: 7,
-            mode: "prompt",
-            message: {text: "<system-reminder>\n[后台任务完成] background task（" + jobs.list()[0]!.jobId + "）\ndone\n</system-reminder>"},
-            caller: {kind: "system"},
-            messageIdentity: "system",
-            signal: expect.any(AbortSignal),
+            text: "<system-reminder>\n[后台任务完成] background task（" + jobs.list()[0]!.jobId + "）\ndone\n</system-reminder>",
+            deliveryId: expect.any(String),
+            clientMessageId: expect.stringMatching(/^[0-9a-f-]{36}$/u),
         });
 
         releaseDelivery!();
@@ -232,11 +236,11 @@ describe("AgentJobManager", () => {
     });
 
     it.each([
-        ["返回 error", async () => ({sessionId: 7, invocationId: "delivery-error", status: "error" as const, acceptance: {state: "none" as const}, error: "owner 忙"})],
-        ["抛出异常", async () => { throw new Error("owner invocation 崩溃"); }],
-    ])("结果回流%s时只标记 delivery failed 且不重试", async (_label, invoke) => {
-        const invokeAgent = vi.fn(invoke);
-        const jobs = new AgentJobManager(() => ({invokeAgent}) as never, "");
+        ["Session queue 拒绝", async () => { throw new Error("owner queue unavailable"); }],
+        ["Session 不存在", async () => { throw new Error("owner session missing"); }],
+    ])("结果回流%s时只标记 delivery failed 且不重试", async (_label, enqueue) => {
+        const enqueueDurableSystemFollowUp = vi.fn(enqueue);
+        const jobs = new AgentJobManager(() => ({enqueueDurableSystemFollowUp}) as never, "");
         const spawned = jobs.spawn({
             kind: "workflow",
             title: "delivery failure",
@@ -252,37 +256,37 @@ describe("AgentJobManager", () => {
             deliveryError: expect.stringContaining("owner"),
             result: {ok: true},
         });
-        expect(invokeAgent).toHaveBeenCalledOnce();
+        expect(enqueueDurableSystemFollowUp).toHaveBeenCalledOnce();
     });
 
-    it("shutdown 会取消在途结果回流，不被不合作的 owner invocation 永久阻塞", async () => {
-        const invokeAgent = vi.fn(async (input: {signal?: AbortSignal}) => {
-            await new Promise<void>((resolve) => {
-                if (input.signal?.aborted) {
-                    resolve();
-                    return;
-                }
-                input.signal?.addEventListener("abort", () => resolve(), {once: true});
-            });
-            return {
-                sessionId: 7,
-                invocationId: "shutdown-followup",
-                status: "error" as const,
-            };
-        });
-        const jobs = new AgentJobManager(() => ({invokeAgent}) as never, "");
+    it("shutdown 期间完成的 Job 保留 pending，交给下次启动幂等回流", async () => {
+        const root = resolve(".agent", "agent-job-shutdown-test", randomUUID());
+        const registryPath = resolve(root, "jobs.jsonl");
+        const enqueueDurableSystemFollowUp = vi.fn();
+        const jobs = new AgentJobManager(() => ({enqueueDurableSystemFollowUp}) as never, registryPath);
         jobs.spawn({
             kind: "workflow",
             title: "shutdown delivery",
             ownerSessionId: 7,
-            run: async () => ({resultPreview: "done"}),
+            run: async (context) => {
+                await new Promise<void>((resolveGate) => {
+                    context.signal.addEventListener("abort", () => resolveGate(), {once: true});
+                });
+                return {resultPreview: "cancelled"};
+            },
         });
-        await vi.waitFor(() => expect(invokeAgent).toHaveBeenCalledOnce());
 
         await expect(Promise.race([
             jobs.shutdown().then(() => "settled"),
             new Promise<string>((resolve) => setTimeout(() => resolve("timed-out"), 300)),
         ])).resolves.toBe("settled");
+        expect(enqueueDurableSystemFollowUp).not.toHaveBeenCalled();
+        const durable = await new AgentJobDurableStore(resolve(root, "jobs")).read(jobs.list()[0]!.jobId);
+        expect(durable?.snapshot).toMatchObject({
+            status: "cancelled",
+            deliveryStatus: "pending",
+        });
+        await rm(root, {recursive: true, force: true});
     });
 
     it("shutdown 先关闭事件订阅并清理 preview，取消终态不再发布", async () => {
@@ -324,12 +328,16 @@ describe("AgentJobManager", () => {
     });
 
     it("list 保持轻量，get 保存完整大型结构化结果且通知不截断", async () => {
-        const invokeAgent = vi.fn(async (_input: {message: {text: string}}) => ({
-            sessionId: 7,
-            invocationId: "job-followup",
-            status: "completed" as const,
+        const enqueueDurableSystemFollowUp = vi.fn(async (input: {
+            deliveryId: string;
+            clientMessageId: string;
+            text: string;
+        }) => ({
+            state: "queued" as const,
+            deliveryId: input.deliveryId,
+            clientMessageId: input.clientMessageId,
         }));
-        const jobs = new AgentJobManager(() => ({invokeAgent}) as never, "");
+        const jobs = new AgentJobManager(() => ({enqueueDurableSystemFollowUp}) as never, "");
         const largeText = "完整结果".repeat(3_000);
         const spawned = jobs.spawn({
             kind: "workflow",
@@ -345,7 +353,7 @@ describe("AgentJobManager", () => {
         await jobs.waitIdle();
         const summary = jobs.list()[0]!;
         const detail = (await jobs.get(spawned.job.jobId))!;
-        const notification = invokeAgent.mock.calls[0]![0].message.text;
+        const notification = enqueueDurableSystemFollowUp.mock.calls[0]![0].text;
 
         expect(summary).not.toHaveProperty("result");
         expect(summary.preview?.length).toBeLessThanOrEqual(401);
@@ -357,9 +365,11 @@ describe("AgentJobManager", () => {
         expect(notification).not.toContain("```json");
     });
 
-    it("jobs.jsonl 串行记录 running、waiting、running、terminal", async () => {
+    it("每个 Job 只保留最新 durable 文件，旧 jobs.jsonl 不再追加", async () => {
         const root = resolve(".agent", "agent-job-manager-test", randomUUID());
         const registryPath = resolve(root, "jobs.jsonl");
+        await mkdir(root, {recursive: true});
+        await writeFile(registryPath, "legacy-audit\n", "utf8");
         const jobs = new AgentJobManager(() => {
             throw new Error("ownerless 测试不应投递");
         }, registryPath);
@@ -381,36 +391,253 @@ describe("AgentJobManager", () => {
         release!();
         await jobs.waitIdle();
 
-        const lines = (await readFile(registryPath, "utf8"))
-            .trim()
-            .split("\n")
-            .map((line) => (JSON.parse(line) as {status: string}).status);
-        expect(lines).toEqual(["running", "waiting", "running", "completed"]);
+        expect(await readFile(registryPath, "utf8")).toBe("legacy-audit\n");
+        const durableFiles = await readdir(resolve(root, "jobs"));
+        expect(durableFiles).toHaveLength(1);
+        const durable = JSON.parse(await readFile(resolve(root, "jobs", durableFiles[0]!), "utf8")) as DurableAgentJobRecord;
+        expect(durable.snapshot).toMatchObject({
+            status: "completed",
+            preview: "done",
+            deliveryStatus: "not_required",
+        });
         await rm(root, {recursive: true, force: true});
     });
 
-    it("recoverInterrupted 独立处理每条中断通知，单条失败不阻塞后续", async () => {
+    it("旧 jobs.jsonl 只迁移 active Job，并独立处理每条中断通知", async () => {
         const root = resolve(".agent", "agent-job-recovery-test", randomUUID());
         const registryPath = resolve(root, "jobs.jsonl");
         await mkdir(root, {recursive: true});
         await writeFile(registryPath, [
             {at: 1, jobId: "job-fail", kind: "workflow", title: "失败通知", ownerSessionId: 1, status: "running", deliveryStatus: "pending"},
             {at: 2, jobId: "job-ok", kind: "workflow", title: "成功通知", ownerSessionId: 2, status: "waiting", deliveryStatus: "pending"},
+            {at: 3, jobId: "job-terminal", kind: "bash", title: "旧终态", ownerSessionId: null, status: "completed", deliveryStatus: "not_required"},
         ].map((line) => JSON.stringify(line)).join("\n") + "\n", "utf8");
-        const invokeAgent = vi.fn(async (input: {sessionId: number; messageIdentity?: string; caller?: {kind: string}}) => {
+        const originalRegistry = await readFile(registryPath, "utf8");
+        const enqueueDurableSystemFollowUp = vi.fn(async (input: {
+            sessionId: number;
+            deliveryId: string;
+            clientMessageId: string;
+        }) => {
             if (input.sessionId === 1) throw new Error("owner-1 offline");
-            return {sessionId: input.sessionId, invocationId: "recovery", status: "completed" as const, acceptance: {state: "none" as const}};
+            return {
+                state: "queued" as const,
+                deliveryId: input.deliveryId,
+                clientMessageId: input.clientMessageId,
+            };
         });
-        const jobs = new AgentJobManager(() => ({invokeAgent}) as never, registryPath);
+        const jobs = new AgentJobManager(() => ({enqueueDurableSystemFollowUp}) as never, registryPath);
 
         await jobs.recoverInterrupted();
 
-        expect(invokeAgent).toHaveBeenCalledTimes(2);
-        expect(invokeAgent).toHaveBeenNthCalledWith(1, expect.objectContaining({messageIdentity: "system", caller: {kind: "system"}}));
-        expect(invokeAgent).toHaveBeenNthCalledWith(2, expect.objectContaining({messageIdentity: "system", caller: {kind: "system"}}));
-        const lines = (await readFile(registryPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line) as {jobId: string; status: string; deliveryStatus?: string; deliveryError?: string});
-        expect(lines.filter((line) => line.jobId === "job-fail").at(-1)).toMatchObject({status: "interrupted", deliveryStatus: "failed", deliveryError: "owner-1 offline"});
-        expect(lines.filter((line) => line.jobId === "job-ok").at(-1)).toMatchObject({status: "interrupted", deliveryStatus: "accepted"});
+        expect(enqueueDurableSystemFollowUp).toHaveBeenCalledTimes(2);
+        expect(jobs.list().map((job) => job.jobId).sort()).toEqual(["job-fail", "job-ok"]);
+        await expect(jobs.get("job-fail")).resolves.toMatchObject({
+            status: "interrupted",
+            deliveryStatus: "failed",
+            deliveryError: "owner-1 offline",
+        });
+        await expect(jobs.get("job-ok")).resolves.toMatchObject({
+            status: "interrupted",
+            deliveryStatus: "accepted",
+        });
+        expect(await readFile(registryPath, "utf8")).toBe(originalRegistry);
+        expect((await readdir(resolve(root, "jobs"))).sort()).toEqual(["job-fail.json", "job-ok.json"]);
+        await rm(root, {recursive: true, force: true});
+    });
+
+    it("进程重启后恢复终态列表、完整 result 和 kind detail", async () => {
+        const root = resolve(".agent", "agent-job-history-test", randomUUID());
+        const registryPath = resolve(root, "jobs.jsonl");
+        const first = new AgentJobManager(() => {
+            throw new Error("ownerless 测试不应投递");
+        }, registryPath);
+        const spawned = first.spawn({
+            kind: "workflow",
+            title: "durable history",
+            deliver: "none",
+            detail: async () => ({runId: "run-history", status: "completed"}),
+            run: async () => ({
+                resultPreview: "done",
+                result: {payload: "complete"},
+            }),
+        });
+        await first.waitIdle();
+
+        const restored = new AgentJobManager(() => {
+            throw new Error("终态 ownerless 历史不应投递");
+        }, registryPath);
+        await restored.recoverInterrupted();
+
+        expect(restored.list()).toEqual([
+            expect.objectContaining({
+                jobId: spawned.job.jobId,
+                status: "completed",
+                preview: "done",
+            }),
+        ]);
+        await expect(restored.get(spawned.job.jobId)).resolves.toMatchObject({
+            result: {payload: "complete"},
+            detail: {runId: "run-history", status: "completed"},
+        });
+        await rm(root, {recursive: true, force: true});
+    });
+
+    it("terminal pending 在重启后使用原稳定 ID 重投并更新为 accepted", async () => {
+        const root = resolve(".agent", "agent-job-pending-test", randomUUID());
+        const registryPath = resolve(root, "jobs.jsonl");
+        const store = new AgentJobDurableStore(resolve(root, "jobs"));
+        const durable = durableCompletedRecord("job_pending", {
+            deliveryId: "delivery-stable",
+            clientMessageId: "9ec1c584-22d6-4dcc-9748-b54258892a23",
+            message: "<system-reminder>\nreliable result\n</system-reminder>",
+        });
+        await store.write(durable);
+        const enqueueDurableSystemFollowUp = vi.fn(async (input: {
+            deliveryId: string;
+            clientMessageId: string;
+        }) => ({
+            state: "persisted" as const,
+            deliveryId: input.deliveryId,
+            clientMessageId: input.clientMessageId,
+        }));
+        const jobs = new AgentJobManager(() => ({enqueueDurableSystemFollowUp}) as never, registryPath);
+
+        await jobs.recoverInterrupted();
+
+        expect(enqueueDurableSystemFollowUp).toHaveBeenCalledWith({
+            sessionId: 7,
+            text: durable.delivery!.message,
+            deliveryId: "delivery-stable",
+            clientMessageId: "9ec1c584-22d6-4dcc-9748-b54258892a23",
+        });
+        await expect(jobs.get("job_pending")).resolves.toMatchObject({
+            status: "completed",
+            deliveryStatus: "accepted",
+            result: {ok: true},
+        });
+        await rm(root, {recursive: true, force: true});
+    });
+
+    it("accepted=queued 的历史在重启后重新触发 drain，已提交时升级私有证据", async () => {
+        const root = resolve(".agent", "agent-job-accepted-queue-test", randomUUID());
+        const registryPath = resolve(root, "jobs.jsonl");
+        const store = new AgentJobDurableStore(resolve(root, "jobs"));
+        const durable = durableCompletedRecord("job_accepted_queue", {
+            deliveryId: "delivery-accepted",
+            clientMessageId: "b6c72bf4-25f4-4c34-8c52-a6ccfe38c492",
+            message: "<system-reminder>\nalready queued\n</system-reminder>",
+            acceptedState: "queued",
+        });
+        durable.snapshot.deliveryStatus = "accepted";
+        await store.write(durable);
+        const enqueueDurableSystemFollowUp = vi.fn(async (input: {
+            deliveryId: string;
+            clientMessageId: string;
+        }) => ({
+            state: "persisted" as const,
+            deliveryId: input.deliveryId,
+            clientMessageId: input.clientMessageId,
+        }));
+        const jobs = new AgentJobManager(() => ({enqueueDurableSystemFollowUp}) as never, registryPath);
+
+        await jobs.recoverInterrupted();
+
+        expect(enqueueDurableSystemFollowUp).toHaveBeenCalledOnce();
+        expect((await store.read("job_accepted_queue"))?.delivery).toMatchObject({
+            deliveryId: "delivery-accepted",
+            acceptedState: "persisted",
+        });
+        await rm(root, {recursive: true, force: true});
+    });
+
+    it("terminal durable commit 失败时不发布 completed，而是收口为持久化失败", async () => {
+        const root = resolve(".agent", "agent-job-persist-failure-test", randomUUID());
+        class TerminalFailingStore extends AgentJobDurableStore {
+            private failed = false;
+
+            override async write(record: DurableAgentJobRecord): Promise<void> {
+                if (!this.failed && record.snapshot.status === "completed") {
+                    this.failed = true;
+                    throw new Error("disk full");
+                }
+                await super.write(record);
+            }
+        }
+        const store = new TerminalFailingStore(resolve(root, "jobs"));
+        const jobs = new AgentJobManager(() => {
+            throw new Error("ownerless 测试不应投递");
+        }, resolve(root, "jobs.jsonl"), store);
+        const cursor = jobs.recovery().eventCursor;
+        const spawned = jobs.spawn({
+            kind: "bash",
+            title: "persist failure",
+            deliver: "none",
+            run: async () => ({resultPreview: "done", result: {ok: true}}),
+        });
+        const subscription = jobs.subscribeEvents(cursor);
+        await subscription.next();
+
+        await jobs.waitIdle();
+        const terminal = await subscription.next();
+
+        expect(terminal).toMatchObject({
+            value: {payload: {event: {type: "job_upserted", job: {
+                jobId: spawned.job.jobId,
+                status: "failed",
+                error: expect.stringContaining("disk full"),
+            }}}},
+        });
+        await expect(jobs.get(spawned.job.jobId)).resolves.toMatchObject({
+            status: "failed",
+            error: expect.stringContaining("持久化失败"),
+        });
+        subscription.close();
+        await rm(root, {recursive: true, force: true});
+    });
+
+    it("terminal durable commit 完成前，列表和 SSE 都不公开 completed", async () => {
+        const root = resolve(".agent", "agent-job-terminal-gate-test", randomUUID());
+        let releaseTerminal!: () => void;
+        const terminalGate = new Promise<void>((resolveGate) => {
+            releaseTerminal = resolveGate;
+        });
+        let terminalWriteStarted!: () => void;
+        const terminalStarted = new Promise<void>((resolveStarted) => {
+            terminalWriteStarted = resolveStarted;
+        });
+        class BlockingTerminalStore extends AgentJobDurableStore {
+            override async write(record: DurableAgentJobRecord): Promise<void> {
+                if (record.snapshot.status === "completed") {
+                    terminalWriteStarted();
+                    await terminalGate;
+                }
+                await super.write(record);
+            }
+        }
+        const store = new BlockingTerminalStore(resolve(root, "jobs"));
+        const jobs = new AgentJobManager(() => {
+            throw new Error("ownerless 测试不应投递");
+        }, resolve(root, "jobs.jsonl"), store);
+        const cursor = jobs.recovery().eventCursor;
+        jobs.spawn({
+            kind: "bash",
+            title: "terminal gate",
+            deliver: "none",
+            run: async () => ({resultPreview: "done"}),
+        });
+        const subscription = jobs.subscribeEvents(cursor);
+        await subscription.next();
+        await terminalStarted;
+
+        expect(jobs.list()[0]).toMatchObject({status: "running"});
+        expect(jobs.recovery().eventCursor.after).toBe(cursor.after + 1);
+
+        releaseTerminal();
+        await jobs.waitIdle();
+        await expect(subscription.next()).resolves.toMatchObject({
+            value: {payload: {event: {type: "job_upserted", job: {status: "completed"}}}},
+        });
+        subscription.close();
         await rm(root, {recursive: true, force: true});
     });
 
@@ -440,7 +667,7 @@ describe("AgentJobManager", () => {
         await vi.waitFor(() => expect(jobs.list().find((job) => job.title === "finished")?.status).toBe("completed"));
         const cursor = jobs.recovery().eventCursor;
 
-        expect(jobs.clearFinished()).toBe(1);
+        await expect(jobs.clearFinished()).resolves.toBe(1);
         expect(jobs.list().map((job) => job.jobId)).toEqual([running.job.jobId]);
         expect(jobs.recovery().eventCursor.after).toBe(cursor.after + 1);
         await expect(jobs.subscribeEvents(cursor).next()).resolves.toMatchObject({
@@ -452,20 +679,25 @@ describe("AgentJobManager", () => {
         await jobs.waitIdle();
     });
 
-    it("clearFinished 后迟到的 delivery 状态不重新发布已清除 Job", async () => {
+    it("delivery pending 不能清除，accepted 后删除 durable 记录且重启不再出现", async () => {
+        const root = resolve(".agent", "agent-job-clear-test", randomUUID());
+        const registryPath = resolve(root, "jobs.jsonl");
         let releaseDelivery!: () => void;
         const delivery = new Promise<void>((resolve) => {
             releaseDelivery = resolve;
         });
-        const invokeAgent = vi.fn(async () => {
+        const enqueueDurableSystemFollowUp = vi.fn(async (input: {
+            deliveryId: string;
+            clientMessageId: string;
+        }) => {
             await delivery;
             return {
-                sessionId: 7,
-                invocationId: "late-delivery",
-                status: "completed" as const,
+                state: "queued" as const,
+                deliveryId: input.deliveryId,
+                clientMessageId: input.clientMessageId,
             };
         });
-        const jobs = new AgentJobManager(() => ({invokeAgent}) as never, "");
+        const jobs = new AgentJobManager(() => ({enqueueDurableSystemFollowUp}) as never, registryPath);
         const before = jobs.recovery().eventCursor;
         const spawned = jobs.spawn({
             kind: "workflow",
@@ -475,11 +707,11 @@ describe("AgentJobManager", () => {
         });
 
         await vi.waitFor(() => expect(jobs.list().find((job) => job.jobId === spawned.job.jobId)?.status).toBe("completed"));
-        await vi.waitFor(() => expect(invokeAgent).toHaveBeenCalledOnce());
+        await vi.waitFor(() => expect(enqueueDurableSystemFollowUp).toHaveBeenCalledOnce());
         const terminal = jobs.recovery().eventCursor;
-        expect(jobs.clearFinished()).toBe(1);
-        expect(jobs.list()).toEqual([]);
-        expect(jobs.recovery().eventCursor.after).toBe(terminal.after + 1);
+        await expect(jobs.clearFinished()).resolves.toBe(0);
+        expect(jobs.list()).toHaveLength(1);
+        expect(jobs.recovery().eventCursor).toEqual(terminal);
 
         let idleResolved = false;
         const idle = jobs.waitIdle().then(() => {
@@ -491,10 +723,41 @@ describe("AgentJobManager", () => {
         releaseDelivery();
         await idle;
         expect(idleResolved).toBe(true);
+        await expect(jobs.clearFinished()).resolves.toBe(1);
         expect(jobs.list()).toEqual([]);
-        expect(jobs.recovery().eventCursor).toEqual({
-            eventEpoch: before.eventEpoch,
-            after: terminal.after + 1,
-        });
+        expect(jobs.recovery().eventCursor.after).toBe(terminal.after + 2);
+
+        const restored = new AgentJobManager(() => {
+            throw new Error("已清除记录不应投递");
+        }, registryPath);
+        await restored.recoverInterrupted();
+        expect(restored.list()).toEqual([]);
+        expect(await readdir(resolve(root, "jobs"))).toEqual([]);
+        expect(before.eventEpoch).toEqual(expect.any(String));
+        await rm(root, {recursive: true, force: true});
     });
 });
+
+function durableCompletedRecord(
+    jobId: string,
+    delivery: DurableAgentJobRecord["delivery"],
+): DurableAgentJobRecord {
+    return {
+        schemaVersion: 1,
+        snapshot: {
+            jobId,
+            kind: "workflow",
+            title: "pending delivery",
+            ownerSessionId: 7,
+            status: "completed",
+            deliveryStatus: "pending",
+            createdAt: 1,
+            endedAt: 2,
+            ref: {runId: "run-pending"},
+            preview: "done",
+        },
+        result: {ok: true},
+        detail: {runId: "run-pending", status: "completed"},
+        delivery,
+    };
+}

--- a/server/agent/jobs/agent-job-manager.ts
+++ b/server/agent/jobs/agent-job-manager.ts
@@ -1,9 +1,14 @@
-import {existsSync} from "node:fs";
-import {appendFile, mkdir, readFile} from "node:fs/promises";
-import {dirname} from "node:path";
 import {randomUUID} from "node:crypto";
+import {existsSync} from "node:fs";
+import {readFile} from "node:fs/promises";
+import {dirname, join} from "node:path";
 import {appLogger} from "nbook/server/app-logs/logger";
 import type {NeuroAgentHarness} from "nbook/server/agent/harness/neuro-agent-harness";
+import {
+    AgentJobDurableStore,
+    type DurableAgentJobDelivery,
+    type DurableAgentJobRecord,
+} from "nbook/server/agent/jobs/agent-job-durable-store";
 import {
     AgentJobEventHub,
     type AgentJobEventSubscription,
@@ -18,30 +23,29 @@ import type {
     AgentJobStatus,
     JsonValue,
 } from "nbook/shared/dto/agent-job.dto";
-import type {AgentInvocationResult} from "nbook/server/agent/harness/types";
 
 export type {AgentJobDetail, AgentJobKind, AgentJobSnapshot, AgentJobStatus} from "nbook/shared/dto/agent-job.dto";
 
 /** kind 专属详情只在 get_job/HTTP 详情入口按需读取，不进入列表快照。 */
 export type JobDetailProvider = () => Promise<JsonValue | undefined>;
 
-/** job 执行回调拿到的运行上下文 */
+/** job 执行回调拿到的运行上下文。 */
 export type JobRunContext = {
     /** cancel_job 触发；invoke/workflow Agent activity 走 Harness 有界取消，bash 走 owned-process。 */
     signal: AbortSignal;
-    /** 更新进行中预览（任务列表/气泡实时可见） */
+    /** 更新进行中预览（任务列表/气泡实时可见）。 */
     setPreview(text: string): void;
-    /** 标记 job 进入等待人工应答状态（workflow ask 挂起用）；恢复运行时再 setRunning */
+    /** 标记 job 进入等待人工应答状态（workflow ask 挂起用）；恢复运行时再 setRunning。 */
     setWaiting(text: string): void;
     setRunning(): void;
 };
 
-/** job 结束产物：resultPreview 进快照，message 作为回流 followup 的完整正文 */
+/** job 结束产物：resultPreview 进快照，message 作为回流 follow-up 的完整正文。 */
 export type JobOutcome = {
     resultPreview: string;
     /** get_job / 单 Job HTTP 详情返回的完整结构化结果，不做裁剪。 */
     result?: JsonValue;
-    /** 回流 followup 的完整正文；缺省时由 Manager 用标题和 resultPreview 组装结果卡。 */
+    /** 回流 follow-up 的完整正文；缺省时由 Manager 用标题和 resultPreview 组装结果卡。 */
     message?: string;
 };
 
@@ -62,7 +66,7 @@ export type SpawnJobSpec = {
     run: (ctx: JobRunContext) => Promise<JobOutcome>;
     /** kind 专属取消传播钩子（bash=owned-process terminate；workflow=Run signal）。 */
     onCancel?: () => void | Promise<void>;
-    /** 缺省：有 owner 则 followup 回流，无则 none */
+    /** 缺省：有 owner 则 followup 回流，无则 none。 */
     deliver?: "followup" | "none";
     /** kind 专属详情；Provider 失败不改变执行状态，由详情入口记录为不可用。 */
     detail?: JobDetailProvider;
@@ -74,7 +78,7 @@ export type SpawnedAgentJob = {
     jobEventCursor: AgentJobEventCursor;
 };
 
-/** 登记表行（append-only 状态翻转；不存观测载荷） */
+/** 旧 jobs.jsonl 的薄登记行；只用于迁移遗留 active Job。 */
 type RegistryLine = {
     at: number;
     jobId: string;
@@ -90,52 +94,55 @@ type RegistryLine = {
 
 type JobRecord = {
     snapshot: AgentJobSnapshot;
-    /** 仅详情面消费；不进入 list() 投影与薄登记表。 */
     result?: JsonValue;
+    persistedDetail?: JsonValue;
+    workflowRun?: JsonValue;
+    delivery?: DurableAgentJobDelivery;
     detail?: JobDetailProvider;
-    controller: AbortController;
+    controller?: AbortController;
     promise: Promise<void>;
-    spec: SpawnJobSpec;
+    spec?: SpawnJobSpec;
 };
 
 /**
- * 统一后台任务管理器（Task 111 PLAN-E）。
+ * 统一后台任务管理器。
  *
- * Job = 有身份、有状态机、有观测面、有回流策略的后台工作单元：
- * - 回流走 harness invokeAgent(mode:"prompt")：owner 空闲立即触发一轮、忙时自动进 followup 队列；
- *   回流只带 message 文本（结果卡），不带 payload——payload 会撞 owner profile 的 PayloadSchema 校验，
- *   完整数据让 agent 用 get_job / workflow runs API 查询；
- * - 崩溃恢复：jobs.jsonl 薄登记表（只记身份与状态翻转），启动扫描把 running/waiting 标 interrupted
- *   并给 owner 补发中断通知——「重启丢回流」从静默变显式；
- * - 观测：HTTP 原子恢复快照 + 全局 Jobs SSE；完整 result 仍按 Job 详情读取。
+ * Durable truth 位于 `<Workspace Root>/.nbook/agent/jobs/<jobId>.json`：
+ * - 列表只在内存保留公开 snapshot；完整 result/detail 按需读取单 Job 文件；
+ * - terminal snapshot、完整结果、详情、回流正文与稳定 ID 在一次原子 commit 中发布；
+ * - 结果回流写入 Harness 现有 durable follow-up queue，accepted 不等待 Provider 回合完成；
+ * - 旧 jobs.jsonl 不再追加，只把遗留 running/waiting 迁移为 interrupted。
  */
 export class AgentJobManager {
     private readonly jobs = new Map<string, JobRecord>();
     private readonly events = new AgentJobEventHub();
-    /** bash 输出 preview 采用每 Job 独立的 250ms 尾沿合并。 */
     private readonly previewTimers = new Map<string, ReturnType<typeof setTimeout>>();
-    /** jobs.jsonl 必须保持状态翻转顺序，避免迟到的 running 行覆盖 terminal 行。 */
+    private readonly durableStore: AgentJobDurableStore;
+    /** 所有 durable 写按调用顺序串行；失败不会毒化后续写。 */
     private persistQueue: Promise<void> = Promise.resolve();
-    /** clearFinished 移除的条目若回流投递仍在途，其 promise 挂在此链上，waitIdle 仍会等它。 */
+    /** clearFinished 移除后仍可能有极短的 promise 收尾；waitIdle 继续等待。 */
     private removedSettle: Promise<void> = Promise.resolve();
-    /** 结果回流属于 Job 的收尾边界；停服时必须能取消在途的 owner invocation。 */
-    private readonly deliveryController = new AbortController();
-    /** shutdown 开始后不再启动新的结果回流 invocation。 */
+    private recoveryRun: Promise<void> | null = null;
     private shuttingDown = false;
 
     constructor(
-        /** 延迟取 harness：Manager 在 harness 构造期创建，回流时才解引用 */
+        /** 延迟取 harness：Manager 在 harness 构造期创建，回流时才解引用。 */
         private readonly harness: () => NeuroAgentHarness,
-        /** 登记表路径（<workspaceRoot>/.nbook/agent/jobs.jsonl）；空字符串 = 关闭持久化（隔离测试用） */
+        /** 旧登记表路径；同目录 `jobs/` 是新 durable store。空字符串关闭持久化。 */
         private readonly registryPath: string,
-    ) {}
+        durableStore?: AgentJobDurableStore,
+    ) {
+        this.durableStore = durableStore
+            ?? new AgentJobDurableStore(registryPath ? join(dirname(registryPath), "jobs") : "");
+    }
 
-    /** 启动一个后台 job：登记 + 落盘 + 后台执行 + settle 回流 */
+    /** 启动一个后台 job：内存登记、首次快照发布、durable running 写入和后台执行。 */
     spawn(spec: SpawnJobSpec): SpawnedAgentJob {
         if (this.shuttingDown) {
             throw new Error("Agent Job Manager 已关闭，不能启动新任务");
         }
-        const delivery = spec.deliver ?? (spec.ownerSessionId === undefined ? "none" : "followup");
+        const deliver = spec.deliver ?? (spec.ownerSessionId === undefined ? "none" : "followup");
+        const deliveryRequired = deliver === "followup" && spec.ownerSessionId !== undefined;
         const snapshot: AgentJobSnapshot = {
             jobId: `job_${randomUUID().slice(0, 8)}`,
             kind: spec.kind,
@@ -143,19 +150,30 @@ export class AgentJobManager {
             ownerSessionId: spec.ownerSessionId ?? null,
             originToolCallId: spec.originToolCallId,
             status: "running",
-            deliveryStatus: delivery === "none" || spec.ownerSessionId === undefined ? "not_required" : "pending",
+            deliveryStatus: deliveryRequired ? "pending" : "not_required",
             createdAt: Date.now(),
             ref: spec.ref ?? null,
         };
-        const controller = new AbortController();
-        const record: JobRecord = {snapshot, controller, spec, detail: spec.detail, promise: Promise.resolve()};
+        const record: JobRecord = {
+            snapshot,
+            controller: new AbortController(),
+            spec,
+            detail: spec.detail,
+            promise: Promise.resolve(),
+            ...(deliveryRequired ? {
+                delivery: {
+                    deliveryId: randomUUID(),
+                    clientMessageId: randomUUID(),
+                },
+            } : {}),
+        };
         this.jobs.set(snapshot.jobId, record);
         const createdEvent = this.publishSnapshot(record);
         if (!createdEvent || createdEvent.payload.event.type !== "job_upserted") {
             this.jobs.delete(snapshot.jobId);
             throw new Error("Agent Job 创建事件未发布");
         }
-        void this.persist(snapshot);
+        this.persistBestEffort(record, "spawn");
         record.promise = this.execute(record);
         return {
             job: {...snapshot},
@@ -187,41 +205,45 @@ export class AgentJobManager {
     async get(jobId: string): Promise<AgentJobDetail | null> {
         const record = this.jobs.get(jobId);
         if (!record) return null;
-        let detail: JsonValue | undefined;
-        if (record.detail) {
-            try {
-                detail = await record.detail();
-            } catch (error) {
-                void appLogger.warn("agent.jobs.detailUnavailable", {
-                    jobId,
-                    error: error instanceof Error ? error.message : String(error),
-                });
-            }
+
+        const durable = isTerminal(record.snapshot.status)
+            ? await this.readDurableRecord(jobId)
+            : null;
+        let detail = durable?.detail ?? record.persistedDetail;
+        if (detail === undefined && record.detail) {
+            detail = await this.resolveDetail(record);
         }
+        const result = durable?.result ?? record.result;
         return {
             ...record.snapshot,
-            ...(record.result === undefined ? {} : {result: record.result}),
+            ...(result === undefined ? {} : {result}),
             ...(detail === undefined ? {} : {detail}),
         };
     }
 
-    /** 请求取消：置 abort 信号 + 调用 kind 专属钩子；实际状态翻转由执行路径收尾时落 */
+    /** 请求取消：置 abort 信号 + 调用 kind 专属钩子；实际状态翻转由执行路径收尾时落。 */
     async cancel(jobId: string): Promise<AgentJobSnapshot> {
         const record = this.jobs.get(jobId);
         if (!record) throw new Error(`job ${jobId} 不存在`);
         if (record.snapshot.status !== "running" && record.snapshot.status !== "waiting") {
             return {...record.snapshot};
         }
+        if (!record.controller || !record.spec) {
+            throw new Error(`job ${jobId} 缺少当前进程执行上下文`);
+        }
         record.controller.abort();
         try {
             await record.spec.onCancel?.();
         } catch (error) {
-            void appLogger.warn("agent.jobs.cancelHookFailed", {jobId, error: error instanceof Error ? error.message : String(error)});
+            void appLogger.warn("agent.jobs.cancelHookFailed", {
+                jobId,
+                error: error instanceof Error ? error.message : String(error),
+            });
         }
         return {...record.snapshot};
     }
 
-    /** harness.close 统一等待：所有 job 落定（含回流完成） */
+    /** harness.close 统一等待：所有 live Job、结果入队与 durable 写入都落定。 */
     async waitIdle(): Promise<void> {
         const waited = new Set<Promise<void>>();
         while (true) {
@@ -233,19 +255,28 @@ export class AgentJobManager {
             await Promise.allSettled(pending);
         }
         await this.removedSettle;
+        await this.persistQueue;
     }
 
     /**
-     * 清除内存中的已结束任务（任务中心「清除已结束」按钮）；返回清除数量。
-     * 仅内存回收——jobs.jsonl 登记表是 append-only 审计面，不受影响。
+     * 删除 durable 已结束历史；deliveryStatus=pending 的 Job 必须保留到可靠入队完成。
      */
-    clearFinished(): number {
+    async clearFinished(): Promise<number> {
         const removedJobIds: string[] = [];
-        for (const [jobId, record] of this.jobs) {
-            const status = record.snapshot.status;
-            if (status === "running" || status === "waiting") continue;
+        for (const [jobId, record] of [...this.jobs]) {
+            if (!isTerminal(record.snapshot.status) || record.snapshot.deliveryStatus === "pending") {
+                continue;
+            }
+            try {
+                await this.durableStore.delete(jobId);
+            } catch (error) {
+                void appLogger.warn("agent.jobs.clearDurableFailed", {
+                    jobId,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+                continue;
+            }
             this.jobs.delete(jobId);
-            // 终态翻转发生在回流投递之前：被清条目可能仍有在途 followup，保住 waitIdle 合同
             this.removedSettle = Promise.allSettled([this.removedSettle, record.promise]).then(() => {});
             removedJobIds.push(jobId);
         }
@@ -255,75 +286,137 @@ export class AgentJobManager {
         return removedJobIds.length;
     }
 
-    /** 取消所有仍活跃的 Job；Harness dispose 用它解除 waiting Job。 */
+    /** 取消所有仍活跃的当前进程 Job；历史记录不会进入此路径。 */
     async cancelActive(): Promise<void> {
         const active = [...this.jobs.values()]
-            .filter((record) => record.snapshot.status === "running" || record.snapshot.status === "waiting")
+            .filter((record) => (record.snapshot.status === "running" || record.snapshot.status === "waiting")
+                && record.controller !== undefined)
             .map((record) => record.snapshot.jobId);
         await Promise.all(active.map((jobId) => this.cancel(jobId)));
     }
 
-    /** 停服收口：先取消活跃任务，再等待执行、结果投递和登记表写入全部完成。 */
+    /** 停服收口：取消活跃任务，等待执行与 durable 写入；pending 回流留给下次启动幂等恢复。 */
     async shutdown(): Promise<void> {
         this.shuttingDown = true;
         this.events.close();
         for (const timer of this.previewTimers.values()) clearTimeout(timer);
         this.previewTimers.clear();
-        this.deliveryController.abort(new Error("agent job manager shutdown"));
         await this.cancelActive();
         await this.waitIdle();
-        await this.persistQueue;
     }
 
     /**
-     * 启动恢复：把上次进程留下的 running/waiting job 标 interrupted，并给 owner 补发中断通知。
-     * 由 harness 构造尾部 fire-and-forget 调用（与 profile bootSweep 同模式）。
+     * 启动恢复：
+     * - 新 durable store 的全部历史重新进入列表；
+     * - running/waiting 转为 interrupted；
+     * - terminal pending 使用稳定 deliveryId/clientMessageId 幂等重投；
+     * - 旧 jobs.jsonl 只迁移遗留 active 行，不伪造历史终态结果。
      */
     async recoverInterrupted(): Promise<void> {
-        if (!this.registryPath || !existsSync(this.registryPath)) return;
+        if (!this.recoveryRun) {
+            this.recoveryRun = this.recoverDurableState();
+        }
+        await this.recoveryRun;
+    }
+
+    private async recoverDurableState(): Promise<void> {
         await this.persistQueue;
-        const lines = (await readFile(this.registryPath, "utf8")).split("\n").filter(Boolean);
+        const durableJobIds = await this.durableStore.listJobIds();
+        for (const jobId of durableJobIds) {
+            if (this.jobs.has(jobId)) {
+                continue;
+            }
+            let durable: DurableAgentJobRecord | null;
+            try {
+                durable = await this.durableStore.read(jobId);
+            } catch (error) {
+                void appLogger.error("agent.jobs.durableReadFailed", {
+                    jobId,
+                    error: error instanceof Error ? error.message : String(error),
+                }, error, "读取 Agent Job durable 历史失败");
+                continue;
+            }
+            if (!durable) {
+                continue;
+            }
+            const record = this.recordFromDurable(durable);
+            if (record.snapshot.status === "running" || record.snapshot.status === "waiting") {
+                this.interruptRecoveredRecord(record);
+                await this.persistRequired(record);
+            }
+            this.jobs.set(jobId, record);
+            this.publishSnapshot(record);
+            if (record.snapshot.deliveryStatus === "pending") {
+                await this.deliverPending(record);
+            } else if (record.snapshot.deliveryStatus === "accepted"
+                && record.delivery?.acceptedState === "queued") {
+                await this.resumeAcceptedDelivery(record);
+            }
+        }
+        await this.migrateLegacyActiveJobs(new Set(durableJobIds));
+    }
+
+    private async migrateLegacyActiveJobs(existingJobIds: Set<string>): Promise<void> {
+        if (!this.registryPath || !existsSync(this.registryPath)) {
+            return;
+        }
+        const lines = (await readFile(this.registryPath, "utf8")).split(/\r?\n/u).filter(Boolean);
+        const firstAt = new Map<string, number>();
         const last = new Map<string, RegistryLine>();
         for (const line of lines) {
             try {
                 const parsed = JSON.parse(line) as RegistryLine;
+                firstAt.set(parsed.jobId, Math.min(firstAt.get(parsed.jobId) ?? parsed.at, parsed.at));
                 last.set(parsed.jobId, parsed);
             } catch {
-                // 损坏行跳过：登记表是尽力而为的恢复面，不是 truth
+                // 旧登记表只作为迁移输入；损坏行无法安全恢复，保留原文件供人工审计。
             }
         }
         for (const entry of last.values()) {
-            if (entry.status !== "running" && entry.status !== "waiting") continue;
-            const interrupted: RegistryLine = {...entry, at: Date.now(), status: "interrupted", error: "进程重启，后台任务丢失"};
-            const needsDelivery = entry.deliveryStatus === "pending" || (entry.deliveryStatus === undefined && entry.ownerSessionId !== null);
-            interrupted.deliveryStatus = needsDelivery ? "pending" : "not_required";
-            await this.persistLine(interrupted);
-            if (entry.ownerSessionId !== null && needsDelivery) {
-                try {
-                    const result = await this.sendFollowup(entry.ownerSessionId, [
-                        `[后台任务中断] ${entry.title}（${entry.jobId}）`,
-                        "服务重启导致该后台任务丢失，未能产出结果。如仍需要请重新发起。",
-                    ].join("\n"));
-                    if (result.status === "error") {
-                        await this.persistLine({...interrupted, deliveryStatus: "failed", deliveryError: result.error ?? "owner invocation 返回 error"});
-                    } else {
-                        await this.persistLine({...interrupted, deliveryStatus: "accepted", deliveryError: undefined});
-                    }
-                } catch (error) {
-                    const message = error instanceof Error ? error.message : String(error);
-                    void appLogger.error("agent.jobs.recoverDeliveryFailed", {
-                        jobId: entry.jobId,
-                        ownerSessionId: entry.ownerSessionId,
-                        error: message,
-                    }, error, "后台任务中断通知回流失败");
-                    await this.persistLine({...interrupted, deliveryStatus: "failed", deliveryError: message});
-                }
+            if ((entry.status !== "running" && entry.status !== "waiting")
+                || existingJobIds.has(entry.jobId)
+                || this.jobs.has(entry.jobId)) {
+                continue;
+            }
+            const deliveryRequired = entry.deliveryStatus === "pending"
+                || (entry.deliveryStatus === undefined && entry.ownerSessionId !== null);
+            const record: JobRecord = {
+                snapshot: {
+                    jobId: entry.jobId,
+                    kind: entry.kind,
+                    title: entry.title,
+                    ownerSessionId: entry.ownerSessionId,
+                    originToolCallId: entry.originToolCallId,
+                    status: "interrupted",
+                    createdAt: firstAt.get(entry.jobId) ?? entry.at,
+                    endedAt: Date.now(),
+                    ref: null,
+                    error: "进程重启，后台任务丢失",
+                    deliveryStatus: deliveryRequired ? "pending" : "not_required",
+                },
+                promise: Promise.resolve(),
+                ...(deliveryRequired ? {
+                    delivery: {
+                        deliveryId: randomUUID(),
+                        clientMessageId: randomUUID(),
+                        message: interruptedDeliveryMessage(entry.title, entry.jobId),
+                    },
+                } : {}),
+            };
+            await this.persistRequired(record);
+            this.jobs.set(entry.jobId, record);
+            this.publishSnapshot(record);
+            if (record.snapshot.deliveryStatus === "pending") {
+                await this.deliverPending(record);
             }
         }
     }
 
     private async execute(record: JobRecord): Promise<void> {
         const {snapshot, spec, controller} = record;
+        if (!spec || !controller) {
+            throw new Error(`live Job ${snapshot.jobId} 缺少执行上下文`);
+        }
         const ctx: JobRunContext = {
             signal: controller.signal,
             setPreview: (text) => {
@@ -335,15 +428,16 @@ export class AgentJobManager {
                 snapshot.preview = clip(text, 400);
                 this.cancelPreview(record);
                 this.publishSnapshot(record);
-                void this.persist(snapshot);
+                this.persistBestEffort(record, "waiting");
             },
             setRunning: () => {
                 snapshot.status = "running";
                 this.cancelPreview(record);
                 this.publishSnapshot(record);
-                void this.persist(snapshot);
+                this.persistBestEffort(record, "running");
             },
         };
+
         let outcome: JobOutcome | null = null;
         let failure: string | null = null;
         try {
@@ -354,105 +448,273 @@ export class AgentJobManager {
                 controller.abort();
             }
         }
-        snapshot.endedAt = Date.now();
+
+        const terminalSnapshot: AgentJobSnapshot = {
+            ...snapshot,
+            endedAt: Date.now(),
+        };
+        let result: JsonValue | undefined;
         if (controller.signal.aborted) {
-            snapshot.status = "cancelled";
-            snapshot.error = failure ?? undefined;
+            terminalSnapshot.status = "cancelled";
+            terminalSnapshot.error = failure ?? undefined;
         } else if (failure !== null) {
-            snapshot.status = "failed";
-            snapshot.error = failure;
+            terminalSnapshot.status = "failed";
+            terminalSnapshot.error = failure;
         } else {
-            snapshot.status = "completed";
-            snapshot.preview = clip(outcome!.resultPreview, 400);
-            record.result = outcome!.result;
+            terminalSnapshot.status = "completed";
+            terminalSnapshot.preview = clip(outcome!.resultPreview, 400);
+            result = outcome!.result;
+        }
+        const persistedDetail = await this.resolveDetail(record);
+        const delivery = record.delivery
+            ? {...record.delivery}
+            : undefined;
+        if (terminalSnapshot.deliveryStatus === "pending" && delivery) {
+            delivery.message = resultDeliveryMessage(terminalSnapshot, outcome, failure);
         }
         this.cancelPreview(record);
-        this.publishSnapshot(record);
-        await this.persist(snapshot);
-        await this.deliverResult(record, outcome, failure);
-    }
 
-    /** settle 回流：完成/失败/取消都告知 owner（agent 读到结果卡后向用户汇报或继续编排） */
-    private async deliverResult(record: JobRecord, outcome: JobOutcome | null, failure: string | null): Promise<void> {
-        const {snapshot, spec} = record;
-        const deliver = spec.deliver ?? (snapshot.ownerSessionId !== null ? "followup" : "none");
-        if (deliver === "none" || snapshot.ownerSessionId === null) return;
-        if (this.shuttingDown) {
-            await this.setDeliveryStatus(record, "failed", "Agent Job Manager 已关闭，未发送结果回流");
+        if (!await this.commitTerminal(record, {
+            schemaVersion: 1,
+            snapshot: terminalSnapshot,
+            ...(result === undefined ? {} : {result}),
+            ...(persistedDetail === undefined ? {} : {detail: persistedDetail}),
+            ...(record.workflowRun === undefined ? {} : {workflowRun: record.workflowRun}),
+            ...(delivery === undefined ? {} : {delivery}),
+        })) {
             return;
         }
-        const header = snapshot.status === "completed"
-            ? `[后台任务完成] ${snapshot.title}（${snapshot.jobId}）`
-            : snapshot.status === "cancelled"
-                ? `[后台任务已取消] ${snapshot.title}（${snapshot.jobId}）`
-                : `[后台任务失败] ${snapshot.title}（${snapshot.jobId}）：${failure ?? "未知错误"}`;
-        const content = snapshot.status === "completed" && outcome?.message
-            ? outcome.message
-            : [header, snapshot.status === "completed" ? outcome?.resultPreview ?? "" : ""].filter(Boolean).join("\n");
+        await this.deliverPending(record);
+    }
+
+    /** terminal 完整 truth 必须先 durable commit，成功后才进入列表/SSE 公共终态。 */
+    private async commitTerminal(record: JobRecord, terminal: DurableAgentJobRecord): Promise<boolean> {
         try {
-            const result = await this.sendFollowup(snapshot.ownerSessionId, [
-                "<system-reminder>",
-                content,
-                "</system-reminder>",
-            ].join("\n"));
-            if (result.status === "error") {
-                await this.setDeliveryStatus(record, "failed", result.error ?? "owner invocation 返回 error");
+            await this.persistDurable(terminal);
+        } catch (error) {
+            const message = `后台任务结果持久化失败：${error instanceof Error ? error.message : String(error)}`;
+            const failed: DurableAgentJobRecord = {
+                schemaVersion: 1,
+                snapshot: {
+                    ...terminal.snapshot,
+                    status: "failed",
+                    error: message,
+                    deliveryStatus: terminal.delivery ? "failed" : "not_required",
+                    deliveryError: terminal.delivery ? message : undefined,
+                },
+            };
+            await this.persistDurable(failed).catch((persistError) => {
+                void appLogger.error("agent.jobs.terminalPersistFailed", {
+                    jobId: terminal.snapshot.jobId,
+                    error: persistError instanceof Error ? persistError.message : String(persistError),
+                }, persistError, "Agent Job terminal durable commit 失败");
+            });
+            this.applyDurableRecord(record, failed);
+            this.publishSnapshot(record);
+            return false;
+        }
+        this.applyDurableRecord(record, terminal);
+        this.publishSnapshot(record);
+        return true;
+    }
+
+    /**
+     * 结果回流只把稳定系统 follow-up 写入 Session durable queue。
+     * accepted 不等待 Provider 回合完成；重启通过 queue item/sourceQueueItemId 幂等确认。
+     */
+    private async deliverPending(record: JobRecord): Promise<void> {
+        const {snapshot, delivery} = record;
+        if (snapshot.deliveryStatus !== "pending") {
+            return;
+        }
+        if (this.shuttingDown) {
+            return;
+        }
+        if (snapshot.ownerSessionId === null || !delivery?.message) {
+            await this.trySetDeliveryFailed(record, "Job 缺少可靠结果回流正文或 owner Session");
+            return;
+        }
+        try {
+            const admission = await this.harness().enqueueDurableSystemFollowUp({
+                sessionId: snapshot.ownerSessionId,
+                text: delivery.message,
+                deliveryId: delivery.deliveryId,
+                clientMessageId: delivery.clientMessageId,
+            });
+            const previousAcceptedState = delivery.acceptedState;
+            delivery.acceptedState = admission.state;
+            try {
+                await this.setDeliveryStatus(record, "accepted");
+            } catch (error) {
+                delivery.acceptedState = previousAcceptedState;
+                throw error;
+            }
+        } catch (error) {
+            if (this.shuttingDown) {
                 return;
             }
-            await this.setDeliveryStatus(record, "accepted");
-        } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
-            await this.setDeliveryStatus(record, "failed", message);
+            await this.trySetDeliveryFailed(record, message);
             void appLogger.error("agent.jobs.deliverFailed", {
                 jobId: snapshot.jobId,
                 ownerSessionId: snapshot.ownerSessionId,
                 deliveryError: message,
-            }, error, "后台任务结果回流失败");
+            }, error, "后台任务结果进入 Session durable queue 失败");
         }
     }
 
-    /** mode:"prompt" 兼顾两态：owner 空闲立即触发一轮，忙时 harness 自动进 followup 队列。 */
-    private async sendFollowup(sessionId: number, text: string): Promise<AgentInvocationResult> {
-        if (this.deliveryController.signal.aborted) {
-            return {
-                sessionId,
-                invocationId: "delivery-aborted",
-                status: "error",
-                acceptance: {state: "none"},
-                error: "Agent Job Manager 已关闭",
-            };
+    /** accepted=queued 时，重启只重新触发现有 durable queue 的 drain，不重复写消息。 */
+    private async resumeAcceptedDelivery(record: JobRecord): Promise<void> {
+        const {snapshot, delivery} = record;
+        if (this.shuttingDown || snapshot.ownerSessionId === null || !delivery?.message) {
+            return;
         }
-        return await this.harness().invokeAgent({
-            sessionId,
-            mode: "prompt",
-            message: {text},
-            caller: {kind: "system"},
-            messageIdentity: "system",
-            signal: this.deliveryController.signal,
+        try {
+            const admission = await this.harness().enqueueDurableSystemFollowUp({
+                sessionId: snapshot.ownerSessionId,
+                text: delivery.message,
+                deliveryId: delivery.deliveryId,
+                clientMessageId: delivery.clientMessageId,
+            });
+            if (admission.state === "persisted") {
+                delivery.acceptedState = "persisted";
+                await this.persistRequired(record);
+            }
+        } catch (error) {
+            void appLogger.warn("agent.jobs.acceptedDeliveryResumeFailed", {
+                jobId: snapshot.jobId,
+                ownerSessionId: snapshot.ownerSessionId,
+                error: error instanceof Error ? error.message : String(error),
+            });
+        }
+    }
+
+    private async trySetDeliveryFailed(record: JobRecord, message: string): Promise<void> {
+        await this.setDeliveryStatus(record, "failed", message).catch((error) => {
+            void appLogger.error("agent.jobs.deliveryStatusPersistFailed", {
+                jobId: record.snapshot.jobId,
+                deliveryError: message,
+                persistError: error instanceof Error ? error.message : String(error),
+            }, error, "Agent Job delivery failed 状态持久化失败");
         });
     }
 
-    /** 投递状态独立于执行状态翻转，并通过同一快照/SSE/登记表发布。 */
-    private async setDeliveryStatus(record: JobRecord, status: AgentJobSnapshot["deliveryStatus"], error?: string): Promise<void> {
-        record.snapshot.deliveryStatus = status;
-        record.snapshot.deliveryError = error;
+    /** delivery 状态先 durable commit，再发布列表/SSE；失败时恢复旧内存快照。 */
+    private async setDeliveryStatus(
+        record: JobRecord,
+        status: AgentJobSnapshot["deliveryStatus"],
+        error?: string,
+    ): Promise<void> {
+        const durable = this.toDurableRecord(record);
+        durable.snapshot = {
+            ...durable.snapshot,
+            deliveryStatus: status,
+            deliveryError: error,
+        };
+        await this.persistDurable(durable);
+        this.applyDurableRecord(record, durable);
         this.publishSnapshot(record);
-        await this.persist(record.snapshot);
     }
 
-    private async persist(snapshot: AgentJobSnapshot): Promise<void> {
-        await this.persistLine({
-            at: Date.now(),
-            jobId: snapshot.jobId,
-            kind: snapshot.kind,
-            title: snapshot.title,
-            ownerSessionId: snapshot.ownerSessionId,
-            originToolCallId: snapshot.originToolCallId,
-            status: snapshot.status,
-            error: snapshot.error,
-            deliveryStatus: snapshot.deliveryStatus,
-            deliveryError: snapshot.deliveryError,
+    private async resolveDetail(record: JobRecord): Promise<JsonValue | undefined> {
+        if (!record.detail) {
+            return record.persistedDetail;
+        }
+        try {
+            return await record.detail();
+        } catch (error) {
+            void appLogger.warn("agent.jobs.detailUnavailable", {
+                jobId: record.snapshot.jobId,
+                error: error instanceof Error ? error.message : String(error),
+            });
+            return record.persistedDetail;
+        }
+    }
+
+    private recordFromDurable(durable: DurableAgentJobRecord): JobRecord {
+        const active = durable.snapshot.status === "running" || durable.snapshot.status === "waiting";
+        const deliveryMutable = durable.snapshot.deliveryStatus === "pending"
+            || (durable.snapshot.deliveryStatus === "accepted" && durable.delivery?.acceptedState === "queued");
+        const retainPayload = active || deliveryMutable;
+        return {
+            snapshot: {...durable.snapshot},
+            ...(retainPayload && durable.result !== undefined ? {result: durable.result} : {}),
+            ...(retainPayload && durable.detail !== undefined ? {persistedDetail: durable.detail} : {}),
+            ...(retainPayload && durable.workflowRun !== undefined ? {workflowRun: durable.workflowRun} : {}),
+            ...(deliveryMutable && durable.delivery ? {delivery: {...durable.delivery}} : {}),
+            promise: Promise.resolve(),
+        };
+    }
+
+    private applyDurableRecord(record: JobRecord, durable: DurableAgentJobRecord): void {
+        record.snapshot = {...durable.snapshot};
+        record.result = durable.result;
+        record.persistedDetail = durable.detail;
+        record.workflowRun = durable.workflowRun;
+        record.delivery = durable.delivery ? {...durable.delivery} : undefined;
+    }
+
+    private interruptRecoveredRecord(record: JobRecord): void {
+        record.snapshot.status = "interrupted";
+        record.snapshot.endedAt = Date.now();
+        record.snapshot.error = "进程重启，后台任务丢失";
+        const deliveryRequired = record.snapshot.ownerSessionId !== null
+            && record.snapshot.deliveryStatus !== "not_required";
+        record.snapshot.deliveryStatus = deliveryRequired ? "pending" : "not_required";
+        record.snapshot.deliveryError = undefined;
+        record.result = undefined;
+        record.persistedDetail = undefined;
+        record.delivery = deliveryRequired
+            ? {
+                deliveryId: record.delivery?.deliveryId ?? randomUUID(),
+                clientMessageId: record.delivery?.clientMessageId ?? randomUUID(),
+                message: interruptedDeliveryMessage(record.snapshot.title, record.snapshot.jobId),
+            }
+            : undefined;
+    }
+
+    private async readDurableRecord(jobId: string): Promise<DurableAgentJobRecord | null> {
+        try {
+            return await this.durableStore.read(jobId);
+        } catch (error) {
+            void appLogger.warn("agent.jobs.detailDurableReadFailed", {
+                jobId,
+                error: error instanceof Error ? error.message : String(error),
+            });
+            return null;
+        }
+    }
+
+    private persistBestEffort(record: JobRecord, phase: string): void {
+        void this.persistRequired(record).catch((error) => {
+            void appLogger.warn("agent.jobs.persistFailed", {
+                jobId: record.snapshot.jobId,
+                phase,
+                error: error instanceof Error ? error.message : String(error),
+            });
         });
+    }
+
+    private async persistRequired(record: JobRecord): Promise<void> {
+        await this.persistDurable(this.toDurableRecord(record));
+    }
+
+    private async persistDurable(record: DurableAgentJobRecord): Promise<void> {
+        const durable = structuredClone(record);
+        const operation = this.persistQueue.then(() => this.durableStore.write(durable));
+        this.persistQueue = operation.catch(() => undefined);
+        await operation;
+    }
+
+    private toDurableRecord(record: JobRecord): DurableAgentJobRecord {
+        return {
+            schemaVersion: 1,
+            snapshot: {...record.snapshot},
+            ...(record.result === undefined ? {} : {result: record.result}),
+            ...(record.persistedDetail === undefined ? {} : {detail: record.persistedDetail}),
+            ...(record.workflowRun === undefined ? {} : {workflowRun: record.workflowRun}),
+            ...(record.delivery === undefined ? {} : {delivery: {...record.delivery}}),
+        };
     }
 
     /** 合并高频 preview，只在最后一次更新静默 250ms 后发布。 */
@@ -469,11 +731,10 @@ export class AgentJobManager {
 
     /** 取消尚未发布的 preview，供离散状态变化抢先发布最新快照。 */
     private cancelPreview(record: JobRecord): void {
-        const jobId = record.snapshot.jobId;
-        const pending = this.previewTimers.get(jobId);
+        const pending = this.previewTimers.get(record.snapshot.jobId);
         if (!pending) return;
         clearTimeout(pending);
-        this.previewTimers.delete(jobId);
+        this.previewTimers.delete(record.snapshot.jobId);
     }
 
     /** 发布 detached Job 快照；shutdown 后的迟到状态变化不再进入事件流。 */
@@ -481,24 +742,39 @@ export class AgentJobManager {
         if (this.shuttingDown || this.jobs.get(record.snapshot.jobId) !== record) return null;
         return this.events.publish({type: "job_upserted", job: {...record.snapshot}});
     }
+}
 
-    private async persistLine(line: RegistryLine): Promise<void> {
-        if (!this.registryPath) return;
-        this.persistQueue = this.persistQueue.then(async () => {
-            await this.appendRegistryLine(line);
-        });
-        await this.persistQueue;
-    }
+function isTerminal(status: AgentJobStatus): boolean {
+    return status !== "running" && status !== "waiting";
+}
 
-    /** 单次物理 append；调用方必须经过 persistQueue 串行化。 */
-    private async appendRegistryLine(line: RegistryLine): Promise<void> {
-        try {
-            await mkdir(dirname(this.registryPath), {recursive: true});
-            await appendFile(this.registryPath, `${JSON.stringify(line)}\n`, "utf8");
-        } catch (error) {
-            void appLogger.warn("agent.jobs.persistFailed", {jobId: line.jobId, error: error instanceof Error ? error.message : String(error)});
-        }
-    }
+function resultDeliveryMessage(
+    snapshot: AgentJobSnapshot,
+    outcome: JobOutcome | null,
+    failure: string | null,
+): string {
+    const header = snapshot.status === "completed"
+        ? `[后台任务完成] ${snapshot.title}（${snapshot.jobId}）`
+        : snapshot.status === "cancelled"
+            ? `[后台任务已取消] ${snapshot.title}（${snapshot.jobId}）`
+            : `[后台任务失败] ${snapshot.title}（${snapshot.jobId}）：${failure ?? "未知错误"}`;
+    const content = snapshot.status === "completed" && outcome?.message
+        ? outcome.message
+        : [header, snapshot.status === "completed" ? outcome?.resultPreview ?? "" : ""].filter(Boolean).join("\n");
+    return [
+        "<system-reminder>",
+        content,
+        "</system-reminder>",
+    ].join("\n");
+}
+
+function interruptedDeliveryMessage(title: string, jobId: string): string {
+    return [
+        "<system-reminder>",
+        `[后台任务中断] ${title}（${jobId}）`,
+        "服务重启导致该后台任务丢失，未能产出结果。如仍需要请重新发起。",
+        "</system-reminder>",
+    ].join("\n");
 }
 
 function clip(text: string, max: number): string {

--- a/server/agent/tools/agent-collaboration-tools.test.ts
+++ b/server/agent/tools/agent-collaboration-tools.test.ts
@@ -176,7 +176,7 @@ describe("agent collaboration tool definitions", () => {
     });
 
     it("invoke_agent background 即时返回 job，完成结果卡沿用规范化结果合同", async () => {
-        let runJob: ((context: {signal: AbortSignal}) => Promise<{resultPreview: string; message?: string}>) | undefined;
+        let runJob: ((context: {signal: AbortSignal}) => Promise<{resultPreview: string; result?: unknown; message?: string}>) | undefined;
         const invokeAgent = vi.fn(async () => ({
             sessionId: 2,
             invocationId: "background-invocation",
@@ -188,7 +188,7 @@ describe("agent collaboration tool definitions", () => {
             invokeAgent,
             abortInvocation: vi.fn(async () => undefined),
             jobs: {
-                spawn(spec: {run: (context: {signal: AbortSignal}) => Promise<{resultPreview: string; message?: string}>}) {
+                spawn(spec: {run: (context: {signal: AbortSignal}) => Promise<{resultPreview: string; result?: unknown; message?: string}>}) {
                     runJob = spec.run;
                     return {
                         job: {jobId: "job-test"},
@@ -220,6 +220,12 @@ describe("agent collaboration tool definitions", () => {
         const controller = new AbortController();
         const outcome = await runJob!({signal: controller.signal});
         expect(outcome.resultPreview).toBe("background result");
+        expect(outcome.result).toMatchObject({
+            status: "completed",
+            sessionId: 2,
+            finalMessage: "background result",
+            data: {chapterCount: 3},
+        });
         expect(outcome.message).toContain('"status": "completed"');
         expect(outcome.message).toContain('"sessionId": 2');
         expect(outcome.message).toContain('"finalMessage": "background result"');

--- a/server/agent/tools/agent-collaboration-tools.ts
+++ b/server/agent/tools/agent-collaboration-tools.ts
@@ -157,6 +157,7 @@ export const agentCollaborationTools = {
                         const compact = compactInvokeAgentResult(result, invocation.sessionId);
                         return {
                             resultPreview: compact.finalMessage.slice(0, 300),
+                            result: compact,
                             message: `agent #${invocation.sessionId} 返回：\n${JSON.stringify(compact, null, 2)}`,
                         };
                     },

--- a/server/agent/tools/file-tools.ts
+++ b/server/agent/tools/file-tools.ts
@@ -31,6 +31,7 @@ import {
 import {AttachmentError} from "nbook/server/agent/attachments/types";
 import {AGENT_IMAGE_POLICY} from "nbook/server/agent/attachments/agent-attachment-policy";
 import type {ReadyProjectSessionRef} from "nbook/server/workspace-files/project-session-types";
+import type {JsonValue} from "nbook/shared/dto/agent-job.dto";
 
 const ReadSchema = Type.Object({
     path: Type.String({description: "Path to the file to read (relative or absolute)."}),
@@ -408,6 +409,12 @@ function createBashTool(): NeuroAgentTool {
                             if (result.exitCode !== 0) throw new Error(formatted.length > 4000 ? `${formatted.slice(0, 4000)}…` : formatted);
                             return {
                                 resultPreview: `exit 0（输出 ${snapshot.content.length} 字符）`,
+                                result: {
+                                    exitCode: result.exitCode,
+                                    output: snapshot.content,
+                                    truncation: snapshot.truncation as unknown as JsonValue,
+                                    fullOutput: (snapshot.fullOutput ?? null) as unknown as JsonValue,
+                                },
                                 message: [
                                     `后台 bash 命令完成：\`${input.command}\``,
                                     "```",

--- a/server/api/agent/jobs/clear-finished.post.ts
+++ b/server/api/agent/jobs/clear-finished.post.ts
@@ -1,6 +1,6 @@
 import {useAgentHarness} from "nbook/server/agent/http";
 
-/** 清除内存中的已结束后台任务（jobs.jsonl 登记表为 append-only 审计面，不受影响） */
-export default defineEventHandler(() => {
-    return {removed: useAgentHarness().jobs.clearFinished()};
+/** 清除 durable 已结束后台任务；仍待结果回流的 Job 保留。 */
+export default defineEventHandler(async () => {
+    return {removed: await useAgentHarness().jobs.clearFinished()};
 });


### PR DESCRIPTION
## 关联

- Issue：无 / None
- Task：Task 142（由 PR #69 创建）

## 用户可见结果

- 后台 Job 在服务重启后仍会出现在任务中心，完整结果与详情可以继续查询。
- Workflow/bash/invoke_agent 的完成结果先可靠落盘，再进入 Session 的持久 follow-up 队列；进程在“完成后、回流前”崩溃时，重启会继续投递。
- “清除已结束”现在会真正删除 durable 历史；仍处于 `deliveryStatus=pending` 的 Job 不会被误删。

## Durable 合同

- 新增 `<Workspace Root>/.nbook/agent/jobs/<jobId>.json` 私有 schema v1。
- 每次离散状态写同目录临时文件，fsync 后原子 rename；terminal snapshot、完整 result、kind detail、回流正文和稳定 delivery/client IDs 在同一次 commit 中发布。
- terminal durable commit 完成前，列表和 SSE 不公开 `completed`；持久化失败收口为明确 `failed`。
- 启动只把历史公开 snapshot 放回列表；完整 result/detail 由 `get_job` 按需读单文件。
- 旧 `jobs.jsonl` 停止追加但保留；只迁移遗留 running/waiting 为 interrupted，旧终态不伪造结果。

## 可靠结果回流

- 不再用一次非幂等 `invokeAgent()` 作为 Job delivery。
- Harness 新增内部 durable system follow-up 接口，稳定 `deliveryId` 同时作为 queue item ID 与最终 `custom_message.sourceQueueItemId`。
- queue item 已存在、消息已提交两层均可幂等确认；`accepted` 只表示已进入 durable queue 或 Session，不等待 Provider 回合结束。
- Harness 启动时恢复并 drain ready follow-up queue；accepted=queued 的 Job 重启后也会重新触发 drain。
- 不承诺跨 Provider 分布式 exactly-once；保证同一 Job 不重复写入系统结果消息。

## 其它范围

- background invoke_agent 把规范化完整结果写入 Job result。
- background bash 把 exitCode、可见输出、截断元数据和 full-output locator 写入 Job result。
- 公共 Job DTO、列表/SSE 形状和 `{removed}` HTTP 返回形状不变。

## 验证

- Job/Harness/Workflow/Tools/API/Jobs feed 聚焦批次：13 files / 357 tests passed。
- `bun run typecheck`：通过。
- `git diff --check`：通过。

## 未运行与边界

- 未运行全仓测试、浏览器验收、服务真实重启 smoke 或真实 Provider；这些留到 Task 142 最终收口。
- 本 PR 不实现 Workflow Run 历史投影和 `interrupted` Run API；该项是下一顺序 PR。
- 不增加自动保留天数、历史数量上限、Job SQLite 表或通用 outbox。
- 不删除旧 `jobs.jsonl`、Session、trace 或现有缓存。