### PR TITLE
fix(bun): use hoisted linker for Source Dev

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,6 @@
+[install]
+linker = "hoisted"
+
 [test]
 pathIgnorePatterns = [
     "product/**",


### PR DESCRIPTION
## 概述

从最新 `master` 重放 #73 的单一 Bun 配置修复，使本仓 CI 能在维护者分支上正常运行检查。

## 用户可见结果

源码开发默认使用 hoisted 依赖布局，避免隔离布局下 AJV ESM default export 导致 Nuxt 500。

## 验证

- `bun install --frozen-lockfile`：通过，`bun.lock` 未变化
- `bun run generate`：通过
- `bun run typecheck`：通过
- 隔离 State/Cache Root 的 `bun run dev`：HTTP 200，页面不含 AJV/default export 错误
- `git diff --check origin/master...HEAD`：通过

## 范围

仅修改 `bunfig.toml`。不修改数据库、运行时 API 或用户数据。

Refs #71
Supersedes #73 after merge.