### PR TITLE
重设计「新建世界书条目」类型选择弹窗：类型卡片化，取消不再混同于选项

### DIFF
--- a/app/composables/useDialog.ts
+++ b/app/composables/useDialog.ts
@@ -28,6 +28,21 @@ interface ChooseDialogOptions {
     }>;
 }
 
+interface CardAction {
+    label: string;
+    value: DialogActionValue;
+    /** 图标类名（如 "i-lucide-map-pinned"），可省略。 */
+    icon?: string;
+    /** 图标容器的彩色样式类（如 workspace-entry-meta 的 iconClass），可省略。 */
+    iconClass?: string;
+}
+
+interface ChooseCardsDialogOptions {
+    message: string;
+    title?: string;
+    actions: CardAction[];
+}
+
 type VueI18nContextApp = App<Element> & {
     __VUE_I18N_SYMBOL__?: InjectionKey<object>;
     _context: {
@@ -269,6 +284,94 @@ function createChooseDialogInstance(options: ChooseDialogOptions, sourceApp: Vue
 }
 
 /**
+ * 动态创建一个卡片式多选项对话框实例，返回选中的动作值。
+ *
+ * 与 createChooseDialogInstance 的区别：选项以带图标卡片网格展示在正文，
+ * 取消通过标题栏 × / Esc / 遮罩点击完成（不混同于选项按钮）。
+ */
+function createChooseCardsDialogInstance(options: ChooseCardsDialogOptions, sourceApp: VueI18nContextApp): Promise<DialogActionValue> {
+    return new Promise((resolve) => {
+        const container = document.createElement("div");
+        const themeHost = document.querySelector<HTMLElement>(`.${IDE_THEME_HOST_CLASS}`);
+        (themeHost ?? document.body).appendChild(container);
+
+        let resolved = false;
+
+        /**
+         * 销毁对话框实例和 DOM。
+         */
+        const destroy = (): void => {
+            setTimeout(() => {
+                app.unmount();
+                container.remove();
+            }, 300);
+        };
+
+        const DialogWrapper = defineComponent({
+            setup() {
+                const visible = ref(true);
+
+                /**
+                 * 关闭并返回选中的动作。
+                 */
+                const choose = (value: DialogActionValue): void => {
+                    if (resolved) {
+                        return;
+                    }
+
+                    resolved = true;
+                    visible.value = false;
+                    resolve(value);
+                    destroy();
+                };
+
+                return () => h(Dialog, {
+                    modelValue: visible.value,
+                    "onUpdate:modelValue": (val: boolean) => {
+                        visible.value = val;
+                    },
+                    title: options.title ?? "",
+                    closable: true,
+                    closeOnOverlay: true,
+                    closeOnEsc: true,
+                    showFooter: false,
+                    width: "440px",
+                    teleportTarget: false,
+                    onCancel: () => choose("cancel"),
+                    onRequestClose: () => choose("cancel"),
+                }, {
+                    default: () => [
+                        options.message ? h("p", {
+                            class: "m-0 text-sm leading-relaxed text-[var(--text-secondary)]",
+                        }, options.message) : null,
+                        h("div", {
+                            class: "mt-3 grid grid-cols-2 gap-2",
+                        }, options.actions.map((action) => h("button", {
+                            type: "button",
+                            class: "flex items-center gap-2.5 rounded-md border border-[var(--border-color)] bg-[var(--bg-input)] px-3 py-2.5 text-left text-[13px] font-medium text-[var(--text-main)] transition-colors duration-150 hover:border-[var(--accent-main)] hover:bg-[var(--bg-hover)] active:scale-[0.98]",
+                            onClick: () => choose(action.value),
+                        }, [
+                            action.iconClass ? h("span", {
+                                class: `flex h-8 w-8 shrink-0 items-center justify-center rounded-md border ${action.iconClass}`,
+                            }, action.icon ? h("span", {
+                                class: `h-4 w-4 ${action.icon}`,
+                            }) : undefined) : null,
+                            h("span", {
+                                class: "min-w-0 truncate",
+                            }, action.label),
+                        ]))),
+                    ],
+                });
+            },
+        });
+
+        const app = createApp(DialogWrapper);
+        inheritI18nContext(app, sourceApp);
+        app.mount(container);
+    });
+}
+
+/**
  * 通用对话框 JS API composable。
  *
  * 提供 alert / confirm / prompt 三个异步函数，
@@ -317,5 +420,20 @@ export function useDialog() {
         }, sourceApp);
     };
 
-    return { alert, confirm, prompt, choose };
+    /**
+     * 卡片式多动作选择对话框：选项以图标卡片网格展示，取消走标题栏 × 关闭。
+     */
+    const chooseCards = (
+        message: string,
+        actions: ChooseCardsDialogOptions["actions"],
+        title?: string,
+    ): Promise<DialogActionValue> => {
+        return createChooseCardsDialogInstance({
+            message,
+            title: title ?? t("dialog.chooseTitle"),
+            actions,
+        }, sourceApp);
+    };
+
+    return {alert, confirm, prompt, choose, chooseCards};
 }

--- a/app/composables/useDialog.ts
+++ b/app/composables/useDialog.ts
@@ -252,10 +252,10 @@ function createChooseDialogInstance(options: ChooseDialogOptions, sourceApp: Vue
                     }, options.message),
                     footer: () => options.actions.map((action) => h("button", {
                         class: action.tone === "primary"
-                            ? "inline-flex items-center justify-center h-8 px-4 rounded-md text-[13px] font-medium cursor-pointer border border-transparent bg-[var(--accent-main)] text-[var(--text-inverse)] transition-all duration-200 hover:opacity-90 hover:shadow-md active:scale-95"
+                            ? "inline-flex items-center justify-center h-8 whitespace-nowrap px-3 rounded-md text-[13px] font-medium cursor-pointer border border-transparent bg-[var(--accent-main)] text-[var(--text-inverse)] transition-all duration-200 hover:opacity-90 hover:shadow-md active:scale-95"
                             : action.tone === "danger"
-                                ? "inline-flex items-center justify-center h-8 px-4 rounded-md text-[13px] font-medium cursor-pointer border border-[var(--status-danger-border)] bg-[var(--status-danger-bg)] text-[var(--status-danger)] transition-colors duration-200 hover:bg-[var(--status-danger)] hover:text-[var(--text-inverse)] active:scale-95"
-                                : "inline-flex items-center justify-center h-8 px-4 rounded-md text-[13px] font-medium cursor-pointer border border-[var(--border-color)] bg-[var(--bg-input)] text-[var(--text-main)] transition-colors duration-200 hover:bg-[var(--bg-hover)] active:scale-95",
+                                ? "inline-flex items-center justify-center h-8 whitespace-nowrap px-3 rounded-md text-[13px] font-medium cursor-pointer border border-[var(--status-danger-border)] bg-[var(--status-danger-bg)] text-[var(--status-danger)] transition-colors duration-200 hover:bg-[var(--status-danger)] hover:text-[var(--text-inverse)] active:scale-95"
+                                : "inline-flex items-center justify-center h-8 whitespace-nowrap px-3 rounded-md text-[13px] font-medium cursor-pointer border border-[var(--border-color)] bg-[var(--bg-input)] text-[var(--text-main)] transition-colors duration-200 hover:bg-[var(--bg-hover)] active:scale-95",
                         onClick: () => choose(action.value),
                     }, action.label)),
                 });

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -28,6 +28,7 @@ import {useWorkspaceFileEvents} from "nbook/app/composables/useWorkspaceFileEven
 import {isProjectSessionSupersededError, useProjectSession} from "nbook/app/composables/useProjectSession";
 import {useResizablePanel} from "nbook/app/composables/useResizablePanel";
 import {useDialog} from "nbook/app/composables/useDialog";
+import {getWorkspaceLorebookTypeMeta} from "nbook/app/components/novel-ide/workspace/workspace-entry-meta";
 import {useNotification} from "nbook/app/composables/useNotification";
 import {useInlineEditorAgentController} from "nbook/app/composables/useInlineEditorAgentController";
 import {useWorkbenchChromeRegistration} from "nbook/app/composables/useWorkbenchChrome";
@@ -217,7 +218,7 @@ const studio = useMarkdownStudioController({
 // store 在切文件 / 磁盘同步 / 保存前先结算编辑器防抖输入，防止防抖窗口内的输入被误判为「无修改」
 novelIdeStore.registerActiveEditorFlush(() => studio.flushActiveEditor());
 
-const {alert, choose, prompt} = useDialog();
+const {alert, choose, chooseCards, prompt} = useDialog();
 const notification = useNotification();
 const {t} = useI18n();
 const inlineEditorAgent = useInlineEditorAgentController({
@@ -2233,14 +2234,22 @@ async function createWelcomeMarkdownFile(): Promise<void> {
  * 创建欢迎页 Lorebook 条目。
  */
 async function createWelcomeLorebookEntry(): Promise<void> {
-    const selectedType = await choose(t("ide.shell.createLorebookTypePrompt"), [
-        {label: t("ide.shell.lorebookLocation"), value: "location", tone: "primary"},
-        {label: t("ide.shell.lorebookCharacter"), value: "character"},
-        {label: t("ide.shell.lorebookItem"), value: "item"},
-        {label: t("ide.shell.lorebookRule"), value: "rule"},
-        {label: t("ide.shell.lorebookNote"), value: "note"},
-        {label: t("common.cancel"), value: "cancel"},
-    ], t("ide.shell.createLorebookTitle"));
+    const typeLabelKeys: Record<WelcomeLorebookEntryType, string> = {
+        location: "ide.shell.lorebookLocation",
+        character: "ide.shell.lorebookCharacter",
+        item: "ide.shell.lorebookItem",
+        rule: "ide.shell.lorebookRule",
+        note: "ide.shell.lorebookNote",
+    };
+    const selectedType = await chooseCards(t("ide.shell.createLorebookTypePrompt"), WELCOME_LOREBOOK_ENTRY_TYPES.map((type) => {
+        const meta = getWorkspaceLorebookTypeMeta(type);
+        return {
+            label: t(typeLabelKeys[type]),
+            value: type,
+            icon: meta.icon,
+            iconClass: meta.iconClass,
+        };
+    }), t("ide.shell.createLorebookTitle"));
     if (!isWelcomeLorebookEntryType(selectedType)) {
         return;
     }


### PR DESCRIPTION
## 概述

重设计欢迎页「新建世界书条目」的类型选择弹窗：5 个类型改为带彩色图标的两列卡片，「取消」不再混同于选项（改为标题栏 × 关闭），并消除按钮文字竖排的布局缺陷。

## 背景

- 原弹窗把 5 个类型（地点/角色/物品/规则/笔记）与「取消」渲染成同款底部按钮，选项与取消无法区分。
- 6 个按钮在 420px 弹窗内放不下，按钮被压缩后中文标签按字符断行成竖排（1280×720 可复现）。

## 变更

- 新增通用卡片式多选项弹窗 `chooseCards`（`app/composables/useDialog.ts`）：标题栏 × 关闭（Esc、遮罩点击同样取消），正文两列图标卡片，无底部选项按钮。
- 欢迎页世界书入口改用 `chooseCards`：5 个类型卡片复用现有类型图标与配色（地点/角色/物品/规则/笔记），选择后进入原有「输入路径」步骤，创建行为不变。
- 共享 `choose` 弹窗底部按钮收紧内边距并加 `whitespace-nowrap`，消除多按钮场景下中文竖排；其他弹窗（如未保存确认）样式与行为不变。

## 验证

- 1280×720 与 900×700：卡片两列排布、文字单行、无溢出；×/Esc/遮罩均取消且不创建文件；点卡片进入路径输入。
- `bun run typecheck` 通过；相关 vitest（tooltip-position 14 + world-engine 32）通过。

Closes #112