### PR TITLE
fix: 让 Source Dev 在 Ctrl+C 后干净停止 dev server

### DIFF
--- a/packages/owned-process/src/posix-adapter.ts
+++ b/packages/owned-process/src/posix-adapter.ts
@@ -68,6 +68,10 @@ export function spawnPosixOwnedProcess(spec: OwnedProcessSpec, options: PosixAda
             });
             return;
         }
+        if (signal) {
+            settle({exitCode: code, signal, terminationReason: "cancel"});
+            return;
+        }
         rejectOnce(new OwnedProcessError(
             `POSIX监督进程未报告目标终态：code=${code ?? "null"} signal=${signal ?? "null"}`,
             {stage: "supervisor-close"},

--- a/packages/owned-process/src/posix-supervisor-source.ts
+++ b/packages/owned-process/src/posix-supervisor-source.ts
@@ -28,6 +28,12 @@ process.on("message", (message) => {
 process.on("disconnect", () => {
     if (!finished) terminate("host-disconnect");
 });
+process.on("SIGINT", () => {
+    if (payload && !finished) terminate("cancel");
+});
+process.on("SIGTERM", () => {
+    if (payload && !finished) terminate("cancel");
+});
 
 /** 目标以独立 process group 启动，监督器只转发 stdio 与终态。 */
 function start(message) {

--- a/scripts/cli/source-dev.ts
+++ b/scripts/cli/source-dev.ts
@@ -2,7 +2,6 @@
 import {randomBytes} from "node:crypto";
 import {resolve} from "node:path";
 import {spawnOwnedProcess, type OwnedProcessCompletion} from "@notnotype/owned-process";
-import {shutdownNativeProduct} from "nbook/shared/product-runtime-shutdown";
 import {
     PRODUCT_RUNTIME_EXIT_CODE_AGENT_SESSION_STORE_LEASE_COMPROMISED,
     PRODUCT_SHUTDOWN_TOKEN_ENVIRONMENT,
@@ -47,7 +46,7 @@ export async function runSourceDev(options: SourceDevOptions = {}): Promise<numb
     });
     const completion = lease.completion.then(productExit);
     let signalCount = 0;
-    let shutdownPromise: Promise<"graceful" | "forced"> | null = null;
+    let shutdownPromise: Promise<"forced"> | null = null;
     let forcedShutdownPromise: Promise<"forced"> | null = null;
     let rejectShutdownFailure!: (error: unknown) => void;
     const shutdownFailure = new Promise<never>((_resolve, reject) => {
@@ -57,15 +56,7 @@ export async function runSourceDev(options: SourceDevOptions = {}): Promise<numb
     const requestShutdown = (): void => {
         signalCount += 1;
         if (signalCount === 1) {
-            shutdownPromise = shutdownNativeProduct({
-                port,
-                token,
-                host: sourceDevLoopbackHost(configuredHost),
-                completion,
-                forceTerminate: async () => {
-                    await lease.terminate("shutdown");
-                },
-            });
+            shutdownPromise = lease.terminate("shutdown").then(() => "forced" as const);
             void shutdownPromise.catch(rejectShutdownFailure);
             return;
         }
@@ -93,14 +84,6 @@ export async function runSourceDev(options: SourceDevOptions = {}): Promise<numb
         process.off("SIGINT", requestShutdown);
         process.off("SIGTERM", requestShutdown);
     }
-}
-
-/** 将Source Dev监听配置收窄为认证shutdown允许使用的loopback地址。 */
-function sourceDevLoopbackHost(host: string | undefined): "127.0.0.1" | "localhost" | "[::1]" {
-    const normalized = host?.toLocaleLowerCase("en-US").replace(/^\[|\]$/gu, "");
-    if (normalized === "localhost") return "localhost";
-    if (normalized === "::" || normalized === "::1") return "[::1]";
-    return "127.0.0.1";
 }
 
 /** Source Dev 继续沿用 Nuxt 的 NUXT_PORT/PORT/default 解析顺序。 */

--- a/shared/source-dev-launcher.test.ts
+++ b/shared/source-dev-launcher.test.ts
@@ -8,14 +8,10 @@ import {
 
 const mocks = vi.hoisted(() => ({
     spawnOwnedProcess: vi.fn(),
-    shutdownNativeProduct: vi.fn(),
 }));
 
 vi.mock("@notnotype/owned-process", () => ({
     spawnOwnedProcess: mocks.spawnOwnedProcess,
-}));
-vi.mock("nbook/shared/product-runtime-shutdown", () => ({
-    shutdownNativeProduct: mocks.shutdownNativeProduct,
 }));
 
 import {runSourceDev} from "nbook/scripts/cli/source-dev";
@@ -69,11 +65,10 @@ describe("Source Dev launcher", () => {
         }));
     });
 
-    it("首次信号只请求共享graceful shutdown并等待Product终态", async () => {
+    it("首次信号直接调用lease.terminate，不尝试HTTP graceful", async () => {
         const terminal = deferred<OwnedProcessCompletion>();
         const ownedLease = lease(terminal.promise);
         mocks.spawnOwnedProcess.mockReturnValue(ownedLease);
-        mocks.shutdownNativeProduct.mockResolvedValue("graceful");
         const before = new Set(process.listeners("SIGINT"));
         const running = runSourceDev({env: {PORT: "43131"}});
 
@@ -81,33 +76,30 @@ describe("Source Dev launcher", () => {
         terminal.resolve({exitCode: 0, signal: null});
 
         await expect(running).resolves.toBe(0);
-        expect(mocks.shutdownNativeProduct).toHaveBeenCalledWith(expect.objectContaining({
-            port: 43131,
-            host: "127.0.0.1",
-            completion: expect.any(Promise),
-            forceTerminate: expect.any(Function),
-        }));
-        expect(ownedLease.terminate).not.toHaveBeenCalled();
+        expect(ownedLease.terminate).toHaveBeenCalledWith("shutdown");
     });
 
-    it("显式localhost监听时graceful shutdown使用同一loopback地址", async () => {
+    it("首次信号后租约已终止时，第二次信号保持幂等", async () => {
         const terminal = deferred<OwnedProcessCompletion>();
-        mocks.spawnOwnedProcess.mockReturnValue(lease(terminal.promise));
-        mocks.shutdownNativeProduct.mockResolvedValue("graceful");
+        const ownedLease = lease(terminal.promise);
+        mocks.spawnOwnedProcess.mockReturnValue(ownedLease);
         const before = new Set(process.listeners("SIGINT"));
-        const running = runSourceDev({env: {PORT: "43134", HOST: "localhost"}});
+        const running = runSourceDev({env: {PORT: "43132"}});
+        const signal = addedSignalListener("SIGINT", before);
 
-        addedSignalListener("SIGINT", before)();
+        signal();
+        signal();
+        signal();
         terminal.resolve({exitCode: 0, signal: null});
 
         await expect(running).resolves.toBe(0);
-        expect(mocks.shutdownNativeProduct).toHaveBeenCalledWith(expect.objectContaining({host: "localhost"}));
+        expect(ownedLease.terminate).toHaveBeenCalledTimes(1);
+        expect(ownedLease.terminate).toHaveBeenCalledWith("shutdown");
     });
 
     it("shutdown竞态中Product以75退出时保留专用退出码", async () => {
         const terminal = deferred<OwnedProcessCompletion>();
         mocks.spawnOwnedProcess.mockReturnValue(lease(terminal.promise));
-        mocks.shutdownNativeProduct.mockResolvedValue("forced");
         const before = new Set(process.listeners("SIGINT"));
         const running = runSourceDev({env: {PORT: "43135"}});
 
@@ -120,36 +112,12 @@ describe("Source Dev launcher", () => {
         await expect(running).resolves.toBe(PRODUCT_RUNTIME_EXIT_CODE_AGENT_SESSION_STORE_LEASE_COMPROMISED);
     });
 
-    it("第二次信号幂等地立即强制收口，不等待仍挂起的graceful请求", async () => {
+    it("lease.terminate失败时直接向CLI传播错误", async () => {
         const terminal = deferred<OwnedProcessCompletion>();
-        const graceful = deferred<"graceful" | "forced">();
+        const failure = new Error("terminate failed");
         const ownedLease = lease(terminal.promise);
-        vi.mocked(ownedLease.terminate).mockResolvedValue({
-            exitCode: null,
-            signal: "SIGTERM",
-            terminationReason: "shutdown",
-        });
+        vi.mocked(ownedLease.terminate).mockRejectedValue(failure);
         mocks.spawnOwnedProcess.mockReturnValue(ownedLease);
-        mocks.shutdownNativeProduct.mockReturnValue(graceful.promise);
-        const before = new Set(process.listeners("SIGINT"));
-        const running = runSourceDev({env: {PORT: "43132"}});
-        const signal = addedSignalListener("SIGINT", before);
-
-        signal();
-        signal();
-        signal();
-        terminal.resolve({exitCode: null, signal: "SIGTERM", terminationReason: "shutdown"});
-
-        await expect(running).resolves.toBe(0);
-        expect(ownedLease.terminate).toHaveBeenCalledTimes(1);
-        expect(ownedLease.terminate).toHaveBeenCalledWith("shutdown");
-    });
-
-    it("graceful和force均失败时立即向CLI传播AggregateError", async () => {
-        const terminal = deferred<OwnedProcessCompletion>();
-        const failure = new AggregateError([new Error("graceful"), new Error("force")], "shutdown failed");
-        mocks.spawnOwnedProcess.mockReturnValue(lease(terminal.promise));
-        mocks.shutdownNativeProduct.mockRejectedValue(failure);
         const before = new Set(process.listeners("SIGTERM"));
         const running = runSourceDev({env: {PORT: "43133"}});
 


### PR DESCRIPTION
## 概述

macOS 上 `bun run dev`（Source Dev 模式）按 Ctrl+C 无法干净停止：命令报错退出但 dev server（默认端口 3101）残留并继续占用端口。

## 背景

Source Dev 用进程监督层（`owned-process`）管理 nuxt dev 子进程，链路为 CLI（`source-dev.ts`）→ POSIX supervisor → nuxt dev。停止流程有两个断点，另有一处冗余：

1. POSIX supervisor 没有 SIGINT 处理，收到信号后直接死亡，既不清理 detached 子进程组也不报告终态；
2. adapter 把「supervisor 因外部信号关闭」一律当作错误，抛出 `OwnedProcessError: POSIX监督进程未报告目标终态`，子进程仍在运行；
3. `source-dev.ts` 在 dev 模式先尝试 HTTP 优雅关闭，但 dev server 没有该接口，请求必然失败，产生误导日志并延迟停止。

## 方案

- POSIX supervisor 增加 SIGINT/SIGTERM 处理：收到信号后向 detached 子进程组发 SIGTERM 收口，进程组消失后向宿主报告 `terminated` 终态；
- adapter 在 supervisor 因外部信号关闭且未及报告终态时，走优雅降级（记录 `cancel` 终止原因）而非报错；
- `source-dev.ts` 移除 dev 模式下无意义的 HTTP 优雅关闭，收到停止信号后直接让监督层收口子进程树；同步更新 launcher 测试用例。

## 验证

- `packages/owned-process` 15 个测试全部通过（在独立 worktree 复验）。
- 修复前：Ctrl+C 报 `OwnedProcessError`，3101 端口仍被占用。
- 修复后：Ctrl+C 干净退出，3101 端口立即释放，无错误堆栈。

## 验证边界

`shared/source-dev-launcher.test.ts` 用例已更新，但当前仓库存在与本次改动无关的预存测试环境问题（`zod` 模块解析报错），该文件本机与独立 worktree 均未能运行，需在 CI 中确认。

Closes #119