### PR TITLE
fix(agent): surface stop request failures on current master

### DIFF
--- a/app/components/novel-ide/agent/AgentChatSurface.vue
+++ b/app/components/novel-ide/agent/AgentChatSurface.vue
@@ -1505,7 +1505,7 @@ const stopRun = async (): Promise<void> => {
         await agentApi.abortSession(activeSessionId.value, {reason: "user abort"});
         await syncActiveSessionRecovery();
     } catch (error) {
-        console.error("停止 Agent 运行失败", error);
+        notification.error(resolveApiErrorMessage(error, t("agent.chatSurface.stopRunFailed")));
     }
 };
 

--- a/app/i18n/locales/en-US.ts
+++ b/app/i18n/locales/en-US.ts
@@ -2020,6 +2020,7 @@ const enUS = {
             reconnectFailed: "Failed to reconnect Agent event stream",
             userTerminated: "User chose to stop this run.",
             stopped: "Stop requested",
+            stopRunFailed: "Failed to stop Agent run",
             submitAnswersFailed: "Failed to submit answers",
             cancelUserInputFailed: "Failed to cancel user input",
             switchModeFailed: "Failed to switch Agent mode",

--- a/app/i18n/locales/zh-CN.ts
+++ b/app/i18n/locales/zh-CN.ts
@@ -2018,6 +2018,7 @@ const zhCN = {
             reconnectFailed: "重新连接 Agent 事件流失败",
             userTerminated: "用户选择终止本轮。",
             stopped: "已请求停止",
+            stopRunFailed: "停止 Agent 运行失败",
             submitAnswersFailed: "提交问题答案失败",
             cancelUserInputFailed: "取消等待用户输入失败",
             switchModeFailed: "切换 Agent 模式失败",


### PR DESCRIPTION
## 范围

Refs #70

在当前 master 的 Agent 界面上补齐停止请求失败的用户出口：停止接口或后续同步失败时，使用统一 API 错误解析和全局通知提示用户，不再只写入控制台。

## 验证

- `git diff --check`
- `bun run generate`
- `bun run typecheck`
- `bun run test -- app/components/novel-ide/agent/useAgentSessionApi.test.ts --reporter=dot`（7 passed）

## 未运行

- 浏览器拦截停止接口失败后的真实通知验收，待合并后集中执行。
- 全仓测试未运行。

## 非目标

- 不改变停止/取消状态合同。
- 不新增状态管理或重试机制。
- 原 #70 分支保持不变。