### PR TITLE
feat: 左侧栏图标按钮接入 Tooltip 提示系统

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ GitHub Issue 承载需求与 TODO，task walkthrough 记录重大任务，独立
 
 ## HTML/Vue
 
-- 通用组件优先复用 `app/components/common`：`NotificationViewport`、`Dialog`、`DialogWindow` 和 `form/FormColorField`。
+- 通用组件优先复用 `app/components/common`：`NotificationViewport`、`Dialog`、`DialogWindow`、`Tooltip` 和 `form/FormColorField`。
 - Novel IDE 普通界面颜色只消费 `app/utils/theme/README.md` 登记的主题变量，不新增 Tailwind 调色板或 `dark:` 变体；新增组件变量前确认现有变量无法表达，并同步登记到主题文档和 8 套内置主题。
 - 状态色使用 `warning`（草稿/待审/未保存）、`success`（完成/已同步）、`danger`（错误/删除/冲突）、`info`（运行中/引用/说明）和 `accent`（选中/当前/主操作）。内容、编辑器和 chip 分类色是例外，不按状态色重写。
 - World Engine 的 `--we-*` 只在 `app/styles/theme-vars.css` 的 `.world-engine-workbench-theme` 中映射；真实 Dialog 和 preview 使用该 class，不在局部样式反向覆盖全局变量。

--- a/app/components/common/Tooltip.vue
+++ b/app/components/common/Tooltip.vue
@@ -1,0 +1,260 @@
+<script setup lang="ts">
+import {useEventListener} from "@vueuse/core";
+import {cloneVNode, computed, isVNode, nextTick, onBeforeUnmount, onMounted, ref, useId, useSlots, type VNode} from "vue";
+import {IDE_THEME_HOST_CLASS} from "nbook/app/utils/theme/theme-tokens";
+import {
+    computeTooltipPosition,
+    type TooltipEffectivePlacement,
+    type TooltipPlacement,
+} from "nbook/app/utils/tooltip-position";
+
+const props = withDefaults(defineProps<{
+    text: string;
+    placement?: TooltipPlacement;
+    showDelay?: number;
+    hideDelay?: number;
+}>(), {
+    placement: "right",
+    showDelay: 300,
+    hideDelay: 100,
+});
+
+const slots = useSlots();
+const rootRef = ref<HTMLElement | null>(null);
+const triggerRef = ref<HTMLElement | null>(null);
+const tooltipRef = ref<HTMLElement | null>(null);
+const isMounted = ref(false);
+const visible = ref(false);
+const position = ref<TooltipPosition>({x: 0, y: 0, placement: "right"});
+const tooltipId = `nbook-tooltip-${useId().replace(/:/g, "")}`;
+
+let showTimer: ReturnType<typeof setTimeout> | null = null;
+let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** 跟随现有浮层范式：Teleport 到主题宿主内，保证主题变量可解析。 */
+const teleportTarget = computed<HTMLElement | string>(() => {
+    return rootRef.value?.closest(`.${IDE_THEME_HOST_CLASS}`) as HTMLElement | null ?? "body";
+});
+
+const hasContent = computed(() => props.text.trim().length > 0);
+
+/**
+ * 基于当前插槽内容克隆根节点，把 aria-describedby 与测量 ref 挂到真实触发元素上。
+ * 必须用普通函数而非 computed：computed 不会因父组件重渲染产生的「同引用新插槽内容」而失效，
+ * 会导致按钮的 disabled/class 等属性停留在旧状态（已实测复现）。
+ */
+function renderTrigger(): VNode[] {
+    const nodes = slots.default?.() ?? [];
+    if (nodes.length === 0 || !isVNode(nodes[0])) {
+        return nodes;
+    }
+    const [first, ...rest] = nodes;
+    const cloned = cloneVNode(first, {
+        ref: (element: unknown) => {
+            triggerRef.value = element as HTMLElement | null;
+        },
+        "aria-describedby": visible.value ? tooltipId : undefined,
+    }, true);
+    return [cloned, ...rest];
+}
+
+/** 箭头所在边：与「实际出现在哪一侧」相反（tooltip 在右侧 → 箭头贴左边缘）。 */
+const ARROW_EDGE_BY_PLACEMENT: Record<TooltipEffectivePlacement, TooltipEffectivePlacement> = {
+    left: "right",
+    right: "left",
+    top: "bottom",
+    bottom: "top",
+};
+const arrowEdge = computed(() => ARROW_EDGE_BY_PLACEMENT[position.value.placement]);
+
+function clearTimers(): void {
+    if (showTimer !== null) {
+        clearTimeout(showTimer);
+        showTimer = null;
+    }
+    if (hideTimer !== null) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+    }
+}
+
+function updatePosition(): void {
+    const trigger = triggerRef.value ?? (rootRef.value?.firstElementChild as HTMLElement | null);
+    const tooltip = tooltipRef.value;
+    if (!trigger || !tooltip) {
+        return;
+    }
+    position.value = computeTooltipPosition(
+        trigger.getBoundingClientRect(),
+        tooltip.getBoundingClientRect(),
+        props.placement,
+        {left: 0, top: 0, width: window.innerWidth, height: window.innerHeight},
+    );
+}
+
+function open(): void {
+    if (!hasContent.value) {
+        return;
+    }
+    visible.value = true;
+    void nextTick(() => {
+        updatePosition();
+    });
+}
+
+function show(immediate = false): void {
+    if (!hasContent.value) {
+        return;
+    }
+    clearTimers();
+    if (immediate) {
+        open();
+        return;
+    }
+    showTimer = setTimeout(() => {
+        showTimer = null;
+        open();
+    }, props.showDelay);
+}
+
+function hide(immediate = false): void {
+    clearTimers();
+    if (!visible.value) {
+        return;
+    }
+    if (immediate) {
+        visible.value = false;
+        return;
+    }
+    hideTimer = setTimeout(() => {
+        hideTimer = null;
+        visible.value = false;
+    }, props.hideDelay);
+}
+
+function handleMouseEnter(): void {
+    show(false);
+}
+
+function handleMouseLeave(): void {
+    hide(false);
+}
+
+function handleFocusIn(): void {
+    show(true);
+}
+
+function handleFocusOut(): void {
+    hide(true);
+}
+
+function handleClick(): void {
+    hide(true);
+}
+
+onMounted(() => {
+    isMounted.value = true;
+    useEventListener(window, "scroll", () => hide(true), {capture: true});
+    useEventListener(window, "pointerdown", () => hide(true));
+    useEventListener(window, "resize", () => hide(true));
+});
+
+onBeforeUnmount(() => {
+    clearTimers();
+});
+</script>
+
+<template>
+    <span
+        ref="rootRef"
+        class="contents"
+        @mouseenter="handleMouseEnter"
+        @mouseleave="handleMouseLeave"
+        @focusin="handleFocusIn"
+        @focusout="handleFocusOut"
+        @click="handleClick"
+    >
+        <template v-for="(node, index) in renderTrigger()" :key="node.key ?? `tooltip-slot-${index}`">
+            <component :is="node" />
+        </template>
+
+        <Teleport v-if="isMounted" :to="teleportTarget">
+            <Transition name="tooltip-fade">
+                <div
+                    v-if="visible"
+                    ref="tooltipRef"
+                    :id="tooltipId"
+                    role="tooltip"
+                    class="tooltip-popover fixed z-[9050] rounded-md border border-[var(--border-color)] bg-[var(--bg-panel)] px-2 py-1 text-xs text-[var(--text-main)] shadow-xl"
+                    :style="{left: `${position.x}px`, top: `${position.y}px`}"
+                >
+                    <span class="tooltip-arrow" :class="`tooltip-arrow--${arrowEdge}`"></span>
+                    <span class="block max-w-[220px] truncate">{{ text }}</span>
+                </div>
+            </Transition>
+        </Teleport>
+    </span>
+</template>
+
+<style scoped>
+.tooltip-popover {
+    pointer-events: none;
+}
+
+.tooltip-arrow {
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    background: var(--bg-panel);
+    transform: rotate(45deg);
+}
+
+.tooltip-arrow--left {
+    left: -4px;
+    top: 50%;
+    margin-top: -4px;
+    border-left: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.tooltip-arrow--right {
+    right: -4px;
+    top: 50%;
+    margin-top: -4px;
+    border-right: 1px solid var(--border-color);
+    border-top: 1px solid var(--border-color);
+}
+
+.tooltip-arrow--top {
+    top: -4px;
+    left: 50%;
+    margin-left: -4px;
+    border-left: 1px solid var(--border-color);
+    border-top: 1px solid var(--border-color);
+}
+
+.tooltip-arrow--bottom {
+    bottom: -4px;
+    left: 50%;
+    margin-left: -4px;
+    border-right: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.tooltip-fade-enter-active,
+.tooltip-fade-leave-active {
+    transition: opacity 120ms ease;
+}
+
+.tooltip-fade-enter-from,
+.tooltip-fade-leave-to {
+    opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .tooltip-fade-enter-active,
+    .tooltip-fade-leave-active {
+        transition: none;
+    }
+}
+</style>

--- a/app/components/novel-ide/NovelIdeActivityBar.vue
+++ b/app/components/novel-ide/NovelIdeActivityBar.vue
@@ -3,6 +3,7 @@ import {onClickOutside} from "@vueuse/core";
 import type {AuthUserDto} from "nbook/shared/dto/auth.dto";
 import type {NovelIdeTab} from "nbook/app/components/novel-ide/mock-data";
 import NovelIdeAccountMenu from "nbook/app/components/novel-ide/NovelIdeAccountMenu.vue";
+import Tooltip from "nbook/app/components/common/Tooltip.vue";
 import {
     createWorkbenchActivityItems,
     resolveActivityBarSecondaryItems,
@@ -250,54 +251,63 @@ onBeforeUnmount(() => {
     <aside ref="activityBarRef" class="workbench-activity-bar flex w-12 shrink-0 flex-col items-center border-r border-[var(--border-color)] bg-[var(--bg-sidebar)] py-2" aria-label="Workbench navigation">
         <div class="flex min-h-0 w-full flex-1 flex-col items-center">
             <div ref="primaryGroupRef" class="flex w-full shrink-0 flex-col items-center">
-                <button
+                <Tooltip
                     v-for="item in activityItems.primary"
                     :key="item.id"
-                    type="button"
-                    class="workbench-activity-bar__item relative mb-1 flex h-10 w-10 items-center justify-center rounded-md border border-transparent transition-colors"
-                    :class="active(item) ? 'bg-[var(--bg-hover)] text-[var(--accent-text)]' : 'text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]'"
-                    :disabled="item.disabled"
-                    :aria-pressed="active(item)"
-                    :title="actionTitle(item)"
-                    :data-activity-id="item.id"
-                    @click="invoke(item)"
+                    :text="actionTitle(item)"
+                    placement="right"
                 >
-                    <span v-if="active(item)" class="absolute inset-y-1 left-0 w-0.5 rounded-r bg-[var(--accent-main)]"></span>
-                    <span :class="iconClasses[item.id]" class="h-[18px] w-[18px]"></span>
-                </button>
+                    <button
+                        type="button"
+                        class="workbench-activity-bar__item relative mb-1 flex h-10 w-10 items-center justify-center rounded-md border border-transparent transition-colors"
+                        :class="active(item) ? 'bg-[var(--bg-hover)] text-[var(--accent-text)]' : 'text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]'"
+                        :disabled="item.disabled"
+                        :aria-pressed="active(item)"
+                        :data-activity-id="item.id"
+                        @click="invoke(item)"
+                    >
+                        <span v-if="active(item)" class="absolute inset-y-1 left-0 w-0.5 rounded-r bg-[var(--accent-main)]"></span>
+                        <span :class="iconClasses[item.id]" class="h-[18px] w-[18px]"></span>
+                    </button>
+                </Tooltip>
 
                 <div class="my-1 h-px w-7 bg-[var(--border-color)]"></div>
             </div>
 
-            <button
+            <Tooltip
                 v-for="item in secondaryItems.visible"
                 :key="item.id"
-                type="button"
-                class="workbench-activity-bar__item relative mb-1 flex h-10 w-10 items-center justify-center rounded-md border border-transparent text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]"
-                :class="active(item) ? 'bg-[var(--bg-hover)] text-[var(--accent-text)]' : ''"
-                :disabled="item.disabled"
-                :aria-pressed="active(item)"
-                :title="actionTitle(item)"
-                :data-activity-id="item.id"
-                @click="invoke(item)"
+                :text="actionTitle(item)"
+                placement="right"
             >
-                <span :class="iconClasses[item.id]" class="h-[18px] w-[18px]"></span>
-            </button>
+                <button
+                    type="button"
+                    class="workbench-activity-bar__item relative mb-1 flex h-10 w-10 items-center justify-center rounded-md border border-transparent text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]"
+                    :class="active(item) ? 'bg-[var(--bg-hover)] text-[var(--accent-text)]' : ''"
+                    :disabled="item.disabled"
+                    :aria-pressed="active(item)"
+                    :data-activity-id="item.id"
+                    @click="invoke(item)"
+                >
+                    <span :class="iconClasses[item.id]" class="h-[18px] w-[18px]"></span>
+                </button>
+            </Tooltip>
 
             <div v-if="secondaryItems.overflow.length > 0" ref="moreRootRef" class="relative mb-1 h-10 w-10 shrink-0">
-                <button
-                    ref="moreButtonRef"
-                    type="button"
-                    class="workbench-activity-bar__item flex h-10 w-10 items-center justify-center rounded-md border border-transparent text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]"
-                    :title="t('ide.activityBar.more')"
-                    aria-haspopup="menu"
-                    :aria-expanded="moreOpen"
-                    aria-controls="workbench-activity-more-menu"
-                    @click="toggleMore"
-                    @keydown="handleMoreButtonKeydown"
-                >
-                    <span class="i-lucide-ellipsis h-[18px] w-[18px]"></span>
-                </button>
+                <Tooltip :text="moreOpen ? '' : t('ide.activityBar.more')" placement="right">
+                    <button
+                        ref="moreButtonRef"
+                        type="button"
+                        class="workbench-activity-bar__item flex h-10 w-10 items-center justify-center rounded-md border border-transparent text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]"
+                        aria-haspopup="menu"
+                        :aria-expanded="moreOpen"
+                        aria-controls="workbench-activity-more-menu"
+                        @click="toggleMore"
+                        @keydown="handleMoreButtonKeydown"
+                    >
+                        <span class="i-lucide-ellipsis h-[18px] w-[18px]"></span>
+                    </button>
+                </Tooltip>
                 <div
                     v-if="moreOpen"
                     id="workbench-activity-more-menu"
@@ -324,20 +334,24 @@ onBeforeUnmount(() => {
                 </div>
             </div>
 
-            <button
+            <Tooltip
                 v-if="activityItems.agentPanel"
-                ref="agentPanelRef"
-                type="button"
-                class="workbench-activity-bar__item relative mb-1 flex h-10 w-10 items-center justify-center rounded-md border border-transparent transition-colors"
-                :class="props.agentPanelOpen ? 'bg-[var(--bg-hover)] text-[var(--accent-text)]' : 'text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]'"
-                :disabled="activityItems.agentPanel.disabled"
-                :aria-pressed="props.agentPanelOpen"
-                :title="actionTitle(activityItems.agentPanel)"
-                data-activity-id="agent-panel"
-                @click="invoke(activityItems.agentPanel)"
+                :text="actionTitle(activityItems.agentPanel)"
+                placement="right"
             >
-                <span :class="iconClasses['agent-panel']" class="h-[18px] w-[18px]"></span>
-            </button>
+                <button
+                    ref="agentPanelRef"
+                    type="button"
+                    class="workbench-activity-bar__item relative mb-1 flex h-10 w-10 items-center justify-center rounded-md border border-transparent transition-colors"
+                    :class="props.agentPanelOpen ? 'bg-[var(--bg-hover)] text-[var(--accent-text)]' : 'text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]'"
+                    :disabled="activityItems.agentPanel.disabled"
+                    :aria-pressed="props.agentPanelOpen"
+                    data-activity-id="agent-panel"
+                    @click="invoke(activityItems.agentPanel)"
+                >
+                    <span :class="iconClasses['agent-panel']" class="h-[18px] w-[18px]"></span>
+                </button>
+            </Tooltip>
         </div>
 
         <div ref="footerRef" class="mt-auto flex w-full shrink-0 flex-col items-center gap-1">
@@ -351,15 +365,16 @@ onBeforeUnmount(() => {
                     @logout="emit('logout')"
                 />
             </div>
-            <button
-                type="button"
-                class="workbench-activity-bar__item flex h-10 w-10 items-center justify-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]"
-                :title="labels.settings"
-                data-activity-id="settings"
-                @click="emit('open-settings')"
-            >
-                <span :class="iconClasses.settings" class="h-[18px] w-[18px]"></span>
-            </button>
+            <Tooltip :text="labels.settings" placement="right">
+                <button
+                    type="button"
+                    class="workbench-activity-bar__item flex h-10 w-10 items-center justify-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]"
+                    data-activity-id="settings"
+                    @click="emit('open-settings')"
+                >
+                    <span :class="iconClasses.settings" class="h-[18px] w-[18px]"></span>
+                </button>
+            </Tooltip>
         </div>
     </aside>
 </template>

--- a/app/components/novel-ide/NovelIdeActivityBar.vue
+++ b/app/components/novel-ide/NovelIdeActivityBar.vue
@@ -102,7 +102,7 @@ function active(item: WorkbenchActivityItem): boolean {
 }
 
 function actionTitle(item: WorkbenchActivityItem): string {
-    return item.disabled ? `${labels.value[item.id]} · 请先打开一个 Project` : labels.value[item.id];
+    return item.disabled ? `${labels.value[item.id]} · ${t("ide.activityBar.needOpenProject")}` : labels.value[item.id];
 }
 
 function invoke(item: WorkbenchActivityItem): void {

--- a/app/components/novel-ide/NovelIdeToolPanel.vue
+++ b/app/components/novel-ide/NovelIdeToolPanel.vue
@@ -2,6 +2,7 @@
 import {ref, useAttrs} from "vue";
 import Dialog from "nbook/app/components/common/Dialog.vue";
 import Dropdown from "nbook/app/components/common/Dropdown.vue";
+import Tooltip from "nbook/app/components/common/Tooltip.vue";
 import DiffWorkbenchDialog from "nbook/app/components/common/diff/DiffWorkbenchDialog.vue";
 import type {DiffWorkbenchActionPayload, DiffWorkbenchDocument} from "nbook/app/components/common/diff/diff-workbench.types";
 import type {DropdownItem} from "nbook/app/components/common/dropdown.types";
@@ -361,9 +362,11 @@ function handleSyncDiffAction(payload: DiffWorkbenchActionPayload): void {
 
             <div class="shrink-0 border-b border-[var(--border-color)]">
                 <div class="flex h-9 items-center gap-1 border-b border-[var(--border-color)] px-2">
-                    <button type="button" class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" :title="t('ide.header.bookshelfTitle')" @click="emit('openHome')">
-                        <span class="i-lucide-library h-4 w-4"></span>
-                    </button>
+                    <Tooltip :text="t('ide.header.bookshelfTitle')" placement="bottom">
+                        <button type="button" class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" @click="emit('openHome')">
+                            <span class="i-lucide-library h-4 w-4"></span>
+                        </button>
+                    </Tooltip>
                     <Dropdown
                         v-if="!props.userAssetsMode"
                         class="min-w-0 flex-1"
@@ -392,26 +395,38 @@ function handleSyncDiffAction(payload: DiffWorkbenchActionPayload): void {
                         <input ref="projectDirectoryInputRef" class="hidden" type="file" multiple webkitdirectory @change="(event) => void handleProjectDirectorySelected(event)">
                         <input ref="projectZipInputRef" class="hidden" type="file" accept=".zip,application/zip" @change="(event) => void handleProjectZipSelected(event)">
 
-                        <button class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-50" :title="t('ide.toolPanel.uploadSingleTitle')" :disabled="uploadingSingleFile" @click="openSingleFileUpload">
-                            <span :class="uploadingSingleFile ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-file-up'" class="h-4 w-4"></span>
-                        </button>
-                        <Dropdown class="!w-auto" :items="projectUploadItems" menu-class="right-0 top-full mt-1 w-36" @select="selectProjectUploadMode">
-                            <button class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-50" :title="t('ide.toolPanel.uploadProjectTitle')" :disabled="uploadingProject">
-                                <span :class="uploadingProject ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-folder-up'" class="h-4 w-4"></span>
+                        <Tooltip :text="t('ide.toolPanel.uploadSingleTitle')" placement="bottom">
+                            <button class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-50" :disabled="uploadingSingleFile" @click="openSingleFileUpload">
+                                <span :class="uploadingSingleFile ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-file-up'" class="h-4 w-4"></span>
                             </button>
+                        </Tooltip>
+                        <Dropdown class="!w-auto" :items="projectUploadItems" menu-class="right-0 top-full mt-1 w-36" @select="selectProjectUploadMode">
+                            <Tooltip :text="t('ide.toolPanel.uploadProjectTitle')" placement="bottom">
+                                <button class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-50" :disabled="uploadingProject">
+                                    <span :class="uploadingProject ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-folder-up'" class="h-4 w-4"></span>
+                                </button>
+                            </Tooltip>
                         </Dropdown>
-                        <button class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-50" :title="downloadButtonTitle" :disabled="downloadingWorkspace" @click="openDownloadConfirm">
-                            <span :class="downloadingWorkspace ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-download'" class="h-4 w-4"></span>
-                        </button>
-                        <button v-if="props.userAssetsMode" class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-50" :title="t('ide.toolPanel.syncAssetsTitle')" :disabled="syncingAssets" @click="void syncSystemAssets()">
-                            <span :class="syncingAssets ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-folder-sync'" class="h-4 w-4"></span>
-                        </button>
-                        <button v-if="props.userAssetsMode && lastSyncWarnings.length" class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" :title="t('ide.toolPanel.viewSyncConflicts')" @click="syncWarningsOpen = true">
-                            <span class="i-lucide-triangle-alert h-4 w-4"></span>
-                        </button>
-                        <button class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" @click="emit('close')">
-                            <span class="i-lucide-minus h-4 w-4"></span>
-                        </button>
+                        <Tooltip :text="downloadButtonTitle" placement="bottom">
+                            <button class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-50" :disabled="downloadingWorkspace" @click="openDownloadConfirm">
+                                <span :class="downloadingWorkspace ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-download'" class="h-4 w-4"></span>
+                            </button>
+                        </Tooltip>
+                        <Tooltip v-if="props.userAssetsMode" :text="t('ide.toolPanel.syncAssetsTitle')" placement="bottom">
+                            <button class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-50" :disabled="syncingAssets" @click="void syncSystemAssets()">
+                                <span :class="syncingAssets ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-folder-sync'" class="h-4 w-4"></span>
+                            </button>
+                        </Tooltip>
+                        <Tooltip v-if="props.userAssetsMode && lastSyncWarnings.length" :text="t('ide.toolPanel.viewSyncConflicts')" placement="bottom">
+                            <button class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" @click="syncWarningsOpen = true">
+                                <span class="i-lucide-triangle-alert h-4 w-4"></span>
+                            </button>
+                        </Tooltip>
+                        <Tooltip :text="t('ide.toolPanel.collapsePanel')" placement="bottom">
+                            <button class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" @click="emit('close')">
+                                <span class="i-lucide-minus h-4 w-4"></span>
+                            </button>
+                        </Tooltip>
                     </div>
                 </div>
             </div>

--- a/app/i18n/locales/en-US.ts
+++ b/app/i18n/locales/en-US.ts
@@ -1587,6 +1587,7 @@ const enUS = {
             syncDetailsTitle: "User Assets Sync Details",
             syncDetailsDescription: "The following user overrides were kept, and system versions were not applied automatically. Open a diff to inspect changes.",
             userOverrideDiff: "User Override Diff",
+            collapsePanel: "Collapse panel",
             close: "Close",
         },
         bookshelf: {

--- a/app/i18n/locales/en-US.ts
+++ b/app/i18n/locales/en-US.ts
@@ -907,6 +907,7 @@ const enUS = {
         activityBar: {
             more: "More",
             moreActions: "More workbench actions",
+            needOpenProject: "Please open a Project first",
         },
         header: {
             openAdmin: "Admin Console",

--- a/app/i18n/locales/zh-CN.ts
+++ b/app/i18n/locales/zh-CN.ts
@@ -905,6 +905,7 @@ const zhCN = {
         activityBar: {
             more: "更多",
             moreActions: "更多工作台入口",
+            needOpenProject: "请先打开一个 Project",
         },
         header: {
             openAdmin: "进入后台",

--- a/app/i18n/locales/zh-CN.ts
+++ b/app/i18n/locales/zh-CN.ts
@@ -1585,6 +1585,7 @@ const zhCN = {
             syncDetailsTitle: "用户资产同步详情",
             syncDetailsDescription: "以下用户覆盖已保留，系统版本没有自动覆盖。可以打开 diff 查看差异。",
             userOverrideDiff: "用户覆盖 Diff",
+            collapsePanel: "收起面板",
             close: "关闭",
         },
         bookshelf: {

--- a/app/utils/tooltip-position.test.ts
+++ b/app/utils/tooltip-position.test.ts
@@ -1,0 +1,66 @@
+import {describe, expect, it} from "vitest";
+import {computeTooltipPosition, TOOLTIP_GAP, TOOLTIP_VIEWPORT_PADDING} from "nbook/app/utils/tooltip-position";
+
+const VIEWPORT = {left: 0, top: 0, width: 1280, height: 800};
+
+describe("computeTooltipPosition", () => {
+    it("places a right tooltip to the right of the trigger, vertically centered", () => {
+        const trigger = {left: 40, top: 200, width: 40, height: 40};
+        const tooltip = {left: 0, top: 0, width: 120, height: 28};
+
+        expect(computeTooltipPosition(trigger, tooltip, "right", VIEWPORT)).toEqual({
+            x: trigger.left + trigger.width + TOOLTIP_GAP,
+            y: 200 + (40 - 28) / 2,
+            placement: "right",
+        });
+    });
+
+    it("flips a right tooltip to the left when it would overflow the right edge", () => {
+        const trigger = {left: 1200, top: 200, width: 40, height: 40};
+        const tooltip = {left: 0, top: 0, width: 120, height: 28};
+
+        const result = computeTooltipPosition(trigger, tooltip, "right", VIEWPORT);
+        expect(result.placement).toBe("left");
+        expect(result.x).toBe(trigger.left - TOOLTIP_GAP - tooltip.width);
+    });
+
+    it("clamps a right tooltip vertically into the viewport", () => {
+        const tooltip = {left: 0, top: 0, width: 120, height: 28};
+
+        const nearTop = computeTooltipPosition({left: 40, top: 0, width: 40, height: 40}, tooltip, "right", VIEWPORT);
+        expect(nearTop.y).toBe(TOOLTIP_VIEWPORT_PADDING);
+
+        const nearBottom = computeTooltipPosition({left: 40, top: 780, width: 40, height: 40}, tooltip, "right", VIEWPORT);
+        expect(nearBottom.y).toBe(VIEWPORT.height - TOOLTIP_VIEWPORT_PADDING - tooltip.height);
+    });
+
+    it("places a bottom tooltip below the trigger, horizontally centered", () => {
+        const trigger = {left: 200, top: 100, width: 40, height: 40};
+        const tooltip = {left: 0, top: 0, width: 120, height: 28};
+
+        expect(computeTooltipPosition(trigger, tooltip, "bottom", VIEWPORT)).toEqual({
+            x: 200 + (40 - 120) / 2,
+            y: trigger.top + trigger.height + TOOLTIP_GAP,
+            placement: "bottom",
+        });
+    });
+
+    it("flips a bottom tooltip above when it would overflow the bottom edge", () => {
+        const trigger = {left: 200, top: 760, width: 40, height: 40};
+        const tooltip = {left: 0, top: 0, width: 120, height: 28};
+
+        const result = computeTooltipPosition(trigger, tooltip, "bottom", VIEWPORT);
+        expect(result.placement).toBe("top");
+        expect(result.y).toBe(trigger.top - TOOLTIP_GAP - tooltip.height);
+    });
+
+    it("clamps a bottom tooltip horizontally into the viewport", () => {
+        const tooltip = {left: 0, top: 0, width: 120, height: 28};
+
+        const nearLeft = computeTooltipPosition({left: 0, top: 100, width: 40, height: 40}, tooltip, "bottom", VIEWPORT);
+        expect(nearLeft.x).toBe(TOOLTIP_VIEWPORT_PADDING);
+
+        const nearRight = computeTooltipPosition({left: 1240, top: 100, width: 40, height: 40}, tooltip, "bottom", VIEWPORT);
+        expect(nearRight.x).toBe(VIEWPORT.width - TOOLTIP_VIEWPORT_PADDING - tooltip.width);
+    });
+});

--- a/app/utils/tooltip-position.test.ts
+++ b/app/utils/tooltip-position.test.ts
@@ -63,4 +63,22 @@ describe("computeTooltipPosition", () => {
         const nearRight = computeTooltipPosition({left: 1240, top: 100, width: 40, height: 40}, tooltip, "bottom", VIEWPORT);
         expect(nearRight.x).toBe(VIEWPORT.width - TOOLTIP_VIEWPORT_PADDING - tooltip.width);
     });
+
+    it("clamps a flipped-left tooltip to the edge when the flipped side still cannot fit", () => {
+        // tooltip 比视口可用宽度还宽：右侧放不下翻到左侧，左侧也放不下，最终钳到左边缘。
+        const tooltip = {left: 0, top: 0, width: 1300, height: 28};
+
+        const result = computeTooltipPosition({left: 500, top: 200, width: 40, height: 40}, tooltip, "right", VIEWPORT);
+        expect(result.placement).toBe("left");
+        expect(result.x).toBe(TOOLTIP_VIEWPORT_PADDING);
+    });
+
+    it("keeps the tooltip inside the viewport when the viewport is smaller than the tooltip", () => {
+        const tinyViewport = {left: 0, top: 0, width: 100, height: 60};
+        const tooltip = {left: 0, top: 0, width: 300, height: 120};
+
+        const result = computeTooltipPosition({left: 0, top: 0, width: 40, height: 40}, tooltip, "right", tinyViewport);
+        expect(result.x).toBe(TOOLTIP_VIEWPORT_PADDING);
+        expect(result.y).toBe(TOOLTIP_VIEWPORT_PADDING);
+    });
 });

--- a/app/utils/tooltip-position.ts
+++ b/app/utils/tooltip-position.ts
@@ -1,0 +1,79 @@
+export type TooltipPlacement = "right" | "bottom";
+
+export type TooltipEffectivePlacement = "right" | "left" | "bottom" | "top";
+
+export type TooltipRect = Readonly<{
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+}>;
+
+export type TooltipPosition = Readonly<{
+    x: number;
+    y: number;
+    placement: TooltipEffectivePlacement;
+}>;
+
+/** 触发元素与 Tooltip 之间的间距（px）。 */
+export const TOOLTIP_GAP = 8;
+
+/** Tooltip 与视口边缘保持的最小间距（px）。 */
+export const TOOLTIP_VIEWPORT_PADDING = 8;
+
+/**
+ * 计算 fixed 定位的 Tooltip 在视口内的坐标。
+ *
+ * - "right"：默认出现在触发元素右侧并垂直居中；放不下时翻转到左侧。
+ * - "bottom"：默认出现在触发元素下方并水平居中；放不下时翻转到上方。
+ * - 两种 placement 都会把最终坐标钳制在视口内（保留 padding）。
+ * - 返回值里的 placement 是翻转后的实际朝向，供箭头定位使用。
+ */
+export function computeTooltipPosition(
+    trigger: TooltipRect,
+    tooltip: TooltipRect,
+    placement: TooltipPlacement,
+    viewport: TooltipRect,
+): TooltipPosition {
+    const viewportRight = viewport.left + viewport.width;
+    const viewportBottom = viewport.top + viewport.height;
+
+    if (placement === "right") {
+        const preferredX = trigger.left + trigger.width + TOOLTIP_GAP;
+        const fitsRight = preferredX + tooltip.width <= viewportRight - TOOLTIP_VIEWPORT_PADDING;
+        const x = clamp(
+            fitsRight ? preferredX : trigger.left - TOOLTIP_GAP - tooltip.width,
+            TOOLTIP_VIEWPORT_PADDING,
+            viewportRight - TOOLTIP_VIEWPORT_PADDING - tooltip.width,
+        );
+        const preferredY = trigger.top + (trigger.height - tooltip.height) / 2;
+        const y = clamp(
+            preferredY,
+            TOOLTIP_VIEWPORT_PADDING,
+            viewportBottom - TOOLTIP_VIEWPORT_PADDING - tooltip.height,
+        );
+        return {x, y, placement: fitsRight ? "right" : "left"};
+    }
+
+    const preferredX = trigger.left + (trigger.width - tooltip.width) / 2;
+    const x = clamp(
+        preferredX,
+        TOOLTIP_VIEWPORT_PADDING,
+        viewportRight - TOOLTIP_VIEWPORT_PADDING - tooltip.width,
+    );
+    const preferredY = trigger.top + trigger.height + TOOLTIP_GAP;
+    const fitsBottom = preferredY + tooltip.height <= viewportBottom - TOOLTIP_VIEWPORT_PADDING;
+    const y = clamp(
+        fitsBottom ? preferredY : trigger.top - TOOLTIP_GAP - tooltip.height,
+        TOOLTIP_VIEWPORT_PADDING,
+        viewportBottom - TOOLTIP_VIEWPORT_PADDING - tooltip.height,
+    );
+    return {x, y, placement: fitsBottom ? "bottom" : "top"};
+}
+
+function clamp(value: number, min: number, max: number): number {
+    if (max < min) {
+        return min;
+    }
+    return Math.min(Math.max(value, min), max);
+}


### PR DESCRIPTION
## 关联 Issue / Related issue

Closes #107

## 解决的问题 / Problem

创建小说进入 IDE 后，左侧栏（最左 48px 图标条 + 工具面板头部）有大量纯图标按钮。此前依赖原生 `title` 提示：在 Tauri/WebView 桌面端不显示，Web 端延迟约 1s 且样式不统一。用户悬停时无法知道按钮是干嘛的。

## 本次范围 / Scope

包含 / In scope:

- 新增通用 Tooltip 组件与定位工具，覆盖左侧栏（`NovelIdeActivityBar` + `NovelIdeToolPanel` 头部）全部纯图标按钮
- 悬停约 300ms 即时弹出名称提示；禁用态保留「请先打开一个 Project」说明；键盘聚焦立即显示；`prefers-reduced-motion` 降级
- 补「收起面板 / Collapse panel」i18n

不包含 / Out of scope:

- 本地 AI 工作流配置（Trellis，335 文件）——另行提交，避免与功能无关的改动混入
- Agent 会话侧栏、文件树行内操作等其它纯图标区（组件已通用，可后续低成本扩展）
- 「名称 + 一句说明」的富提示文案（当前仅名称）

## 用户可见结果与实现 / User-visible result and implementation

用户现在悬停左侧任意图标按钮即可立即看到规范化的名称提示，禁用状态下会看到「名称 · 请先打开一个 Project」，Web 与桌面端表现一致。

实现：新增 `app/components/common/Tooltip.vue`（Teleport 到主题宿主保证 8 套主题变量可解析；right/bottom 定位 + 视口越界翻转/钳制；箭头、`aria-describedby`）与 `app/utils/tooltip-position.ts`；`NovelIdeActivityBar` / `NovelIdeToolPanel` 的图标按钮接入并移除原生 `title`。集成中发现并修复一个响应式缺陷：克隆插槽 vnode 使用普通函数而非 computed，避免父组件重渲染后按钮 `disabled`/`class` 停留在旧状态。

## 验证 / Verification

实际执行的完整命令和结果 / Exact commands and results:

```text
# 单测（定位工具 + workbench-chrome 回归）
bunx vitest run app/utils/tooltip-position.test.ts app/utils/workbench-chrome.test.ts
→ Test Files 2 passed (2), Tests 9 passed (9)

# 类型检查
bunx nuxt typecheck --dotenv .env.typecheck --logLevel silent
→ EXIT=0

# 空白检查
git diff --check
→ 无输出

# 无头浏览器实测（Playwright 连接本机 dev server，非截图工具）
打开小说后全部按钮可用；回书架正确禁用；重开小说恢复可用；
切换 Tab 时 active 背景与 aria-pressed 实时更新；
悬停提示内容、位置、箭头、z-index、aria-describedby 均正确
```

未运行的检查及原因 / Checks not run and why:

- 全量测试（`bun run test`）：未运行。本次为前端 UI 改动，按仓库风险匹配原则执行聚焦测试与 typecheck；聚焦测试通过不表述为全量通过。
- 桌面端（Electron/Tauri）人工验收：未运行（本机为 Web 开发环境）；`desktop/electron` 子包 typecheck 因该子包依赖未安装失败，为既有环境问题，与本次改动无关。
- 8 套内置主题下的最终观感：代码层面仅消费已有主题变量、未新增变量，建议桌面端人工确认。

## 界面证据 / UI evidence

悬停「剧本工作台」按钮（已打开小说、按钮可用）：

![Tooltip 悬停提示](https://raw.githubusercontent.com/nsxzhou/neuro-book/docs/pr-106-screenshots/docs/pr-106/tooltip-plot.png)

回书架后悬停被禁用的「文件」按钮（禁用态提示）：

![禁用态提示](https://raw.githubusercontent.com/nsxzhou/neuro-book/docs/pr-106-screenshots/docs/pr-106/tooltip-disabled.png)

截图由无头浏览器对本机运行中的应用截取，仅含通用 UI 文案，不含小说正文或私人会话。

## 文档与记录 / Documentation and records

- [x] 已更新或确认不需要更新用户文档 / User documentation updated or not needed
- [x] 已更新或确认不需要更新 Task walkthrough / Task walkthrough updated or not needed
- [x] 已更新或确认不需要更新 Reference、ADR 与 `PROJECT-STATUS.md` / Reference, ADR, and `PROJECT-STATUS.md` updated or not needed
- [x] 本 PR 不修改版本号或 `RELEASE.md`，除非维护者明确要求 / This PR does not change the version or `RELEASE.md` unless requested by a maintainer

## 风险与边界 / Risks and boundaries

- 数据结构或迁移 / Data shape or migration: 无
- 配置、安装或发布 / Configuration, installation, or release: 无
- 安全与隐私 / Security and privacy: 无；截图仅含通用 UI 文案
- 已知限制与后续事项 / Known limitations and follow-ups: 桌面端 8 套主题观感待人工验收；Agent 会话侧栏、文件树行内操作等其它纯图标区未覆盖，可基于本组件后续扩展

## 提交者确认 / Contributor confirmation

- [x] 一个连贯目标之外没有夹带其它改动 / This PR contains no unrelated changes outside one coherent goal
- [x] 我已审查并能解释全部改动，包括开发 Agent 生成的内容 / I reviewed and can explain every change, including coding-agent output
- [x] 验证结果真实，聚焦测试没有被描述成全量测试 / Verification is accurate and focused tests are not presented as the full suite
- [x] 日志、截图和 fixture 不含密钥、小说正文、私人会话或未授权内容 / Logs, screenshots, and fixtures contain no secrets, manuscripts, private sessions, or unlicensed material
