### PR TITLE
fix(profile): improve Agent Profile workbench UI (header icons, nav scroll, panel rails)

### DIFF
--- a/packages/neuro-book/app/components/novel-ide/settings/AgentProfileNavList.vue
+++ b/packages/neuro-book/app/components/novel-ide/settings/AgentProfileNavList.vue
@@ -56,8 +56,9 @@ function statusDotClass(status: ProfileLoadStatus): string {
 </script>
 
 <template>
-    <!-- Agent Profile 二级导航：默认设置 + 可搜索的 Profile 列表。sticky 需要 self-start 配合，否则 grid 会把 aside 拉满高度导致粘不住。 -->
-    <aside class="sticky top-0 flex flex-col self-start rounded-2xl border border-[var(--border-color)] bg-[var(--bg-panel)] p-2 shadow-sm">
+    <!-- Agent Profile 二级导航：默认设置 + 可搜索的 Profile 列表。作为 grid item 需 min-h-0 解除自动最小尺寸，
+         列表区 flex-1 min-h-0 在栏内独立滚动（Profile 过多时搜索框与默认设置入口保持可见）。 -->
+    <aside class="flex min-h-0 flex-col rounded-2xl border border-[var(--border-color)] bg-[var(--bg-panel)] p-2 shadow-sm">
         <!-- 搜索 -->
         <div class="px-1 pb-2 pt-1">
             <FormInput :model-value="props.search" type="search" :placeholder="t('settings.panels.profileModels.nav.searchPlaceholder')" @update:model-value="emit('update:search', $event)">
@@ -91,8 +92,8 @@ function statusDotClass(status: ProfileLoadStatus): string {
             <div class="mt-1 text-[11px] leading-4 text-[var(--text-secondary)] opacity-80">{{ t("settings.panels.profileModels.nav.profilesHint") }}</div>
         </div>
 
-        <!-- 列表由 Dialog body 统一滚动，不再复制 Dialog 的视口高度预算。 -->
-        <div class="flex min-h-[120px] flex-col gap-1 overflow-y-auto px-1 pb-1 custom-scrollbar">
+        <!-- 列表在左栏内独立滚动，不随右侧表单或 Dialog body 同步滚动。 -->
+        <div class="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto px-1 pb-1 custom-scrollbar">
             <button
                 v-for="item in filteredItems"
                 :key="item.profileKey"

--- a/packages/neuro-book/app/components/novel-ide/settings/NovelIdeAgentProfileModelSettingsPanel.vue
+++ b/packages/neuro-book/app/components/novel-ide/settings/NovelIdeAgentProfileModelSettingsPanel.vue
@@ -589,8 +589,10 @@ defineExpose({
 
 <template>
     <!-- Agent Profile 模型设置 -->
-    <div class="space-y-4 pt-1">
-        <div class="flex flex-wrap items-center justify-between gap-4">
+    <!-- xl 下面板绝对定位铺满 section 可视区（包含块 = L888 的 relative section），标题固定，双栏各自独立滚动；
+         若用 h-full 百分比链，滚动容子元素的百分比高度会退化为内容高度导致约束失效。小屏（<xl）保持自然流 + 外层滚动。 -->
+    <div class="space-y-4 pt-1 xl:absolute xl:inset-0 xl:flex xl:flex-col">
+        <div class="flex shrink-0 flex-wrap items-center justify-between gap-4">
             <div class="max-w-xl">
                 <h3 class="text-base font-semibold text-[var(--text-main)]">{{ isProjectScope ? t("settings.panels.profileModels.projectTitle") : t("settings.panels.profileModels.globalTitle") }}</h3>
                 <p class="mt-1 text-xs text-[var(--text-secondary)]">{{ isProjectScope ? t("settings.panels.profileModels.projectDescription", {target: props.targetLabel || t("settings.panels.profileModels.currentProject")}) : t("settings.panels.profileModels.globalDescription") }}</p>
@@ -622,8 +624,8 @@ defineExpose({
             <span class="text-sm text-[var(--text-secondary)]">{{ t("settings.panels.profileModels.loading") }}</span>
         </div>
 
-        <!-- 二级导航 + 详情双栏 -->
-        <div v-else class="grid min-h-[500px] gap-5 xl:grid-cols-[240px_minmax(0,1fr)]">
+        <!-- 二级导航 + 详情双栏：xl 下两栏各自 overflow 滚动；aside 需 min-h-0 解除 grid item 自动最小尺寸，否则行高被内容撑开 -->
+        <div v-else class="grid gap-5 xl:min-h-0 xl:flex-1 xl:grid-cols-[240px_minmax(0,1fr)]">
             <AgentProfileNavList
                 :items="navItems"
                 :active-key="activeNavKey"
@@ -633,7 +635,7 @@ defineExpose({
                 @update:search="navSearch = $event"
             />
 
-            <div class="relative min-w-0">
+            <div class="relative min-w-0 xl:overflow-y-auto">
                 <Transition name="fade-slide" mode="out-in">
                     <!-- Transition 的直接子节点必须是元素，不能直接放子组件：子组件只要编译成 Fragment 根（模板根注释就会），out-in 的离场方拿不到 afterLeave，会永久卡在 isLeaving 只渲染空占位。包一层后子组件根是什么形状都无所谓。 -->
                     <!-- 单个 Profile 详情 -->

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateHeader.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import FormSelect from "nbook/app/components/common/form/FormSelect.vue";
+import Tooltip from "nbook/app/components/common/Tooltip.vue";
 import type {SelectOption} from "nbook/app/components/profile-template-editor/profile-template-editor-ui";
 
 const props = defineProps<{
@@ -59,98 +60,99 @@ const emit = defineEmits<{
             </div>
         </div>
 
-        <FormSelect :model-value="props.selectedTemplate" :options="props.templateOptions" placeholder="选择模板" dropdown-direction="down" class="min-w-[320px]" @update:model-value="emit('update:selectedTemplate', $event)" />
+        <FormSelect :model-value="props.selectedTemplate" :options="props.templateOptions" placeholder="选择模板" dropdown-direction="down" class="min-w-0 max-w-[320px] flex-1" @update:model-value="emit('update:selectedTemplate', $event)" />
 
-        <div class="ml-auto flex items-center gap-2">
+        <div class="ml-auto flex shrink-0 items-center gap-2">
             <span class="hidden items-center gap-1 text-xs text-[var(--status-success)] md:flex">
                 <span class="i-lucide-circle-check h-3.5 w-3.5"></span>
                 <span>{{ props.editorStatusText }}</span>
             </span>
             <div class="mx-2 hidden h-4 w-px bg-[var(--border-color)] lg:block"></div>
-            <button class="icon-btn" title="撤销 Ctrl+Z" :disabled="!props.canUndo" @click="emit('undo')">
-                <span class="i-lucide-undo-2 h-4 w-4"></span>
-            </button>
-            <button class="icon-btn" title="重做 Ctrl+Shift+Z" :disabled="!props.canRedo" @click="emit('redo')">
-                <span class="i-lucide-redo-2 h-4 w-4"></span>
-            </button>
-            <button class="toolbar-btn" :disabled="props.previewing || !props.sourceText" @click="emit('preview')">
-                <span class="i-lucide-play h-3.5 w-3.5"></span>
-                <span>预览</span>
-            </button>
-            <button v-if="!props.compileEnabled" class="toolbar-btn" :disabled="props.validating || !props.sourceText" @click="emit('validate')">
-                <span class="i-lucide-badge-check h-3.5 w-3.5"></span>
-                <span>{{ props.validateLabel ?? "验证" }}</span>
-            </button>
-            <button v-if="props.compileEnabled" class="toolbar-btn" :disabled="props.compiling || props.compilingAll || props.saving || props.parsingSource || !props.sourceText" @click="emit('compile')">
-                <span class="i-lucide-hammer h-3.5 w-3.5"></span>
-                <span>编译</span>
-            </button>
-            <button v-if="props.compileAllEnabled" class="toolbar-btn" :disabled="props.compilingAll || props.compiling || props.saving" @click="emit('compileAll')">
-                <span class="i-lucide-package-check h-3.5 w-3.5"></span>
-                <span>编译全部</span>
-            </button>
-            <button v-if="props.restoreEnabled" class="toolbar-btn" :disabled="props.restoring || props.saving || !props.sourceText" @click="emit('restore')">
-                <span class="i-lucide-rotate-ccw h-3.5 w-3.5"></span>
-                <span>恢复系统版本</span>
-            </button>
-            <button v-if="props.createEnabled" class="toolbar-btn" :disabled="props.saving" @click="emit('create')">
-                <span class="i-lucide-file-plus-2 h-3.5 w-3.5"></span>
-                <span>新建</span>
-            </button>
-            <button v-if="props.runEnabled" class="toolbar-btn" :disabled="props.saving || props.issueCount > 0 || props.runDisabled" @click="emit('run')">
-                <span class="i-lucide-message-circle-plus h-3.5 w-3.5"></span>
-                <span>创建 Session</span>
-            </button>
-            <button class="toolbar-btn primary" :disabled="props.saving || props.parsingSource || !props.sourceText || (!props.allowSaveWithIssues && props.issueCount > 0)" @click="emit('save')">
-                <span class="i-lucide-save h-3.5 w-3.5"></span>
-                <span>保存</span>
-                <span class="i-lucide-chevron-down h-3.5 w-3.5 opacity-80"></span>
-            </button>
-            <button v-if="props.closable" class="icon-btn" title="关闭" @click="emit('close')">
-                <span class="i-lucide-x h-4 w-4"></span>
-            </button>
+            <Tooltip text="撤销 Ctrl+Z" placement="bottom">
+                <button class="icon-btn" aria-label="撤销" :disabled="!props.canUndo" @click="emit('undo')">
+                    <span class="i-lucide-undo-2 h-4 w-4"></span>
+                </button>
+            </Tooltip>
+            <Tooltip text="重做 Ctrl+Shift+Z" placement="bottom">
+                <button class="icon-btn" aria-label="重做" :disabled="!props.canRedo" @click="emit('redo')">
+                    <span class="i-lucide-redo-2 h-4 w-4"></span>
+                </button>
+            </Tooltip>
+            <Tooltip text="预览" placement="bottom">
+                <button class="icon-btn" aria-label="预览" :disabled="props.previewing || !props.sourceText" @click="emit('preview')">
+                    <span class="i-lucide-play h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="!props.compileEnabled" :text="props.validateLabel ?? '验证'" placement="bottom">
+                <button class="icon-btn" aria-label="验证" :disabled="props.validating || !props.sourceText" @click="emit('validate')">
+                    <span class="i-lucide-badge-check h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.compileEnabled" text="编译" placement="bottom">
+                <button class="icon-btn" aria-label="编译" :disabled="props.compiling || props.compilingAll || props.saving || props.parsingSource || !props.sourceText" @click="emit('compile')">
+                    <span class="i-lucide-hammer h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.compileAllEnabled" text="编译全部" placement="bottom">
+                <button class="icon-btn" aria-label="编译全部" :disabled="props.compilingAll || props.compiling || props.saving" @click="emit('compileAll')">
+                    <span class="i-lucide-package-check h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.restoreEnabled" text="恢复系统版本" placement="bottom">
+                <button class="icon-btn" aria-label="恢复系统版本" :disabled="props.restoring || props.saving || !props.sourceText" @click="emit('restore')">
+                    <span class="i-lucide-rotate-ccw h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.createEnabled" text="新建" placement="bottom">
+                <button class="icon-btn" aria-label="新建" :disabled="props.saving" @click="emit('create')">
+                    <span class="i-lucide-file-plus-2 h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.runEnabled" text="创建 Session" placement="bottom">
+                <button class="icon-btn" aria-label="创建 Session" :disabled="props.saving || props.issueCount > 0 || props.runDisabled" @click="emit('run')">
+                    <span class="i-lucide-message-circle-plus h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip text="保存" placement="bottom">
+                <button class="icon-btn primary" aria-label="保存" :disabled="props.saving || props.parsingSource || !props.sourceText || (!props.allowSaveWithIssues && props.issueCount > 0)" @click="emit('save')">
+                    <span class="i-lucide-save h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.closable" text="关闭" placement="bottom">
+                <button class="icon-btn" aria-label="关闭" @click="emit('close')">
+                    <span class="i-lucide-x h-4 w-4"></span>
+                </button>
+            </Tooltip>
         </div>
     </header>
 </template>
 
 <style scoped>
-.toolbar-btn,
 .icon-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 6px;
     border: 1px solid var(--border-color);
     border-radius: 7px;
     background: var(--bg-input);
     color: var(--text-secondary);
     font-size: 12px;
+    height: 32px;
+    width: 32px;
     transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
 }
 
-.toolbar-btn {
-    height: 32px;
-    padding: 0 12px;
-}
-
-.toolbar-btn.primary {
+.icon-btn.primary {
     border-color: var(--accent-main);
     background: var(--accent-main);
-    color: white;
+    color: var(--text-inverse);
 }
 
-.icon-btn {
-    height: 32px;
-    width: 32px;
-}
-
-.toolbar-btn:hover:not(:disabled),
 .icon-btn:hover:not(:disabled) {
     background: var(--bg-hover);
     color: var(--text-main);
 }
 
-.toolbar-btn:disabled,
 .icon-btn:disabled {
     cursor: not-allowed;
     opacity: 0.45;

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateInspectorPanel.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateInspectorPanel.vue
@@ -253,7 +253,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     <!-- 右侧属性检查器：属性、变量、运行时变量 -->
     <section class="panel flex min-w-0 min-h-0 flex-1 flex-col overflow-hidden">
         <div class="mb-3 flex shrink-0 items-center gap-2 border-b border-[var(--border-color)]">
-            <div class="flex min-w-0 flex-1 overflow-x-auto custom-scrollbar">
+            <div class="flex min-w-0 flex-1 overflow-x-auto custom-scrollbar no-scrollbar">
                 <button
                     v-for="tab in props.tabs"
                     :key="tab.value"
@@ -269,7 +269,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
             </button>
         </div>
 
-        <div class="min-h-0 flex-1 overflow-auto pr-1 custom-scrollbar">
+        <div class="min-h-0 flex-1 overflow-auto pr-1 custom-scrollbar no-scrollbar">
             <div v-if="props.activeTab === 'source'" class="h-full min-h-[520px]">
                 <ProfileTemplateSourcePanel
                     :source-text="props.sourceText"
@@ -409,6 +409,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 </template>
 
 <style scoped>
+.no-scrollbar {
+    scrollbar-width: none;
+    scrollbar-color: transparent transparent;
+    -ms-overflow-style: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
+}
+
 .panel {
     border: 1px solid var(--border-color);
     border-radius: 8px;
@@ -419,8 +431,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 .panel-icon-btn {
     display: inline-flex;
-    height: 28px;
-    width: 28px;
+    height: 32px;
+    width: 32px;
     flex-shrink: 0;
     align-items: center;
     justify-content: center;

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateLibraryItem.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateLibraryItem.vue
@@ -40,7 +40,7 @@ const {isDragging} = useDraggable({
         </span>
         <span class="min-w-0 flex-1">
             <span class="block truncate text-xs font-semibold text-[var(--text-main)]">{{ props.label }}</span>
-            <span class="mt-1 block text-[11px] leading-4 text-[var(--text-muted)]">{{ props.description }}</span>
+            <span class="mt-1 block break-words text-[11px] leading-4 text-[var(--text-muted)]">{{ props.description }}</span>
         </span>
     </button>
 </template>

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateVisualEditor.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateVisualEditor.vue
@@ -12,6 +12,7 @@ import ProfileTemplateComponentLibraryPanel from "nbook/app/components/profile-t
 import ProfileTemplateHeader from "nbook/app/components/profile-template-editor/ProfileTemplateHeader.vue";
 import ProfileTemplateInspectorPanel from "nbook/app/components/profile-template-editor/ProfileTemplateInspectorPanel.vue";
 import ProfileTemplatePreviewDialog from "nbook/app/components/profile-template-editor/ProfileTemplatePreviewDialog.vue";
+import Tooltip from "nbook/app/components/common/Tooltip.vue";
 import {
     componentGroupTabs,
     componentLibrary,
@@ -75,6 +76,7 @@ import {
 } from "nbook/app/components/profile-template-editor/profile-template-tree-utils";
 import {buildNovelIdeClientVariables} from "nbook/app/components/novel-ide/agent/client-variables";
 import {useIdeTheme} from "nbook/app/composables/useIdeTheme";
+import {IDE_THEME_HOST_CLASS} from "nbook/app/utils/theme/theme-tokens";
 import {useAgentSessionApi} from "nbook/app/composables/useAgentSessionApi";
 import {useNotification} from "nbook/app/composables/useNotification";
 import {useNovelIdeStore} from "nbook/app/stores/novel-ide";
@@ -2159,7 +2161,11 @@ watch(selectedThreadId, async () => {
 });
 
 onMounted(async () => {
-    mountThemeHost(themeHostRef.value);
+    // 已处于既有主题宿主内（如工作台 Dialog 内嵌场景）时不重复创建嵌套宿主；
+    // 否则 Tooltip 等 fixed 浮层会被 Teleport 进 transform 容器内的嵌套宿主，fixed 定位基准失效。
+    if (!themeHostRef.value?.closest(`.${IDE_THEME_HOST_CLASS}`)) {
+        mountThemeHost(themeHostRef.value);
+    }
     keyboardListener = handleEditorKeydown;
     window.addEventListener("keydown", keyboardListener);
     await Promise.all([
@@ -2232,31 +2238,37 @@ onBeforeUnmount(() => {
             @drag-end="handleNodeDragEnd"
         >
             <main
-                class="grid min-h-0 flex-1 gap-3 p-3"
+                class="grid min-h-0 min-w-0 flex-1 gap-3 overflow-x-auto p-3"
                 :class="[
-                    libraryPanelCollapsed ? 'grid-cols-[42px_minmax(560px,1fr)_minmax(360px,30vw)]' : 'grid-cols-[290px_minmax(560px,1fr)_minmax(360px,30vw)]',
-                    inspectorPanelCollapsed ? (libraryPanelCollapsed ? '!grid-cols-[42px_minmax(560px,1fr)_42px]' : '!grid-cols-[290px_minmax(560px,1fr)_42px]') : '',
+                    libraryPanelCollapsed ? 'grid-cols-[52px_minmax(560px,1fr)_minmax(360px,30vw)]' : 'grid-cols-[290px_minmax(560px,1fr)_minmax(360px,30vw)]',
+                    inspectorPanelCollapsed ? (libraryPanelCollapsed ? '!grid-cols-[52px_minmax(560px,1fr)_52px]' : '!grid-cols-[290px_minmax(560px,1fr)_52px]') : '',
                 ]"
             >
             <aside v-if="libraryPanelCollapsed" class="component-rail">
-                <button type="button" class="rail-icon-btn" title="展开组件库" @click="libraryPanelCollapsed = false">
-                    <span class="i-lucide-panel-left-open h-4 w-4"></span>
-                </button>
+                <Tooltip text="展开组件库" placement="right">
+                    <button type="button" class="rail-icon-btn" @click="libraryPanelCollapsed = false">
+                        <span class="i-lucide-panel-left-open h-4 w-4"></span>
+                    </button>
+                </Tooltip>
                 <div class="rail-divider"></div>
-                <div class="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto overflow-x-hidden pr-0.5 custom-scrollbar">
+                <div class="component-rail-scroll custom-scrollbar">
                     <template v-for="group in compactComponentGroups" :key="group.group">
                         <div class="rail-group-divider" :title="group.label"></div>
-                        <button
+                        <Tooltip
                             v-for="item in group.items"
                             :key="item.type"
-                            type="button"
-                            class="rail-icon-btn"
-                            :class="`library-node-${item.type}`"
-                            :title="`${group.label} / ${item.label}：${item.description}`"
-                            @click="addNode(item.type)"
+                            :text="`${group.label} / ${item.label}：${item.description}`"
+                            placement="right"
                         >
-                            <span :class="item.iconClass" class="h-4 w-4"></span>
-                        </button>
+                            <button
+                                type="button"
+                                class="rail-icon-btn"
+                                :class="`library-node-${item.type}`"
+                                @click="addNode(item.type)"
+                            >
+                                <span :class="item.iconClass" class="h-4 w-4"></span>
+                            </button>
+                        </Tooltip>
                     </template>
                 </div>
             </aside>
@@ -2286,10 +2298,12 @@ onBeforeUnmount(() => {
             />
 
             <!-- 右侧源码、属性与变量面板 -->
-            <aside v-if="inspectorPanelCollapsed" class="panel-rail" title="展开右侧面板" @click="inspectorPanelCollapsed = false">
-                <span class="i-lucide-panel-right-open h-4 w-4"></span>
-                <span class="rail-label">面板</span>
-            </aside>
+            <Tooltip v-if="inspectorPanelCollapsed" text="展开右侧面板" placement="bottom">
+                <aside class="panel-rail" @click="inspectorPanelCollapsed = false">
+                    <span class="i-lucide-panel-right-open h-4 w-4"></span>
+                    <span class="rail-label">面板</span>
+                </aside>
+            </Tooltip>
             <aside v-else class="flex min-w-0 min-h-0 flex-col">
                 <ProfileTemplateInspectorPanel
                     v-model:active-tab="inspectorTab"
@@ -2401,16 +2415,17 @@ onBeforeUnmount(() => {
 <style scoped>
 .panel-rail {
     display: flex;
+    width: 100%;
     min-height: 0;
     cursor: pointer;
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
-    gap: 8px;
+    gap: 10px;
     border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border-radius: 10px;
     background: var(--bg-panel);
-    padding: 10px 6px;
+    padding: 14px 4px 12px;
     color: var(--text-muted);
     box-shadow: 0 16px 44px color-mix(in srgb, var(--shadow-color) 5%, transparent);
     transition: border-color 0.18s ease, background-color 0.18s ease, color 0.18s ease;
@@ -2418,15 +2433,38 @@ onBeforeUnmount(() => {
 
 .component-rail {
     display: flex;
+    width: 100%;
     min-height: 0;
     flex-direction: column;
     align-items: center;
     gap: 6px;
     border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border-radius: 10px;
     background: var(--bg-panel);
-    padding: 8px 5px;
+    padding: 8px 3px;
     box-shadow: 0 16px 44px color-mix(in srgb, var(--shadow-color) 5%, transparent);
+}
+
+.component-rail-scroll {
+    display: flex;
+    min-height: 0;
+    width: 100%;
+    flex: 1;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding-inline: 1px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    scrollbar-width: none;
+    scrollbar-color: transparent transparent;
+    -ms-overflow-style: none;
+}
+
+.component-rail-scroll::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
 }
 
 .rail-icon-btn {
@@ -2435,8 +2473,8 @@ onBeforeUnmount(() => {
     --component-border: color-mix(in srgb, var(--component-accent) 34%, var(--border-color));
     --component-icon-color: color-mix(in srgb, var(--component-accent) 80%, var(--text-main));
     display: inline-flex;
-    height: 30px;
-    width: 30px;
+    height: 28px;
+    width: 28px;
     flex-shrink: 0;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
Closes #124

## 范围内

- Agent Profile 工作台 6 个组件的 UI 体验修复（ProfileTemplateHeader / VisualEditor / InspectorPanel / LibraryItem / AgentProfileNavList / NovelIdeAgentProfileModelSettingsPanel）

## 用户可见结果

- 顶栏按钮图标化 + Tooltip（替代原生 title）；模板选择器宽度自适应，窄窗口不再挤压右侧按钮
- Profile 列表在栏内独立滚动，「默认设置」入口与搜索框常驻可见
- 折叠栏按钮 Tooltip 化、折叠窄轨加宽至 32px、内容区滚动条隐藏

## 技术实现

- 纯模板/样式改动（Vue SFC），无状态或接口变化
- 复用现有 `Tooltip` 组件与主题变量

## 验证

- `bun --cwd packages/neuro-book run typecheck` ✅（基线一致，无新增错误）
- `git diff --check` ✅
- 未运行浏览器人工验收（无截图）

## 范围外

- 不改动 Tooltip 组件本身（上游 `TooltipPlacement` 输入侧仅支持 right/bottom，原 fork 的 left placement 已适配为 bottom）
- 不涉及数据/配置/安全边界