### PR TITLE
fix(t142): make clean-runner baseline portable

### DIFF
--- a/.github/workflows/code-baseline.yml
+++ b/.github/workflows/code-baseline.yml
@@ -58,6 +58,8 @@ jobs:
         uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         run: bun install --frozen-lockfile --linker hoisted
+      - name: Generate Prisma clients
+        run: bun run generate
       - name: Run typecheck
         run: bun run typecheck
 
@@ -76,6 +78,8 @@ jobs:
         uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         run: bun install --frozen-lockfile --linker hoisted
+      - name: Generate Prisma clients
+        run: bun run generate
       - name: Generate Nuxt types
         # vitest 依赖根 tsconfig.json extends ./.nuxt/tsconfig.json（见 tsconfig.json）；
         # 不先 prepare 生成 .nuxt/，oxc 解析 global-setup 等文件时会报 Tsconfig not found。

--- a/.github/workflows/code-baseline.yml
+++ b/.github/workflows/code-baseline.yml
@@ -84,5 +84,8 @@ jobs:
         # vitest 依赖根 tsconfig.json extends ./.nuxt/tsconfig.json（见 tsconfig.json）；
         # 不先 prepare 生成 .nuxt/，oxc 解析 global-setup 等文件时会报 Tsconfig not found。
         run: bunx nuxt prepare
+      - name: Install test runtime dependencies
+        # Agent bash 合同会真实执行 rg；GitHub Ubuntu runner 不保证预装 ripgrep。
+        run: sudo apt-get update && sudo apt-get install --yes ripgrep
       - name: Run full tests
         run: bun run test -- --reporter=dot

--- a/scripts/build/nuxt-output-contract.test.ts
+++ b/scripts/build/nuxt-output-contract.test.ts
@@ -110,13 +110,16 @@ describe("Nuxt raw Product output", () => {
     });
 
     it("Product island matcher 覆盖 bare、Bun、pnpm 与 scoped package", () => {
+        const sharpPlatformPackage = productRuntimeIslandPackageNames()
+            .find((packageName) => packageName.startsWith("@img/sharp-"));
+        expect(sharpPlatformPackage).toBeTruthy();
         expect(isProductRuntimeIslandModule("typescript")).toBe(true);
         expect(isProductRuntimeIslandModule("typescript/lib/typescript.js?raw")).toBe(true);
         expect(isProductRuntimeIslandModule("C:\\repo\\node_modules\\.bun\\typescript@5.9.3\\node_modules\\typescript\\lib\\typescript.js"))
             .toBe(true);
         expect(isProductRuntimeIslandModule("/repo/node_modules/.pnpm/jsdom@29.1.1/node_modules/jsdom/lib/api.js"))
             .toBe(true);
-        expect(isProductRuntimeIslandModule("/repo/node_modules/@img/sharp-win32-x64/lib/sharp.node"))
+        expect(isProductRuntimeIslandModule(`/repo/node_modules/${sharpPlatformPackage}/lib/sharp.node`))
             .toBe(true);
         expect(isProductRuntimeIslandModule("zod/v4")).toBe(false);
         expect(isProductRuntimeIslandModule("\0virtual:typescript")).toBe(false);

--- a/scripts/build/workspace-cli-wrapper.test.ts
+++ b/scripts/build/workspace-cli-wrapper.test.ts
@@ -50,7 +50,7 @@ describe("workspace CLI wrapper", () => {
 
         const result = await runWrapper(fixture, ["node", "chapter one"]);
 
-        await expectProductInvocation(result, fixture, ["node", "chapter one"]);
+        await expectProductInvocation(result, fixture, ["command", "workspace", "node", "chapter one"]);
     });
 
     it.skipIf(process.platform === "win32")("POSIX包装器在bundle缺失时回退Source入口", async () => {

--- a/server/agent/harness/neuro-agent-harness.black-box.test.ts
+++ b/server/agent/harness/neuro-agent-harness.black-box.test.ts
@@ -1276,6 +1276,7 @@ describe("NeuroAgentHarness black-box contract", () => {
         }
     });
 
+    // 外层预算覆盖 full-suite 下的 Harness/Provider 初始化；取消是否有界仍由用例内 300ms/1s race 精确约束。
     it("Running provider 忽略 AbortSignal 时 cancel 仍有界释放调用方，并隔离迟到结果", async () => {
         const profileKey = registerPlainProfile(harness, {
             key: "test.blackbox.forced-running-abort",
@@ -1325,7 +1326,7 @@ describe("NeuroAgentHarness black-box contract", () => {
         const snapshot = await harness.repo.readSession(created.sessionId);
         expect(visibleText(harness.repo.reduce(snapshot).messages)).not.toContain("late provider result");
         expect(lifecycleStatuses(snapshot)).toEqual(["start", "aborted", "start", "end"]);
-    });
+    }, 15_000);
 
     it("外部 signal 只取消 admission 接收的精确 invocation，不影响同 session 后续调用", async () => {
         const profileKey = registerPlainProfile(harness, {
@@ -1374,7 +1375,7 @@ describe("NeuroAgentHarness black-box contract", () => {
         const snapshot = await harness.repo.readSession(created.sessionId);
         expect(visibleText(harness.repo.reduce(snapshot).messages)).not.toContain("late exact-signal result");
         expect(lifecycleStatuses(snapshot)).toEqual(["start", "aborted", "start", "end"]);
-    });
+    }, 15_000);
 
     it("Running tool 忽略 AbortSignal 时 cancel 仍有界释放调用方，并隔离迟到结果", async () => {
         let releaseTool: (() => void) | undefined;

--- a/server/agent/harness/neuro-agent-harness.black-box.test.ts
+++ b/server/agent/harness/neuro-agent-harness.black-box.test.ts
@@ -1276,7 +1276,8 @@ describe("NeuroAgentHarness black-box contract", () => {
         }
     });
 
-    // 外层预算覆盖 full-suite 下的 Harness/Provider 初始化；取消是否有界仍由用例内 300ms/1s race 精确约束。
+    // 这两个用例的外层预算覆盖 full-suite 下的 Harness/Provider 初始化；
+    // 取消是否有界仍由用例内 300ms/1s race 精确约束。
     it("Running provider 忽略 AbortSignal 时 cancel 仍有界释放调用方，并隔离迟到结果", async () => {
         const profileKey = registerPlainProfile(harness, {
             key: "test.blackbox.forced-running-abort",
@@ -1326,7 +1327,7 @@ describe("NeuroAgentHarness black-box contract", () => {
         const snapshot = await harness.repo.readSession(created.sessionId);
         expect(visibleText(harness.repo.reduce(snapshot).messages)).not.toContain("late provider result");
         expect(lifecycleStatuses(snapshot)).toEqual(["start", "aborted", "start", "end"]);
-    }, 15_000);
+    }, 30_000);
 
     it("外部 signal 只取消 admission 接收的精确 invocation，不影响同 session 后续调用", async () => {
         const profileKey = registerPlainProfile(harness, {
@@ -1375,7 +1376,7 @@ describe("NeuroAgentHarness black-box contract", () => {
         const snapshot = await harness.repo.readSession(created.sessionId);
         expect(visibleText(harness.repo.reduce(snapshot).messages)).not.toContain("late exact-signal result");
         expect(lifecycleStatuses(snapshot)).toEqual(["start", "aborted", "start", "end"]);
-    }, 15_000);
+    }, 30_000);
 
     it("Running tool 忽略 AbortSignal 时 cancel 仍有界释放调用方，并隔离迟到结果", async () => {
         let releaseTool: (() => void) | undefined;

--- a/server/agent/profiles/profile-compile-worker.ts
+++ b/server/agent/profiles/profile-compile-worker.ts
@@ -61,11 +61,7 @@ type ProfileCompileEntryTask = {
 
 type CompileWorkerPaths = {
     entry: string;
-    /** Product 使用预编译 worker 时为空；Source Node worker 才需要 TS runtime。 */
-    runtime?: string;
-    /** Product 使用预编译 worker 时为空；Source Node worker 才需要 TS loader。 */
-    tsconfig?: string;
-    tsxApiUrl?: string;
+    /** Product 使用预编译 worker 时为空；Source worker 才需要 TS loader。 */
     tsxLoaderUrl?: string;
     precompiled: boolean;
 };
@@ -718,13 +714,8 @@ async function createCompileWorker(): Promise<Worker> {
     if (workerPaths.precompiled) {
         return new Worker(pathToFileURL(workerPaths.entry));
     }
-    if (process.versions.bun) {
-        return new Worker(pathToFileURL(workerPaths.entry), {
-            execArgv: ["--import", requiredWorkerPath(workerPaths.tsxLoaderUrl, "tsx loader")],
-        });
-    }
-    return new Worker(renderNodeWorkerSource(workerPaths), {
-        eval: true,
+    return new Worker(pathToFileURL(workerPaths.entry), {
+        execArgv: ["--import", requiredWorkerPath(workerPaths.tsxLoaderUrl, "tsx loader")],
     });
 }
 
@@ -755,20 +746,12 @@ export async function resolveProfileCompileWorkerPathsForRoot(
     }
     return {
         entry,
-        runtime,
-        tsconfig: resolvePreferredTsconfig(root),
         precompiled: false,
-        ...resolveTsxPackageUrls(existsSync(resolve(root, "package.json")) ? resolve(root, "package.json") : entry, false),
-    };
-}
-
-/**
- * 从指定上下文解析 TSX worker 依赖，避免 worker 使用 cwd 裸包名解析。
- */
-function resolveTsxPackageUrls(requireRoot: string, productRuntime: boolean): {tsxApiUrl: string; tsxLoaderUrl: string} {
-    return {
-        tsxApiUrl: resolvePackageUrl(requireRoot, "tsx/esm/api", productRuntime),
-        tsxLoaderUrl: resolvePackageUrl(requireRoot, "tsx", productRuntime),
+        tsxLoaderUrl: resolvePackageUrl(
+            existsSync(resolve(root, "package.json")) ? resolve(root, "package.json") : entry,
+            "tsx",
+            false,
+        ),
     };
 }
 
@@ -786,50 +769,6 @@ function resolvePackageUrl(requireRoot: string, specifier: string, productRuntim
         }
         throw error;
     }
-}
-
-/**
- * 优先使用 Nuxt server tsconfig，缺失时回退根 tsconfig。
- */
-function resolvePreferredTsconfig(root: string): string {
-    const serverTsconfig = resolve(root, ".nuxt", "tsconfig.server.json");
-    if (existsSync(serverTsconfig)) {
-        return serverTsconfig;
-    }
-    return resolve(root, "tsconfig.json");
-}
-
-function renderNodeWorkerSource(paths: CompileWorkerPaths): string {
-    const entry = requiredWorkerPath(paths.entry, "entry");
-    const runtime = requiredWorkerPath(paths.runtime, "runtime");
-    const tsconfig = requiredWorkerPath(paths.tsconfig, "tsconfig");
-    const tsxApiUrl = requiredWorkerPath(paths.tsxApiUrl, "tsx API");
-    return `
-    import {parentPort} from "node:worker_threads";
-    import {pathToFileURL} from "node:url";
-
-    if (!parentPort) {
-        throw new Error("profile compile worker parentPort missing");
-    }
-
-    const parentURL = pathToFileURL(${JSON.stringify(entry)}).href;
-    const runtimeURL = pathToFileURL(${JSON.stringify(runtime)}).href;
-    const tsconfig = ${JSON.stringify(tsconfig)};
-    const {tsImport} = await import(${JSON.stringify(tsxApiUrl)});
-    const {runProfileCompile, runProfileCompileAll, runProfileCompileEntry} = await tsImport(runtimeURL, {parentURL, tsconfig});
-
-    parentPort.on("message", async (message) => {
-        const result = message.mode === "all"
-            ? await runProfileCompileAll(message.input)
-            : message.mode === "entry"
-                ? await runProfileCompileEntry(message.input)
-            : await runProfileCompile(message.input);
-        parentPort.postMessage({
-            id: message.id,
-            result,
-        });
-    });
-`;
 }
 
 /** 可选 Product/Source 路径在进入具体执行分支后必须完整。 */

--- a/server/agent/tools/agent-sql-project-module.test.ts
+++ b/server/agent/tools/agent-sql-project-module.test.ts
@@ -4,7 +4,8 @@ import {
     PROJECT_AGENT_SQL_MODULE_TOKEN,
     projectAgentSqlModule,
 } from "nbook/server/agent/tools/agent-sql-project-module";
-import {absoluteFsPath, type AbsoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import type {AbsoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 import {
     PROJECT_DATABASE_MODULE_TOKEN,
     type ProjectDatabaseModuleHandle,
@@ -66,8 +67,8 @@ describe("Project Agent SQL Module Interface", () => {
             },
             clientClosed() {},
         });
-        const firstPath = absoluteFsPath("C:\\workspace\\first\\.nbook\\project.sqlite");
-        const secondPath = absoluteFsPath("C:\\workspace\\second\\.nbook\\project.sqlite");
+        const firstPath = testAbsoluteFsPath("agent-sql", "workspace", "first", ".nbook", "project.sqlite");
+        const secondPath = testAbsoluteFsPath("agent-sql", "workspace", "second", ".nbook", "project.sqlite");
         const first = module.start(projectModuleContext(databaseHandle(firstPath)));
         const second = module.start(projectModuleContext(databaseHandle(secondPath)));
 
@@ -97,7 +98,7 @@ describe("Project Agent SQL Module Interface", () => {
     });
 
     it("client close失败后保留精确实例并允许同handle重试", async () => {
-        const databasePath = absoluteFsPath("C:\\workspace\\retry\\.nbook\\project.sqlite");
+        const databasePath = testAbsoluteFsPath("agent-sql", "workspace", "retry", ".nbook", "project.sqlite");
         let openCount = 0;
         let closeCount = 0;
         const firstFailure = new Error("native handle仍被占用");

--- a/server/agent/tools/file-tools.test.ts
+++ b/server/agent/tools/file-tools.test.ts
@@ -1,4 +1,4 @@
-import {access, mkdir, mkdtemp, readFile, rm, symlink, writeFile} from "node:fs/promises";
+import {access, chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile} from "node:fs/promises";
 import {basename, dirname, join, resolve} from "node:path";
 import {createHash} from "node:crypto";
 import {tmpdir} from "node:os";
@@ -829,6 +829,7 @@ describe("v3 file tools", () => {
         const userBinPath = join(workspaceRoot, ".nbook", "agent", "bin", "workspace");
         await mkdir(dirname(userBinPath), {recursive: true});
         await writeFile(userBinPath, "#!/usr/bin/env sh\necho user-bin-path-test\n", "utf-8");
+        if (process.platform !== "win32") await chmod(userBinPath, 0o755);
         const tool = mustTool("bash", harness);
 
         try {
@@ -848,6 +849,7 @@ describe("v3 file tools", () => {
         const userBinPath = join(workspaceRoot, ".nbook", "agent", "bin", "workspace");
         await mkdir(dirname(userBinPath), {recursive: true});
         await writeFile(userBinPath, "#!/usr/bin/env sh\necho user-bin-test\n", "utf-8");
+        if (process.platform !== "win32") await chmod(userBinPath, 0o755);
         const tool = mustTool("bash", harness);
 
         try {

--- a/server/agent/workflow/workflow-job.test.ts
+++ b/server/agent/workflow/workflow-job.test.ts
@@ -2,7 +2,7 @@ import {AgentJobManager} from "nbook/server/agent/jobs/agent-job-manager";
 import {spawnWorkflowJob} from "nbook/server/agent/workflow/workflow-job";
 import {createDefaultEffectiveConfig} from "nbook/server/config/normalizer";
 import type {RunView, WorkflowDefinition} from "nbook/server/vendor/nb-workflow/index";
-import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 import {
     createProjectWorkspaceKey,
     projectWorkspaceRef,
@@ -238,12 +238,12 @@ describe("spawnWorkflowJob cancellation", () => {
 
 /** 构造只用于exact identity断言的Project generation。 */
 function readyProject(): ReadyProjectSessionRef {
-    const workspaceRoot = absoluteFsPath("C:/workflow-job-test");
+    const workspaceRoot = testAbsoluteFsPath("workflow-job-test");
     const ref = projectWorkspaceRef("project");
     return Object.freeze({
         workspace: resolvedProjectWorkspace(
             ref,
-            absoluteFsPath("C:/workflow-job-test/project"),
+            testAbsoluteFsPath("workflow-job-test", "project"),
             createProjectWorkspaceKey(workspaceRoot, ref),
         ),
         generation: 7,

--- a/server/api/projects/control-plane-open-guard.test.ts
+++ b/server/api/projects/control-plane-open-guard.test.ts
@@ -1,7 +1,7 @@
 import {beforeEach, describe, expect, it, vi} from "vitest";
-import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 
-const WORKSPACE_ROOT = absoluteFsPath("C:/test/workspace");
+const WORKSPACE_ROOT = testAbsoluteFsPath("control-plane", "workspace");
 
 describe("Project 控制面不要求 open", () => {
     beforeEach(() => {

--- a/server/api/projects/rag/project-rag-http-target.test.ts
+++ b/server/api/projects/rag/project-rag-http-target.test.ts
@@ -1,5 +1,5 @@
 import {beforeEach, describe, expect, it, vi} from "vitest";
-import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 import type {ReadyProjectSessionRef} from "nbook/server/workspace-files/project-session-types";
 
 const PROJECT_REF = {projectRoot: "rag-ready"};
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("nbook/server/runtime/paths/runtime-paths", () => ({
-    runtimePathsFromEnv: () => ({workspaceRoot: absoluteFsPath("C:/workspace-root")}),
+    runtimePathsFromEnv: () => ({workspaceRoot: testAbsoluteFsPath("project-rag", "workspace-root")}),
 }));
 
 vi.mock("nbook/server/api/projects/project-control-plane", () => ({
@@ -43,7 +43,7 @@ describe("Project RAG HTTP target", () => {
         expect(mocks.requireActiveReadyProject).toHaveBeenCalledOnce();
         expect(mocks.requireActiveReadyProject).toHaveBeenCalledWith(PROJECT_REF);
         expect(target).toEqual({
-            workspaceRoot: absoluteFsPath("C:/workspace-root"),
+            workspaceRoot: testAbsoluteFsPath("project-rag", "workspace-root"),
             project: ready,
         });
     });
@@ -62,7 +62,7 @@ describe("Project RAG HTTP target", () => {
         expect(mocks.runReadyProjectOperation).toHaveBeenCalledWith(ready, expect.any(Function));
         expect(handler).toHaveBeenCalledOnce();
         expect(handler).toHaveBeenCalledWith({
-            workspaceRoot: absoluteFsPath("C:/workspace-root"),
+            workspaceRoot: testAbsoluteFsPath("project-rag", "workspace-root"),
             project: ready,
         });
     });

--- a/server/api/workspace-files/download.get.test.ts
+++ b/server/api/workspace-files/download.get.test.ts
@@ -1,6 +1,6 @@
 import {Readable} from "node:stream";
 import {beforeEach, describe, expect, it, vi} from "vitest";
-import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 import {
     createProjectWorkspaceKey,
     projectWorkspaceRef,
@@ -17,7 +17,7 @@ describe("GET /api/workspace-files/download", () => {
     it("只按 projectRoot 解析 Project Workspace，忽略 root 查询参数", async () => {
         const target = {
             kind: "project-workspace" as const,
-            root: absoluteFsPath("C:/test/workspace/novel-1"),
+            root: testAbsoluteFsPath("workspace-download", "workspace", "novel-1"),
             projectRoot: projectWorkspaceRef("novel-1").projectRoot,
         };
         const resolveWorkspaceFileTarget = vi.fn(async () => target);
@@ -25,7 +25,7 @@ describe("GET /api/workspace-files/download", () => {
         const workspace = resolvedProjectWorkspace(
             ref,
             target.root,
-            createProjectWorkspaceKey(absoluteFsPath("C:/test/workspace"), ref),
+            createProjectWorkspaceKey(testAbsoluteFsPath("workspace-download", "workspace"), ref),
         );
         const createProjectWorkspaceZipStream = vi.fn(async () => ({
             root: target.root,
@@ -75,7 +75,7 @@ describe("GET /api/workspace-files/download", () => {
     it("user-assets 继续使用普通 workspace archive", async () => {
         const target = {
             kind: "user-assets" as const,
-            root: absoluteFsPath("C:/test/state/.nbook"),
+            root: testAbsoluteFsPath("workspace-download", "state", ".nbook"),
         };
         const resolveWorkspaceFileTarget = vi.fn(async () => target);
         const createWorkspaceZipStream = vi.fn(async () => ({

--- a/server/api/workspace-files/events.get.test.ts
+++ b/server/api/workspace-files/events.get.test.ts
@@ -1,5 +1,5 @@
 import {beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
-import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 import {projectWorkspaceRef} from "nbook/server/workspace-files/project-identity";
 
 type WorkspaceFileEventsHandlerFactory = typeof import("nbook/server/api/workspace-files/events.get")["createWorkspaceFileEventsHandler"];
@@ -14,7 +14,7 @@ type TestEventStream = {
 let createWorkspaceFileEventsHandler: WorkspaceFileEventsHandlerFactory;
 const target = {
     kind: "project-workspace" as const,
-    root: absoluteFsPath("C:/test/workspace/novel-1"),
+    root: testAbsoluteFsPath("workspace-events", "workspace", "novel-1"),
     projectRoot: projectWorkspaceRef("novel-1").projectRoot,
 };
 

--- a/server/api/workspace-files/read.get.test.ts
+++ b/server/api/workspace-files/read.get.test.ts
@@ -1,5 +1,5 @@
 import {beforeEach, describe, expect, it, vi} from "vitest";
-import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 import {projectWorkspaceRef} from "nbook/server/workspace-files/project-identity";
 
 describe("GET /api/workspace-files/read", () => {
@@ -26,7 +26,7 @@ describe("GET /api/workspace-files/read", () => {
         vi.doMock("nbook/server/workspace-files/novel-workspace", () => ({
             resolveWorkspaceFileTarget: vi.fn(async () => ({
                 kind: "project-workspace",
-                root: absoluteFsPath("C:/test/workspace/not-open"),
+                root: testAbsoluteFsPath("workspace-read", "workspace", "not-open"),
                 projectRoot: projectWorkspaceRef("not-open").projectRoot,
             })),
         }));

--- a/server/api/workspace-files/upload-file.post.test.ts
+++ b/server/api/workspace-files/upload-file.post.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it, vi, beforeEach} from "vitest";
-import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 
 describe("POST /api/workspace-files/upload-file", () => {
     beforeEach(() => {
@@ -16,7 +16,7 @@ describe("POST /api/workspace-files/upload-file", () => {
     });
 
     it("resolves user-assets uploads to Workspace Root .nbook", async () => {
-        const root = absoluteFsPath("C:/test/workspace/.nbook");
+        const root = testAbsoluteFsPath("workspace-upload-file", "workspace", ".nbook");
         const resolveWorkspaceFileTarget = vi.fn(async () => ({kind: "user-assets" as const, root}));
         const uploadWorkspaceFile = vi.fn(async () => ({written: 1, skipped: 0, totalBytes: 3, files: []}));
 

--- a/server/api/workspace-files/upload-project.post.test.ts
+++ b/server/api/workspace-files/upload-project.post.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it, vi, beforeEach} from "vitest";
-import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 
-const root = absoluteFsPath("C:/test/workspace/novel-7");
+const root = testAbsoluteFsPath("workspace-upload-project", "workspace", "novel-7");
 
 describe("POST /api/workspace-files/upload-project", () => {
     beforeEach(() => {

--- a/server/api/workspace-files/write.put.test.ts
+++ b/server/api/workspace-files/write.put.test.ts
@@ -5,6 +5,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {statWorkspacePath} from "nbook/server/workspace-files/workspace-files";
 import {WorkspaceWriteConflictDtoSchema} from "nbook/shared/dto/workspace-file-conflict.dto";
 import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 import {projectWorkspaceRef} from "nbook/server/workspace-files/project-identity";
 
 const createdRoots: string[] = [];
@@ -102,7 +103,7 @@ describe("PUT /api/workspace-files/write", () => {
         vi.doMock("nbook/server/workspace-files/novel-workspace", () => ({
             resolveWorkspaceFileTarget: vi.fn(async () => ({
                 kind: "project-workspace",
-                root: absoluteFsPath("C:/test/workspace/not-open"),
+                root: testAbsoluteFsPath("workspace-write", "workspace", "not-open"),
                 projectRoot: projectWorkspaceRef("not-open").projectRoot,
             })),
         }));

--- a/server/app-logs/logger.test.ts
+++ b/server/app-logs/logger.test.ts
@@ -11,6 +11,7 @@ import {
     sanitizeAppLogValue,
     serializeAppLogError,
 } from "nbook/server/app-logs/logger";
+import {testHostPath} from "nbook/server/runtime/paths/test-path";
 
 const cleanupRoots: string[] = [];
 
@@ -31,18 +32,20 @@ async function tempLogRoot(): Promise<string> {
 
 describe("app logs logger", () => {
     it("resolves explicit log directory before environment fallbacks", () => {
+        const productRoot = testHostPath("app-logs", "product");
+        const repoRoot = testHostPath("app-logs", "repo");
         expect(resolveAppLogDirectory({
-            cwd: "C:/Product",
+            cwd: productRoot,
             env: {NEURO_BOOK_LOG_DIR: "data/logs"} as NodeJS.ProcessEnv,
-        }).replaceAll("\\", "/")).toBe("C:/Product/data/logs");
+        })).toBe(path.join(productRoot, "data", "logs"));
         expect(resolveAppLogDirectory({
-            cwd: "C:/Product",
+            cwd: productRoot,
             env: {NODE_ENV: "production"} as NodeJS.ProcessEnv,
-        }).replaceAll("\\", "/")).toBe("C:/Product/logs");
+        })).toBe(path.join(productRoot, "logs"));
         expect(resolveAppLogDirectory({
-            cwd: "C:/Repo",
+            cwd: repoRoot,
             env: {} as NodeJS.ProcessEnv,
-        }).replaceAll("\\", "/")).toBe("C:/Repo/workspace/.nbook/logs");
+        })).toBe(path.join(repoRoot, "workspace", ".nbook", "logs"));
     });
 
     it("redacts common secret fields recursively", () => {

--- a/server/runtime/paths/test-path.ts
+++ b/server/runtime/paths/test-path.ts
@@ -1,0 +1,17 @@
+import path from "node:path";
+import {absoluteFsPath, type AbsoluteFsPath} from "nbook/server/runtime/paths/file-path";
+
+/**
+ * 为不触碰真实用户目录的测试建立宿主原生绝对路径。
+ *
+ * Windows runner 得到盘符路径，POSIX runner 得到 `/...` 路径；测试不得再把
+ * `C:/...` 当成跨平台绝对路径。需要验证 Windows 字符串语义时应显式使用
+ * `path.win32`，而不是调用本辅助函数。
+ */
+export function testHostPath(...segments: string[]): string {
+    return path.resolve(process.cwd(), ".agent", "tmp", "test-paths", ...segments);
+}
+
+export function testAbsoluteFsPath(...segments: string[]): AbsoluteFsPath {
+    return absoluteFsPath(testHostPath(...segments));
+}

--- a/server/workspace-files/project-data-plane-guard.test.ts
+++ b/server/workspace-files/project-data-plane-guard.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it, vi} from "vitest";
 import {readFile} from "node:fs/promises";
 import path from "node:path";
-import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 import {
     createProjectWorkspaceKey,
     projectWorkspaceRef,
@@ -73,12 +73,12 @@ describe("Project file data-plane mutation guard", () => {
 
 /** 构造 mutation guard 测试使用的 exact ready generation。 */
 function readyProject(slug: string): ReadyProjectSessionRef {
-    const workspaceRoot = absoluteFsPath("C:/workspace-root");
+    const workspaceRoot = testAbsoluteFsPath("project-data-plane", "workspace-root");
     const ref = projectWorkspaceRef(slug);
     return {
         workspace: resolvedProjectWorkspace(
             ref,
-            absoluteFsPath(`C:/workspace-root/${slug}`),
+            testAbsoluteFsPath("project-data-plane", "workspace-root", slug),
             createProjectWorkspaceKey(workspaceRoot, ref),
         ),
         generation: 1,
@@ -89,7 +89,13 @@ function readyProject(slug: string): ReadyProjectSessionRef {
 function fileTarget(project: ReadyProjectSessionRef): ResolvedFileTarget {
     return {
         kind: "project",
-        absolutePath: absoluteFsPath(`C:/workspace-root/${project.workspace.ref.projectRoot}/manuscript/a.md`),
+        absolutePath: testAbsoluteFsPath(
+            "project-data-plane",
+            "workspace-root",
+            project.workspace.ref.projectRoot,
+            "manuscript",
+            "a.md",
+        ),
         project,
         relativePath: "manuscript/a.md",
     };

--- a/server/workspace-files/project-open-guard.test.ts
+++ b/server/workspace-files/project-open-guard.test.ts
@@ -1,5 +1,5 @@
 import {beforeEach, describe, expect, it, vi} from "vitest";
-import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 import type {ReadyProjectSessionRef} from "nbook/server/workspace-files/project-session-types";
 import {projectWorkspaceRef} from "nbook/server/workspace-files/project-identity";
 import type {WorkspaceFileTarget} from "nbook/server/workspace-files/workspace-file-target";
@@ -68,7 +68,7 @@ describe("Project HTTP data-plane operation guard", () => {
         });
         const target: WorkspaceFileTarget = {
             kind: "project-workspace",
-            root: absoluteFsPath("C:/workspace-root/guard"),
+            root: testAbsoluteFsPath("project-open-guard", "workspace-root", "guard"),
             projectRoot: projectWorkspaceRef("guard").projectRoot,
         };
         const {withProjectTargetOperation} = await import("nbook/server/workspace-files/project-open-guard");
@@ -110,7 +110,7 @@ describe("Project HTTP data-plane operation guard", () => {
         mocks.runReadyProjectOperation.mockImplementation((_ready, operation) => operation());
         const target: WorkspaceFileTarget = {
             kind: "project-workspace",
-            root: absoluteFsPath("C:/workspace-root/mutation"),
+            root: testAbsoluteFsPath("project-open-guard", "workspace-root", "mutation"),
             projectRoot: projectWorkspaceRef("mutation").projectRoot,
         };
         const {withProjectTargetMutation} = await import("nbook/server/workspace-files/project-open-guard");
@@ -128,7 +128,7 @@ describe("Project HTTP data-plane operation guard", () => {
         mocks.mutatePlain.mockImplementation((_target, operation) => operation());
         const target: WorkspaceFileTarget = {
             kind: "workspace-root",
-            root: absoluteFsPath("C:/workspace-root/plain-mutation"),
+            root: testAbsoluteFsPath("project-open-guard", "workspace-root", "plain-mutation"),
         };
         const {withProjectTargetMutation} = await import("nbook/server/workspace-files/project-open-guard");
         const handler = vi.fn(async () => "mutated");

--- a/server/workspace-files/project-session-hmr.test.ts
+++ b/server/workspace-files/project-session-hmr.test.ts
@@ -1,5 +1,6 @@
 import {afterEach, describe, expect, it, vi} from "vitest";
 import {absoluteFsPath, type AbsoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 import {
     createProjectWorkspaceKey,
     projectWorkspaceRef,
@@ -49,8 +50,8 @@ describe("project-session HMR boundaries", () => {
     });
 
     it("复用旧Service并由新mapper与guard识别旧typed errors，最终只关闭一次", async () => {
-        const workspaceRoot = absoluteFsPath("C:/workspace-root-hmr");
-        const otherRoot = absoluteFsPath("C:/workspace-root-other");
+        const workspaceRoot = testAbsoluteFsPath("project-session-hmr", "workspace-root");
+        const otherRoot = testAbsoluteFsPath("project-session-hmr", "other-root");
         const prepared = preparedProject(workspaceRoot, "alpha");
         const moduleClose = {
             database: vi.fn(async () => undefined),

--- a/server/workspace-files/project-session-runtime.test.ts
+++ b/server/workspace-files/project-session-runtime.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, describe, expect, it, vi} from "vitest";
-import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 import {
     createProjectWorkspaceKey,
     projectWorkspaceRef,
@@ -876,11 +876,11 @@ function occupancyHandleWithRelease(release: () => Promise<void>): ProjectOccupa
 
 /** 构造只包含Lifecycle公开字段的PreparedProjectOpen。 */
 function preparedProject(projectRootInput: string, occupancy: ProjectOccupancyHandle): PreparedProjectOpen {
-    const workspaceRoot = absoluteFsPath("C:/nbook-test/workspace");
+    const workspaceRoot = testAbsoluteFsPath("project-session-runtime", "workspace");
     const ref = projectWorkspaceRef(projectRootInput);
     const workspace = resolvedProjectWorkspace(
         ref,
-        absoluteFsPath(`C:/nbook-test/workspace/${projectRootInput}`),
+        testAbsoluteFsPath("project-session-runtime", "workspace", projectRootInput),
         createProjectWorkspaceKey(workspaceRoot, ref),
     );
     return Object.freeze({

--- a/server/workspace-files/project-session-service.test.ts
+++ b/server/workspace-files/project-session-service.test.ts
@@ -1,5 +1,6 @@
 import {afterEach, describe, expect, it, vi} from "vitest";
 import {absoluteFsPath} from "nbook/server/runtime/paths/file-path";
+import {testAbsoluteFsPath} from "nbook/server/runtime/paths/test-path";
 import {
     createProjectWorkspaceKey,
     projectWorkspaceRef,
@@ -43,7 +44,7 @@ describe("ProjectSessionService", () => {
             immediateModule("history"),
             immediateModule("file-index"),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "shared-open");
         const lifecycle = controlLifecycle(prepared);
         const runtime = new ProjectSessionRuntime();
@@ -73,7 +74,7 @@ describe("ProjectSessionService", () => {
             immediateModule("history"),
             immediateModule("file-index"),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = {...preparedProject(workspaceRoot, "control-open"), change: "created" as const};
         const lifecycle = controlLifecycle(prepared);
         const runtime = new ProjectSessionRuntime();
@@ -114,7 +115,7 @@ describe("ProjectSessionService", () => {
             immediateModule("history"),
             immediateModule("file-index"),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "control-intents");
         const lifecycle = controlLifecycle(prepared);
         const service = new ProjectSessionService(workspaceRoot, {
@@ -156,7 +157,7 @@ describe("ProjectSessionService", () => {
             immediateModule("history"),
             immediateModule("file-index", fileIndexMutations),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "metadata-running");
         const lifecycle = controlLifecycle(prepared);
         const service = new ProjectSessionService(workspaceRoot, {
@@ -189,7 +190,7 @@ describe("ProjectSessionService", () => {
             immediateModule("history"),
             immediateModule("file-index"),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "metadata-close-race");
         let notifyEntered: (() => void) | null = null;
         const entered = new Promise<void>((resolve) => {
@@ -246,7 +247,7 @@ describe("ProjectSessionService", () => {
             immediateModule("history"),
             immediateModule("file-index"),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "publication-order");
         const ref = prepared.workspace.ref;
         const listEntered = deferred<void>();
@@ -292,7 +293,7 @@ describe("ProjectSessionService", () => {
             immediateModule("history"),
             immediateModule("file-index"),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "shutdown-abort");
         const updateEntered = deferred<void>();
         const abortUpdate = deferred<void>();
@@ -345,7 +346,7 @@ describe("ProjectSessionService", () => {
             },
             immediateModule("file-index"),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "opening-abort");
         const lifecycle = controlLifecycle(prepared);
         const service = new ProjectSessionService(workspaceRoot, {
@@ -384,7 +385,7 @@ describe("ProjectSessionService", () => {
                 }),
             },
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const seed = preparedProject(workspaceRoot, "sweep-a");
         const lifecycle = controlLifecycle(seed, {
             prepareOpen: vi.fn(async (ref) => preparedProject(workspaceRoot, ref.projectRoot)),
@@ -417,7 +418,7 @@ describe("ProjectSessionService", () => {
             immediateModule("history"),
             immediateModule("file-index"),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "maintenance-data-plane");
         const runtime = new ProjectSessionRuntime();
         const updateEntered = deferred<void>();
@@ -490,7 +491,7 @@ describe("ProjectSessionService", () => {
                 }),
             },
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "sweep-close-race");
         const service = new ProjectSessionService(workspaceRoot, {
             lifecycle: controlLifecycle(prepared),
@@ -516,7 +517,7 @@ describe("ProjectSessionService", () => {
             immediateModule("history"),
             immediateModule("file-index"),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "close-entry");
         const lifecycle = controlLifecycle(prepared);
         const runtime = new ProjectSessionRuntime();
@@ -542,7 +543,7 @@ describe("ProjectSessionService", () => {
             recordingModule("history", closeOrder),
             recordingModule("file-index", closeOrder),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "externally-replaced");
         let notifyReplaced: (() => void) | null = null;
         const stopObservation = vi.fn();
@@ -603,7 +604,7 @@ describe("ProjectSessionService", () => {
                 start: () => ({ready: Promise.resolve(), close}),
             },
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "close-retry");
         const lifecycle = controlLifecycle(prepared);
         const service = new ProjectSessionService(workspaceRoot, {
@@ -629,7 +630,7 @@ describe("ProjectSessionService", () => {
             immediateModule("history"),
             immediateModule("file-index"),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "release-failed-delete");
         vi.mocked(prepared.occupancy.release).mockRejectedValueOnce(new Error("occupancy release failed"));
         const lifecycle = controlLifecycle(prepared);
@@ -655,7 +656,7 @@ describe("ProjectSessionService", () => {
             immediateModule("history"),
             immediateModule("file-index"),
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "shutdown-service");
         const lifecycle = controlLifecycle(prepared);
         const service = new ProjectSessionService(workspaceRoot, {
@@ -698,7 +699,7 @@ describe("ProjectSessionService", () => {
                 start: () => ({ready: Promise.resolve(), close: fileIndexClose}),
             },
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "shutdown-retry");
         const lifecycle = controlLifecycle(prepared);
         const service = new ProjectSessionService(workspaceRoot, {
@@ -743,7 +744,7 @@ describe("ProjectSessionService", () => {
             immediateModule("file-index"),
             {token: lazyToken, start: lazyStart},
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "module-data-plane");
         const service = new ProjectSessionService(workspaceRoot, {
             lifecycle: controlLifecycle(prepared),
@@ -786,7 +787,7 @@ describe("ProjectSessionService", () => {
                 start: () => ({ready: Promise.resolve(), close: fileIndexClose}),
             },
         ]));
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "opening-cleanup");
         const lifecycle = controlLifecycle(prepared);
         const service = new ProjectSessionService(workspaceRoot, {
@@ -814,7 +815,7 @@ describe("ProjectSessionService", () => {
         ]));
         let now = 3_000;
         let agentActive = true;
-        const workspaceRoot = absoluteFsPath("C:/workspace-root");
+        const workspaceRoot = testAbsoluteFsPath("project-session-service", "workspace-root");
         const prepared = preparedProject(workspaceRoot, "service-sweep");
         const runtime = new ProjectSessionRuntime({now: () => now, graceMs: 100});
         const service = new ProjectSessionService(workspaceRoot, {

--- a/server/workspace-files/workspace-files.ts
+++ b/server/workspace-files/workspace-files.ts
@@ -1037,6 +1037,9 @@ function isWorkspaceReferenceTarget(target: string): boolean {
     if (!normalizedTarget) {
         return false;
     }
+    if (path.isAbsolute(normalizedTarget) || path.win32.isAbsolute(normalizedTarget)) {
+        return true;
+    }
     if (normalizedTarget.startsWith("/")) {
         return false;
     }


### PR DESCRIPTION
## Summary`n- Generate Prisma clients and Nuxt types before Code Baseline typecheck/full tests.`n- Replace POSIX-hostile `C:/...` test fixtures with real host temp paths while preserving Windows-only string contracts.`n- Ensure the Linux runner has ripgrep for the real bash contract.`n- Keep the existing profile compile worker behavior valid in Source and Product contexts.`n`n## Verification`n- Branch contains the clean-runner baseline commits `d6bb3149` and `d260d152`.`n- Latest CI result is recorded separately; advisory full tests still need confirmation.