### PR TITLE
fix(manager): follow GitHub Release asset redirects

### DIFF
--- a/packages/neuro-book-manager/src/desktop-installation.test.ts
+++ b/packages/neuro-book-manager/src/desktop-installation.test.ts
@@ -471,9 +471,15 @@ describe("Desktop installation lifecycle", () => {
         })).resolves.toMatchObject({installationRoot: installRoot});
 
         expect(await readFile(cachePath)).toEqual(archiveBytes);
-        expect(fetchMock).toHaveBeenCalledWith(
-            componentURL,
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            1,
+            new URL("https://downloads.example/desktop.distribution.json"),
             expect.objectContaining({redirect: "error"}),
+        );
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            2,
+            componentURL,
+            expect.objectContaining({redirect: "follow"}),
         );
     });
 

--- a/packages/neuro-book-manager/src/download.test.ts
+++ b/packages/neuro-book-manager/src/download.test.ts
@@ -1,11 +1,12 @@
+import {createHash} from "node:crypto";
 import {chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile} from "node:fs/promises";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 
 import {strToU8, zipSync} from "fflate";
-import {afterEach, describe, expect, it} from "vitest";
+import {afterEach, describe, expect, it, vi} from "vitest";
 
-import {extractTarGz, extractZip} from "#manager/download";
+import {downloadVerified, extractTarGz, extractZip} from "#manager/download";
 import {run} from "#manager/process";
 
 const roots: string[] = [];
@@ -67,6 +68,35 @@ describe("Archive Extraction Adapter", () => {
         expect((await stat(join(target, "runtime.mjs"))).mode & 0o777).toBe(0o764);
     });
 });
+
+describe("Verified Release download", () => {
+    it("跟随 GitHub Release 资产的临时重定向并校验最终内容", async () => {
+        const root = await fixtureRoot();
+        const target = join(root, "bun.zip");
+        const content = strToU8("verified-release-asset");
+        const digest = createHash("sha256").update(content).digest("hex");
+        const fetchMock = vi.fn((_input: string | URL | Request, init?: RequestInit) => init?.redirect === "follow"
+            ? Promise.resolve(new Response(content, {status: 200}))
+            : Promise.resolve(new Response(null, {
+                status: 302,
+                headers: {location: "https://objects.example/asset"},
+            })));
+        vi.stubGlobal("fetch", fetchMock);
+
+        try {
+            await downloadVerified("https://github.com/example/release/asset.zip", target, digest);
+            expect(await readFile(target, "utf8")).toBe("verified-release-asset");
+            expect(fetchMock).toHaveBeenNthCalledWith(
+                1,
+                "https://github.com/example/release/asset.zip",
+                expect.objectContaining({redirect: "follow"}),
+            );
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+});
+
 
 /** 创建每项测试独占的归档根。 */
 async function fixtureRoot(): Promise<string> {

--- a/packages/neuro-book-manager/src/download.ts
+++ b/packages/neuro-book-manager/src/download.ts
@@ -23,9 +23,9 @@ type GitHubReleaseResponse = {
     }>;
 };
 
-/** 下载文件并验证 SHA256。 */
+/** 下载文件并验证 SHA256；GitHub Release 资产可能先返回临时 302。 */
 export async function downloadVerified(url: string, target: string, sha256: string): Promise<void> {
-    const response = await fetch(url, {headers: {"User-Agent": "neuro-book-manager"}, redirect: "error"});
+    const response = await fetch(url, {headers: {"User-Agent": "neuro-book-manager"}, redirect: "follow"});
     if (!response.ok) {
         throw new Error(`下载失败 ${response.status}：${url}`);
     }


### PR DESCRIPTION
## 变更\n- GitHub Release 资产下载跟随官方临时 302/重定向。\n- 保留下载后 SHA-256 校验；桌面远端 API 的 fail-closed 重定向策略不变。\n- 新增 302→最终响应回归测试。\n\n## 证据\n- Manager 下载聚焦：4 passed / 1 skipped\n- Manager typecheck：通过\n- ：通过\n\n## 触发背景\n应用 Canary workflow  的唯一失败为 Windows Portable 组包下载  时 。\n\nRefs #87