### PR TITLE
feat(profile): 工作台顶栏按钮图标化，压缩模板选择器宽度

### DIFF
--- a/app/components/profile-template-editor/ProfileTemplateHeader.vue
+++ b/app/components/profile-template-editor/ProfileTemplateHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import FormSelect from "nbook/app/components/common/form/FormSelect.vue";
+import Tooltip from "nbook/app/components/common/Tooltip.vue";
 import type {SelectOption} from "nbook/app/components/profile-template-editor/profile-template-editor-ui";
 
 const props = defineProps<{
@@ -59,98 +60,99 @@ const emit = defineEmits<{
             </div>
         </div>
 
-        <FormSelect :model-value="props.selectedTemplate" :options="props.templateOptions" placeholder="选择模板" dropdown-direction="down" class="min-w-[320px]" @update:model-value="emit('update:selectedTemplate', $event)" />
+        <FormSelect :model-value="props.selectedTemplate" :options="props.templateOptions" placeholder="选择模板" dropdown-direction="down" class="min-w-0 max-w-[320px] flex-1" @update:model-value="emit('update:selectedTemplate', $event)" />
 
-        <div class="ml-auto flex items-center gap-2">
+        <div class="ml-auto flex shrink-0 items-center gap-2">
             <span class="hidden items-center gap-1 text-xs text-[var(--status-success)] md:flex">
                 <span class="i-lucide-circle-check h-3.5 w-3.5"></span>
                 <span>{{ props.editorStatusText }}</span>
             </span>
             <div class="mx-2 hidden h-4 w-px bg-[var(--border-color)] lg:block"></div>
-            <button class="icon-btn" title="撤销 Ctrl+Z" :disabled="!props.canUndo" @click="emit('undo')">
-                <span class="i-lucide-undo-2 h-4 w-4"></span>
-            </button>
-            <button class="icon-btn" title="重做 Ctrl+Shift+Z" :disabled="!props.canRedo" @click="emit('redo')">
-                <span class="i-lucide-redo-2 h-4 w-4"></span>
-            </button>
-            <button class="toolbar-btn" :disabled="props.previewing || !props.sourceText" @click="emit('preview')">
-                <span class="i-lucide-play h-3.5 w-3.5"></span>
-                <span>预览</span>
-            </button>
-            <button v-if="!props.compileEnabled" class="toolbar-btn" :disabled="props.validating || !props.sourceText" @click="emit('validate')">
-                <span class="i-lucide-badge-check h-3.5 w-3.5"></span>
-                <span>{{ props.validateLabel ?? "验证" }}</span>
-            </button>
-            <button v-if="props.compileEnabled" class="toolbar-btn" :disabled="props.compiling || props.compilingAll || props.saving || props.parsingSource || !props.sourceText" @click="emit('compile')">
-                <span class="i-lucide-hammer h-3.5 w-3.5"></span>
-                <span>编译</span>
-            </button>
-            <button v-if="props.compileAllEnabled" class="toolbar-btn" :disabled="props.compilingAll || props.compiling || props.saving" @click="emit('compileAll')">
-                <span class="i-lucide-package-check h-3.5 w-3.5"></span>
-                <span>编译全部</span>
-            </button>
-            <button v-if="props.restoreEnabled" class="toolbar-btn" :disabled="props.restoring || props.saving || !props.sourceText" @click="emit('restore')">
-                <span class="i-lucide-rotate-ccw h-3.5 w-3.5"></span>
-                <span>恢复系统版本</span>
-            </button>
-            <button v-if="props.createEnabled" class="toolbar-btn" :disabled="props.saving" @click="emit('create')">
-                <span class="i-lucide-file-plus-2 h-3.5 w-3.5"></span>
-                <span>新建</span>
-            </button>
-            <button v-if="props.runEnabled" class="toolbar-btn" :disabled="props.saving || props.issueCount > 0 || props.runDisabled" @click="emit('run')">
-                <span class="i-lucide-message-circle-plus h-3.5 w-3.5"></span>
-                <span>创建 Session</span>
-            </button>
-            <button class="toolbar-btn primary" :disabled="props.saving || props.parsingSource || !props.sourceText || (!props.allowSaveWithIssues && props.issueCount > 0)" @click="emit('save')">
-                <span class="i-lucide-save h-3.5 w-3.5"></span>
-                <span>保存</span>
-                <span class="i-lucide-chevron-down h-3.5 w-3.5 opacity-80"></span>
-            </button>
-            <button v-if="props.closable" class="icon-btn" title="关闭" @click="emit('close')">
-                <span class="i-lucide-x h-4 w-4"></span>
-            </button>
+            <Tooltip text="撤销 Ctrl+Z" placement="bottom">
+                <button class="icon-btn" aria-label="撤销" :disabled="!props.canUndo" @click="emit('undo')">
+                    <span class="i-lucide-undo-2 h-4 w-4"></span>
+                </button>
+            </Tooltip>
+            <Tooltip text="重做 Ctrl+Shift+Z" placement="bottom">
+                <button class="icon-btn" aria-label="重做" :disabled="!props.canRedo" @click="emit('redo')">
+                    <span class="i-lucide-redo-2 h-4 w-4"></span>
+                </button>
+            </Tooltip>
+            <Tooltip text="预览" placement="bottom">
+                <button class="icon-btn" aria-label="预览" :disabled="props.previewing || !props.sourceText" @click="emit('preview')">
+                    <span class="i-lucide-play h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="!props.compileEnabled" :text="props.validateLabel ?? '验证'" placement="bottom">
+                <button class="icon-btn" aria-label="验证" :disabled="props.validating || !props.sourceText" @click="emit('validate')">
+                    <span class="i-lucide-badge-check h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.compileEnabled" text="编译" placement="bottom">
+                <button class="icon-btn" aria-label="编译" :disabled="props.compiling || props.compilingAll || props.saving || props.parsingSource || !props.sourceText" @click="emit('compile')">
+                    <span class="i-lucide-hammer h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.compileAllEnabled" text="编译全部" placement="bottom">
+                <button class="icon-btn" aria-label="编译全部" :disabled="props.compilingAll || props.compiling || props.saving" @click="emit('compileAll')">
+                    <span class="i-lucide-package-check h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.restoreEnabled" text="恢复系统版本" placement="bottom">
+                <button class="icon-btn" aria-label="恢复系统版本" :disabled="props.restoring || props.saving || !props.sourceText" @click="emit('restore')">
+                    <span class="i-lucide-rotate-ccw h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.createEnabled" text="新建" placement="bottom">
+                <button class="icon-btn" aria-label="新建" :disabled="props.saving" @click="emit('create')">
+                    <span class="i-lucide-file-plus-2 h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.runEnabled" text="创建 Session" placement="bottom">
+                <button class="icon-btn" aria-label="创建 Session" :disabled="props.saving || props.issueCount > 0 || props.runDisabled" @click="emit('run')">
+                    <span class="i-lucide-message-circle-plus h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip text="保存" placement="bottom">
+                <button class="icon-btn primary" aria-label="保存" :disabled="props.saving || props.parsingSource || !props.sourceText || (!props.allowSaveWithIssues && props.issueCount > 0)" @click="emit('save')">
+                    <span class="i-lucide-save h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.closable" text="关闭" placement="bottom">
+                <button class="icon-btn" aria-label="关闭" @click="emit('close')">
+                    <span class="i-lucide-x h-4 w-4"></span>
+                </button>
+            </Tooltip>
         </div>
     </header>
 </template>
 
 <style scoped>
-.toolbar-btn,
 .icon-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 6px;
     border: 1px solid var(--border-color);
     border-radius: 7px;
     background: var(--bg-input);
     color: var(--text-secondary);
     font-size: 12px;
+    height: 32px;
+    width: 32px;
     transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
 }
 
-.toolbar-btn {
-    height: 32px;
-    padding: 0 12px;
-}
-
-.toolbar-btn.primary {
+.icon-btn.primary {
     border-color: var(--accent-main);
     background: var(--accent-main);
-    color: white;
+    color: var(--text-inverse);
 }
 
-.icon-btn {
-    height: 32px;
-    width: 32px;
-}
-
-.toolbar-btn:hover:not(:disabled),
 .icon-btn:hover:not(:disabled) {
     background: var(--bg-hover);
     color: var(--text-main);
 }
 
-.toolbar-btn:disabled,
 .icon-btn:disabled {
     cursor: not-allowed;
     opacity: 0.45;


### PR DESCRIPTION
## 概述

TSX Profile 工作台/编辑器顶栏右侧原本是一排带文字按钮（预览/编译/编译全部/恢复系统版本/新建/创建Session/保存），加上固定 320px 的模板选择器，顶栏在常用宽度下挤压严重。

## 方案

- 右侧全部文字按钮改为纯图标按钮（32×32），统一用通用 Tooltip 组件悬浮提示，移除慢速原生 title。
- 保存按钮移除装饰性下拉箭头（当前无下拉行为）。
- 模板选择器由固定 320px 改为弹性宽度（`flex-1` + `max-w-[320px]`），窄窗口下自动收缩，不挤压标题与按钮区。
- 保存按钮保留 accent 主操作视觉。

对齐 World Engine Workbench 顶栏先例（此前已做过同类图标化 + Tooltip 改造）。

## 验收证据

- `bun run typecheck`：`app/`、`server/` 无错误（`desktop/electron` 子项目 58 个预存错误系新 worktree 未装 electron 依赖，与本次改动无关）。
- 改动仅 `app/components/profile-template-editor/ProfileTemplateHeader.vue` 一个文件。
- 事件语义、禁用/加载逻辑、props/emits 接口均未改变，两种模式（user-profile / system-template）共用组件保持一致。

浏览器外观需人工走查确认（项目约定不做自动浏览器验收）。