### PR TITLE
fix(agent): synchronize abort tests with provider start

### DIFF
--- a/server/agent/harness/neuro-agent-harness.black-box.test.ts
+++ b/server/agent/harness/neuro-agent-harness.black-box.test.ts
@@ -195,6 +195,13 @@ async function waitUntil(predicate: () => boolean | Promise<boolean>, label: str
     throw new Error(`等待条件超时：${label}`);
 }
 
+/** 等待已返回 Provider 的 Promise continuation 排空，不绑定真实墙钟时长。 */
+async function nextEventLoopTurn(): Promise<void> {
+    const turn = Promise.withResolvers<void>();
+    setImmediate(turn.resolve);
+    await turn.promise;
+}
+
 describe("NeuroAgentHarness black-box contract", () => {
     let root: string;
     let faux: FauxModelsFixture;
@@ -1276,19 +1283,20 @@ describe("NeuroAgentHarness black-box contract", () => {
         }
     });
 
-    // 这两个用例的外层预算覆盖 full-suite 下的 Harness/Provider 初始化；
-    // 取消是否有界仍由用例内 300ms/1s race 精确约束。
+    // 取消前必须等到 Faux Provider 实际取走悬挂响应；activeInvocation=running 只表示 admission 完成。
+    // 300ms/1s race 是被测的公开取消上界，不用于等待测试状态推进。
     it("Running provider 忽略 AbortSignal 时 cancel 仍有界释放调用方，并隔离迟到结果", async () => {
         const profileKey = registerPlainProfile(harness, {
             key: "test.blackbox.forced-running-abort",
         });
-        let releaseProvider: (() => void) | undefined;
-        const providerGate = new Promise<void>((resolve) => {
-            releaseProvider = resolve;
-        });
+        const providerStarted = Promise.withResolvers<void>();
+        const providerGate = Promise.withResolvers<void>();
+        const providerReturned = Promise.withResolvers<void>();
         faux.setResponses([
             async () => {
-                await providerGate;
+                providerStarted.resolve();
+                await providerGate.promise;
+                providerReturned.resolve();
                 return fauxAssistantMessage("late provider result");
             },
             fauxAssistantMessage("fresh invocation result"),
@@ -1302,44 +1310,50 @@ describe("NeuroAgentHarness black-box contract", () => {
             mode: "prompt",
             message: {text: "start hanging provider"},
         });
-        await waitUntil(async () => (await harness.getSessionRecovery(created.sessionId)).activeInvocation?.status === "running", "hanging provider active");
+        await providerStarted.promise;
 
-        const aborted = await harness.abortInvocation(created.sessionId, {reason: "force stop"});
-        const result = await Promise.race([
-            running,
-            new Promise<never>((_, reject) => setTimeout(() => reject(new Error("running invocation did not settle after cancel")), 300)),
-        ]);
-        const recovery = await harness.getSessionRecovery(created.sessionId);
+        try {
+            const aborted = await harness.abortInvocation(created.sessionId, {reason: "force stop"});
+            const result = await Promise.race([
+                running,
+                new Promise<never>((_, reject) => setTimeout(() => reject(new Error("running invocation did not settle after cancel")), 300)),
+            ]);
+            const recovery = await harness.getSessionRecovery(created.sessionId);
 
-        expect(aborted).toEqual({status: "aborted", sessionId: created.sessionId});
-        expect(result).toMatchObject({status: "error", invocationId: expect.any(String)});
-        expect(recovery.activeInvocation).toBeNull();
+            expect(aborted).toEqual({status: "aborted", sessionId: created.sessionId});
+            expect(result).toMatchObject({status: "error", invocationId: expect.any(String)});
+            expect(recovery.activeInvocation).toBeNull();
 
-        const next = await harness.invokeAgent({
-            sessionId: created.sessionId,
-            mode: "prompt",
-            message: {text: "start fresh invocation"},
-        });
-        expect(next).toMatchObject({status: "completed", finalMessage: "fresh invocation result"});
+            const next = await harness.invokeAgent({
+                sessionId: created.sessionId,
+                mode: "prompt",
+                message: {text: "start fresh invocation"},
+            });
+            expect(next).toMatchObject({status: "completed", finalMessage: "fresh invocation result"});
 
-        releaseProvider!();
-        await new Promise((resolve) => setTimeout(resolve, 20));
-        const snapshot = await harness.repo.readSession(created.sessionId);
-        expect(visibleText(harness.repo.reduce(snapshot).messages)).not.toContain("late provider result");
-        expect(lifecycleStatuses(snapshot)).toEqual(["start", "aborted", "start", "end"]);
+            providerGate.resolve();
+            await providerReturned.promise;
+            await nextEventLoopTurn();
+            const snapshot = await harness.repo.readSession(created.sessionId);
+            expect(visibleText(harness.repo.reduce(snapshot).messages)).not.toContain("late provider result");
+            expect(lifecycleStatuses(snapshot)).toEqual(["start", "aborted", "start", "end"]);
+        } finally {
+            providerGate.resolve();
+        }
     }, 30_000);
 
     it("外部 signal 只取消 admission 接收的精确 invocation，不影响同 session 后续调用", async () => {
         const profileKey = registerPlainProfile(harness, {
             key: "test.blackbox.exact-signal-abort",
         });
-        let releaseProvider: (() => void) | undefined;
-        const providerGate = new Promise<void>((resolve) => {
-            releaseProvider = resolve;
-        });
+        const providerStarted = Promise.withResolvers<void>();
+        const providerGate = Promise.withResolvers<void>();
+        const providerReturned = Promise.withResolvers<void>();
         faux.setResponses([
             async () => {
-                await providerGate;
+                providerStarted.resolve();
+                await providerGate.promise;
+                providerReturned.resolve();
                 return fauxAssistantMessage("late exact-signal result");
             },
             fauxAssistantMessage("new invocation survived"),
@@ -1355,27 +1369,32 @@ describe("NeuroAgentHarness black-box contract", () => {
             message: {text: "start signal-owned invocation"},
             signal: controller.signal,
         });
-        await waitUntil(async () => (await harness.getSessionRecovery(created.sessionId)).activeInvocation?.status === "running", "signal-owned invocation active");
+        await providerStarted.promise;
 
-        controller.abort(new Error("parent invocation cancelled"));
-        const cancelled = await Promise.race([
-            running,
-            new Promise<never>((_, reject) => setTimeout(() => reject(new Error("signal-owned invocation did not settle")), 1_000)),
-        ]);
-        expect(cancelled).toMatchObject({status: "error", invocationId: expect.any(String)});
+        try {
+            controller.abort(new Error("parent invocation cancelled"));
+            const cancelled = await Promise.race([
+                running,
+                new Promise<never>((_, reject) => setTimeout(() => reject(new Error("signal-owned invocation did not settle")), 1_000)),
+            ]);
+            expect(cancelled).toMatchObject({status: "error", invocationId: expect.any(String)});
 
-        const next = await harness.invokeAgent({
-            sessionId: created.sessionId,
-            mode: "prompt",
-            message: {text: "start new invocation"},
-        });
-        expect(next).toMatchObject({status: "completed", finalMessage: "new invocation survived"});
+            const next = await harness.invokeAgent({
+                sessionId: created.sessionId,
+                mode: "prompt",
+                message: {text: "start new invocation"},
+            });
+            expect(next).toMatchObject({status: "completed", finalMessage: "new invocation survived"});
 
-        releaseProvider!();
-        await new Promise((resolve) => setTimeout(resolve, 20));
-        const snapshot = await harness.repo.readSession(created.sessionId);
-        expect(visibleText(harness.repo.reduce(snapshot).messages)).not.toContain("late exact-signal result");
-        expect(lifecycleStatuses(snapshot)).toEqual(["start", "aborted", "start", "end"]);
+            providerGate.resolve();
+            await providerReturned.promise;
+            await nextEventLoopTurn();
+            const snapshot = await harness.repo.readSession(created.sessionId);
+            expect(visibleText(harness.repo.reduce(snapshot).messages)).not.toContain("late exact-signal result");
+            expect(lifecycleStatuses(snapshot)).toEqual(["start", "aborted", "start", "end"]);
+        } finally {
+            providerGate.resolve();
+        }
     }, 30_000);
 
     it("Running tool 忽略 AbortSignal 时 cancel 仍有界释放调用方，并隔离迟到结果", async () => {


### PR DESCRIPTION
## 变更

修复两个 Harness provider cancel 黑盒测试的同步竞态。测试原先把 activeInvocation=running 当作 Provider 已经取走 response queue 首项；文件暖机后取消更快，第一条悬挂响应仍在队列里，后续 invocation 误取它并永久等待。

现在由 Faux Provider 回调显式发布 providerStarted，测试只在 Provider 真正进入悬挂响应后取消；finally 无条件释放 provider gate。不修改生产 Harness，不增加 30 秒预算。

Closes #90

## 验证

- 修复前完整 neuro-agent-harness.black-box.test.ts：23 passed / 2 failed，两个目标用例各 30 秒超时，71.56s
- 修复后完整文件连续 3 轮：每轮 25 passed，12.21-12.49s
- bun run typecheck：通过（生成 Prisma、安装 desktop/electron 依赖后）
- Windows 单 worker 根全量：Issue #90 的两个用例通过；最终 497 files passed / 1 skipped，另有 scripts/install/install.test.ts 两个既有本机 GB2312 输出解码断言失败，与本变更无关；该文件在 #88 Windows CI 已通过

## 边界

仅修改测试同步合同，没有业务代码、持久化合同或发行载荷变化。