### PR TITLE
refactor(utils): extract stripFrontmatterBody and reuse in resource-preset

### DIFF
--- a/server/low-code-form/resource-preset.ts
+++ b/server/low-code-form/resource-preset.ts
@@ -1,5 +1,6 @@
 import type {LowCodeFormResolveContext} from "nbook/server/low-code-form";
 import type {ProfileHomeFacade} from "nbook/server/agent/profiles/profile-home";
+import {stripFrontmatterBody} from "nbook/server/utils/frontmatter-document";
 import type {
     ResourcePresetContent,
     ResourcePresetCreateInput,
@@ -171,8 +172,8 @@ function readMarkdownTitle(content: string): string | null {
 
 function withMarkdownTitle(content: string, title: string): string {
     const cleanTitle = title.replaceAll("\"", "\\\"");
-    if (/^---\r?\n[\s\S]*?\r?\n---\r?\n/u.test(content)) {
-        const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/u, "");
+    const body = stripFrontmatterBody(content);
+    if (body !== content) {
         return `---\ntitle: "${cleanTitle}"\n---\n${body.startsWith("\n") ? body : `\n${body}`}`;
     }
     return `---\ntitle: "${cleanTitle}"\n---\n\n${content}`;

--- a/server/utils/frontmatter-document.test.ts
+++ b/server/utils/frontmatter-document.test.ts
@@ -1,0 +1,27 @@
+import {describe, expect, it} from "vitest";
+import {stripFrontmatterBody} from "nbook/server/utils/frontmatter-document";
+
+describe("stripFrontmatterBody", () => {
+    it("剥离 LF 与 CRLF frontmatter，返回正文", () => {
+        expect(stripFrontmatterBody("---\ntitle: a\n---\n正文")).toBe("正文");
+        expect(stripFrontmatterBody("---\r\ntitle: a\r\n---\r\n正文")).toBe("正文");
+    });
+
+    it("frontmatter 后的空行保留在正文开头", () => {
+        expect(stripFrontmatterBody("---\ntitle: a\n---\n\n正文")).toBe("\n正文");
+    });
+
+    it("多字段 frontmatter 整体剥离", () => {
+        expect(stripFrontmatterBody("---\ntitle: a\ntags:\n  - x\n---\n正文")).toBe("正文");
+    });
+
+    it("无 frontmatter、未闭合分隔符或 frontmatter 前有内容时原样返回", () => {
+        expect(stripFrontmatterBody("正文直接开始")).toBe("正文直接开始");
+        expect(stripFrontmatterBody("---\ntitle: a\n正文")).toBe("---\ntitle: a\n正文");
+        expect(stripFrontmatterBody("x\n---\ntitle: a\n---\n正文")).toBe("x\n---\ntitle: a\n---\n正文");
+    });
+
+    it("结束分隔符位于末尾且无换行时按权威解析器语义剥离", () => {
+        expect(stripFrontmatterBody("---\ntitle: a\n---")).toBe("");
+    });
+});

--- a/server/utils/frontmatter-document.ts
+++ b/server/utils/frontmatter-document.ts
@@ -66,6 +66,14 @@ export function assertNoReadonlyFrontmatterKeys(
 }
 
 /**
+ * 剥离 YAML frontmatter，仅返回正文部分；无 frontmatter 时原样返回。
+ */
+export function stripFrontmatterBody(content: string): string {
+    const match = content.match(FRONTMATTER_PATTERN);
+    return match ? match[2] ?? "" : content;
+}
+
+/**
  * 判断值是否为普通对象。
  */
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## 关联 Issue / Related issue

Closes #114

## 解决的问题 / Problem

`server/low-code-form/resource-preset.ts` 的 `withMarkdownTitle` 自己维护一份剥离 frontmatter 的正则，与 `server/utils/frontmatter-document.ts` 的权威解析正则并存；每新增一个"只取正文"的消费方都可能再引入一个变体，边界行为会逐渐分叉。

## 本次范围 / Scope

包含 / In scope:

- `server/utils/frontmatter-document.ts` 新增 `stripFrontmatterBody(content: string): string`，内部复用既有 `FRONTMATTER_PATTERN`，无 frontmatter 时原样返回
- `server/low-code-form/resource-preset.ts` 的 `withMarkdownTitle` 用该函数替换本地正则
- 新增 `server/utils/frontmatter-document.test.ts` 覆盖剥离行为

不包含 / Out of scope:

- `readMarkdownTitle` 的标题提取正则（是提取而非剥离，语义不同）
- 其它 frontmatter 消费方（`writer-writing-style.ts`、`writer-writing-reference.ts` 已使用 `parseFrontmatterDocument`）

## 用户可见结果与实现 / User-visible result and implementation

对用户无可感知变化，是内部一致性改进。`withMarkdownTitle` 剥离 frontmatter 时改用共享实现。与旧正则的唯一行为差异：结束分隔符 `---` 位于文件末尾且无换行时，旧正则不剥离（整段当正文保留），新实现按 `parseFrontmatterDocument` 的既有语义剥离（正文为空）；该差异已在 #114 中说明。

## 验证 / Verification

实际执行的完整命令和结果 / Exact commands and results:

```text
bunx vitest run server/utils/frontmatter-document.test.ts server/low-code-form/low-code-form.test.ts --reporter=dot
Test Files  2 passed (2)
      Tests  27 passed (27)
```

另做了新旧实现的输入等价性对照（LF / CRLF / frontmatter 后空行 / 无 frontmatter / frontmatter 前有内容 / 未闭合分隔符 / 多字段，共 7 类）：除上述已披露的边界外全部一致。

未运行的检查及原因 / Checks not run and why:

- 全量测试套件未运行：改动只触及上述两个文件，聚焦回归已覆盖；CI 会运行全量。
- `bun run typecheck` 在本机存在与本次改动无关的基线错误（Prisma 生成类型缺失、admin 模块隐式 any）；触及文件零类型错误。
