### PR TITLE
fix: rescue first-tier changes from PR #108

### DIFF
--- a/packages/neuro-book/app/components/novel-ide/plot/thread-panel/PlotThreadScenePanel.vue
+++ b/packages/neuro-book/app/components/novel-ide/plot/thread-panel/PlotThreadScenePanel.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type {Data} from "@dnd-kit/abstract";
-import {defaultPreset} from "@dnd-kit/dom";
 import {move} from "@dnd-kit/helpers";
 import {DragDropProvider, KeyboardSensor, PointerSensor} from "@dnd-kit/vue";
 import type {DragDropProviderEmits} from "@dnd-kit/vue";
@@ -292,7 +291,6 @@ watch(() => [props.selectedThreadId, props.scenes], () => {
         <div class="min-h-0 flex-1 overflow-y-auto p-1.5 custom-scrollbar" @contextmenu.prevent="emit('openRootMenu', $event)">
             <DragDropProvider
                 v-if="renderedScenes.length"
-                :plugins="defaultPreset.plugins"
                 :sensors="dndSensors"
                 @drag-start="handleDragStart"
                 @drag-over="handleDragOver"

--- a/packages/neuro-book/app/components/novel-ide/plot/workbench/PlotWorkbenchSceneList.vue
+++ b/packages/neuro-book/app/components/novel-ide/plot/workbench/PlotWorkbenchSceneList.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type {Data} from "@dnd-kit/abstract";
-import {defaultPreset} from "@dnd-kit/dom";
 import {move} from "@dnd-kit/helpers";
 import {DragDropProvider, KeyboardSensor, PointerSensor} from "@dnd-kit/vue";
 import type {DragDropProviderEmits} from "@dnd-kit/vue";
@@ -385,7 +384,6 @@ watch(() => props.thread?.id, () => {
         <section class="mt-3">
             <DragDropProvider
                 v-if="renderedScenes.length"
-                :plugins="defaultPreset.plugins"
                 :sensors="dndSensors"
                 @drag-start="handleSceneDragStart"
                 @drag-over="handleSceneDragOver"

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateVisualEditor.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateVisualEditor.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type {Data} from "@dnd-kit/abstract";
-import {defaultPreset} from "@dnd-kit/dom";
 import {DragDropProvider, KeyboardSensor, PointerSensor} from "@dnd-kit/vue";
 import type {DragDropProviderEmits} from "@dnd-kit/vue";
 import Dialog from "nbook/app/components/common/Dialog.vue";
@@ -2225,7 +2224,6 @@ onBeforeUnmount(() => {
         />
 
         <DragDropProvider
-            :plugins="defaultPreset.plugins"
             :sensors="dndSensors"
             @drag-start="handleNodeDragStart"
             @drag-over="handleNodeDragOver"

--- a/packages/neuro-book/nuxt.config.ts
+++ b/packages/neuro-book/nuxt.config.ts
@@ -1,5 +1,5 @@
 import {fileURLToPath} from "node:url";
-import {resolve} from "node:path";
+import {join, resolve} from "node:path";
 import {
     isProductRuntimeIslandModule,
     productRuntimeIslandPackageNames,
@@ -51,6 +51,9 @@ export default defineNuxtConfig({
         nbook: rootDir,
     },
     vite: {
+        cacheDir: process.env.NEURO_BOOK_CACHE_ROOT?.trim()
+            ? join(process.env.NEURO_BOOK_CACHE_ROOT.trim(), "vite")
+            : undefined,
         server: {
             watch: {
                 ignored: runtimeWorkspaceWatchIgnore,

--- a/scripts/deploy/product-runtime-cleanup.test.ts
+++ b/scripts/deploy/product-runtime-cleanup.test.ts
@@ -1,0 +1,124 @@
+import {existsSync} from "node:fs";
+import {spawnSync} from "node:child_process";
+import {mkdir, mkdtemp, rm, writeFile} from "node:fs/promises";
+import {tmpdir} from "node:os";
+import {join, resolve} from "node:path";
+import {lock as acquireFileLock, unlock as releaseFileLock} from "proper-lockfile";
+import {afterEach, describe, expect, it} from "vitest";
+
+const repositoryRoot = resolve(import.meta.dirname, "..", "..");
+const scriptPath = resolve(repositoryRoot, "scripts", "deploy", "product-runtime.mjs");
+const ACCEPTANCE_OWNER = "nbook.product-runtime-acceptance";
+const OWNER_FILE = ".nbook-product-acceptance.json";
+const LEASE_FILE = ".nbook-product-acceptance-lease";
+const POINTER_FILE = "current.json";
+
+type CleanupResult = {
+    status: number | null;
+    stdout: string;
+    stderr: string;
+};
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+    const tempRoot = await mkdtemp(join(tmpdir(), "nbook-cleanup-"));
+    tempRoots.push(tempRoot);
+    return tempRoot;
+}
+
+function spawnCleanup(tempRoot: string, operationId: string): CleanupResult {
+    const result = spawnSync("bun", [scriptPath, "cleanup", operationId], {
+        cwd: repositoryRoot,
+        encoding: "utf8",
+        env: {...process.env, NBOOK_AGENT_TEMP_ROOT: tempRoot},
+    });
+    return {status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? ""};
+}
+
+async function writeStageFixture(
+    acceptanceRoot: string,
+    operationId: string,
+    ownerOperationId: string = operationId,
+): Promise<string> {
+    const stageRoot = join(acceptanceRoot, operationId);
+    await mkdir(stageRoot, {recursive: true});
+    await writeFile(
+        join(stageRoot, OWNER_FILE),
+        JSON.stringify({owner: ACCEPTANCE_OWNER, schema: 1, operationId: ownerOperationId}),
+    );
+    await writeFile(
+        join(acceptanceRoot, POINTER_FILE),
+        JSON.stringify({owner: ACCEPTANCE_OWNER, schema: 1, operationId: ownerOperationId, path: stageRoot}),
+    );
+    return stageRoot;
+}
+
+afterEach(async () => {
+    while (tempRoots.length > 0) {
+        const tempRoot = tempRoots.pop();
+        if (tempRoot) await rm(tempRoot, {recursive: true, force: true});
+    }
+});
+
+describe("Product 验收 cleanup 命令合同", () => {
+    it("stage 不存在时输出 already-cleaned 并成功退出", async () => {
+        const tempRoot = await makeTempRoot();
+        const result = spawnCleanup(tempRoot, "opmissing1");
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toBe("Product runtime cleanup: already-cleaned\n");
+    });
+
+    it("拒绝路径逃逸的 operation ID 且不以零退出", async () => {
+        const tempRoot = await makeTempRoot();
+        const result = spawnCleanup(tempRoot, "../escape");
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("operation ID 无效");
+    });
+
+    it("owner 与 operation ID 匹配时删除 stage 并清理匹配 pointer", async () => {
+        const tempRoot = await makeTempRoot();
+        const acceptanceRoot = join(tempRoot, "acceptance", "product-runtime");
+        const stageRoot = await writeStageFixture(acceptanceRoot, "opok1");
+
+        const result = spawnCleanup(tempRoot, "opok1");
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toBe("Product runtime cleanup: cleaned\n");
+        expect(existsSync(stageRoot)).toBe(false);
+        expect(existsSync(join(acceptanceRoot, POINTER_FILE))).toBe(false);
+    });
+
+    it("owner operation ID 不匹配时拒绝删除并保留 stage", async () => {
+        const tempRoot = await makeTempRoot();
+        const acceptanceRoot = join(tempRoot, "acceptance", "product-runtime");
+        const stageRoot = await writeStageFixture(acceptanceRoot, "opmis1", "other9");
+
+        const result = spawnCleanup(tempRoot, "opmis1");
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("operation ID 不匹配");
+        expect(existsSync(stageRoot)).toBe(true);
+    });
+
+    it("活动 lease 持有时拒绝删除并保留 stage", async () => {
+        const tempRoot = await makeTempRoot();
+        const acceptanceRoot = join(tempRoot, "acceptance", "product-runtime");
+        const stageRoot = await writeStageFixture(acceptanceRoot, "oplease1");
+        await writeFile(join(stageRoot, LEASE_FILE), "");
+        const leasePath = join(stageRoot, LEASE_FILE);
+        const release = await acquireFileLock(leasePath, {update: null, stale: 3_600_000});
+
+        try {
+            const result = spawnCleanup(tempRoot, "oplease1");
+
+            expect(result.status).not.toBe(0);
+            expect(result.stderr).toContain("lease");
+            expect(existsSync(stageRoot)).toBe(true);
+        } finally {
+            await releaseFileLock(leasePath, release);
+        }
+    });
+});

--- a/scripts/deploy/product-runtime.mjs
+++ b/scripts/deploy/product-runtime.mjs
@@ -27,6 +27,8 @@ if (command === "stage") {
     await runAcceptedCommand("start", process.argv.slice(3));
 } else if (command === "create-admin") {
     await runAcceptedCommand("create-admin", process.argv.slice(3));
+} else if (command === "cleanup") {
+    await cleanupProduct(process.argv[3] ?? process.env.NEURO_BOOK_PRODUCT_OPERATION_ID ?? "");
 } else {
     throw new Error(`未知 product runtime 命令：${command}`);
 }
@@ -200,6 +202,56 @@ function requestedOperationId() {
         throw new Error(`Product 验收 operation ID 无效：${JSON.stringify(operationId)}`);
     }
     return operationId;
+}
+
+/**
+ * 只清理本模块创建、operation 匹配且当前没有 lease 的验收 stage。
+ * 缺少 owner 等同于 already-cleaned；未知 owner、路径逃逸或活动 lease 均拒绝删除。
+ */
+async function cleanupProduct(operationId) {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(operationId) || operationId === "." || operationId === "..") {
+        throw new Error(`Product 验收 cleanup operation ID 无效：${JSON.stringify(operationId)}`);
+    }
+    const stageRoot = resolveStageRoot(operationId);
+    if (!existsSync(stageRoot)) {
+        console.log("Product runtime cleanup: already-cleaned");
+        return;
+    }
+    let owner;
+    try {
+        owner = JSON.parse(await readFile(resolve(stageRoot, OWNER_FILE), "utf8"));
+    } catch (error) {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+            console.log("Product runtime cleanup: already-cleaned");
+            return;
+        }
+        throw new Error(`Product 验收 cleanup owner 无法读取：${String(error)}`);
+    }
+    if (!owner || typeof owner !== "object"
+        || owner.owner !== ACCEPTANCE_OWNER || owner.schema !== ACCEPTANCE_SCHEMA
+        || typeof owner.operationId !== "string") {
+        throw new Error("Product 验收 cleanup 拒绝未知 owner。");
+    }
+    if (owner.operationId !== operationId) throw new Error("Product 验收 cleanup operation ID 不匹配。");
+    assertContained(ACCEPTANCE_ROOT, stageRoot, "Product 验收 cleanup 目录");
+    if (await checkLock(resolve(stageRoot, LEASE_FILE), {realpath: false})) {
+        throw new Error("Product 验收 cleanup 拒绝删除仍被 lease 持有的 stage。");
+    }
+    await rm(stageRoot, {recursive: true, force: true});
+
+    try {
+        const pointer = JSON.parse(await readFile(ACCEPTANCE_POINTER, "utf8"));
+        if (pointer && typeof pointer === "object"
+            && pointer.owner === ACCEPTANCE_OWNER
+            && pointer.schema === ACCEPTANCE_SCHEMA
+            && pointer.operationId === operationId) {
+            const pointerPath = typeof pointer.path === "string" ? resolve(REPO_ROOT, pointer.path) : null;
+            if (pointerPath && pointerPath === stageRoot) await rm(ACCEPTANCE_POINTER, {force: true});
+        }
+    } catch (error) {
+        if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+    }
+    console.log("Product runtime cleanup: cleaned");
 }
 
 function resolveStageRoot(operationId) {


### PR DESCRIPTION
## 来源

PR #108 经深审判定 Request changes 并关闭（原因见其关闭评论）。本 PR 只保留其中经审查确认有效的第一档三项；supervisor 与 research-run 合同待有真实消费者后重新立项。

## 改动

1. **dnd-kit 双副本修复**（3 个正式组件，各删 2 行）：`@dnd-kit/vue` 自带 `@dnd-kit/dom`，外部 import 根提升副本的 `defaultPreset` 传入 DragDropProvider 会在 Vite 预打包下产生两个 Scroller 类实例导致拖拽初始化失败。移除后 provider 使用内置 preset。`.preview` 页面未动（待删资产）。
2. **product stage cleanup 子命令**（`scripts/deploy/product-runtime.mjs`）：`cleanup <operationId>` 仅清理 owner 匹配、无 lease 的验收 stage；owner 缺失视为 already-cleaned，未知/不匹配 owner、路径逃逸、活动 lease 一律拒绝。附聚焦行为测试（5 用例：missing / 非法 ID / 匹配删除+pointer 清理 / owner 不匹配拒绝 / 活动 lease 拒绝，经 `NBOOK_AGENT_TEMP_ROOT` 隔离根 + proper-lockfile 持锁验证真实副作用）。
3. **vite cacheDir 隔离**（nuxt.config.ts）：沿用既有 `NEURO_BOOK_CACHE_ROOT` 约定，并行任务缓存互不踩踏。

## 本地验证

- `node --check scripts/deploy/product-runtime.mjs` 通过
- `bun x vitest run --config scripts/vitest.config.ts scripts/deploy/product-runtime-cleanup.test.ts`：5 passed
- 既有合同回归 `scripts/build/product-runtime-contract.test.ts`：2 passed
- `bun run --cwd packages/neuro-book typecheck` 改动前后 TS 错误集合逐行一致（7 个既有 Prisma 生成物缺失诊断，零新增）
- **运行时浏览器冒烟：已尝试但返回 Nuxt 500，断言未完成**。dev server 启动后访问 `/plot-workbench.preview` 即收到 500——根因是 Source Dev 挂接的用户级 Agent Session Store `runtime.lease` 被另一 NeuroBook 运行实例持有（ELOCKED）；改用隔离 `NEURO_BOOK_STATE_ROOT` 重启后仍命中同一 lease 路径，且空 State Root 缺 SQLite 迁移初始化，遂中止。非 dnd-kit 错误；修复机制另有 PR #108 分支上的真实预览 smoke 记录佐证。

## CI 状态（run 32751466455 / 32751466476）

- ✅ Typecheck、Governance and repository contracts、Community files and docs
- ❌ Full tests 与四平台 Product 构建——**全部归属 Issue #163 登记的既有失败**（#122 合并后引入，与本 PR 三项改动无接触面）：
  - macOS Product：`NBOOK_AGENT_TEMP_ROOT 不能经过 symlink/reparse point`（/var → /private/var 误杀，#163 第 3 类）
  - linux Product：owned-process mkdtemp ENOENT（resolveAgentTempRoot 漂移，#163 第 2 类）
  - Full tests：harness black-box / project-session-hmr 等 36 失败（#163 第 1 类）
- 前向修复已在 `fix/i163-ci-forward-fixes` 进行；建议该 Issue 关闭后在本 PR 重跑确认，再行合并。

## 披露

- Product Runtime 属 docs/specs P0「未汇成当前规范」域；本 PR 未新写 spec，cleanup 行为合同以上述聚焦测试为准。
- `.preview` 页面生产暴露问题（pages 目录自动成路由、无 routeRules 排除、auth 关闭放行）建议另立 task。