### PR TITLE
fix(test): keep Bun deploy test out of Node suite

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,7 +43,6 @@ export default defineConfig({
             "scripts/build/**/*.test.ts",
             "scripts/ci/**/*.test.ts",
             "scripts/db/**/*.test.ts",
-            "scripts/deploy/**/*.test.ts",
             "scripts/install/**/*.test.ts",
             "scripts/maintenance/**/*.test.ts",
             "scripts/release/**/*.test.ts",


### PR DESCRIPTION
## 变更

从根 Node Vitest 配置移除 scripts/deploy 测试目录。scripts/deploy/product-start.test.ts 使用 Bun.Glob，由 release-container.yml 的专用 bun test 门禁执行；放入 Node 根套件会在 Full tests 中报 ReferenceError: Bun is not defined。

## 验证

- bun test scripts/deploy/product-start.test.ts：Windows 平台按既有合同跳过，0 pass / 1 skipped
- node node_modules/vitest/vitest.mjs run --config vitest.config.ts scripts/maintenance/migrate-session-model-refs.test.ts --reporter=dot：1 file / 3 passed

Refs #87