### PR TITLE
test(t142): allow cover route cold import budget

### DIFF
--- a/server/api/projects/cover.get.test.ts
+++ b/server/api/projects/cover.get.test.ts
@@ -74,7 +74,7 @@ describe("GET /api/projects/cover", () => {
             "content-length": 3,
             "content-disposition": "inline; filename*=UTF-8''cover.png",
         });
-    });
+    }, 30_000);
 
     it("ETag 命中时返回 304 且不重复发送图片 body", async () => {
         const handler = (await import("nbook/server/api/projects/cover.get")).default as (event: H3Event) => Promise<unknown>;


### PR DESCRIPTION
## Summary`n- Increase the first project-cover route test timeout from 5 seconds to 30 seconds.`n- The test dynamically imports the route and runs reliably on Windows; production code and response assertions are unchanged.`n`n## Verification`n- `bun run test -- server/api/projects/cover.get.test.ts --reporter=dot` (5 passed)`n- `bun run test -- server/agent/harness/neuro-agent-harness.black-box.test.ts -t "外部 signal 只取消 admission 接收的精确 invocation" --pool=forks --reporter=dot` (1 passed)`n- `git diff --check`