### PR TITLE
fix: restore hosted CI green after #122 (issue #163)

### DIFF
--- a/.github/workflows/desktop-envelope-contract.yml
+++ b/.github/workflows/desktop-envelope-contract.yml
@@ -39,6 +39,10 @@ jobs:
           - platform: macos-arm64
             runner: macos-15
     runs-on: ${{ matrix.runner }}
+    env:
+      # bun 在 Windows 上偶发 EEXIST: failed copying files from cache；
+      # 每次 run 使用独立缓存目录，消除跨 run 缓存复制的竞争与脏状态。
+      BUN_INSTALL_CACHE_DIR: ${{ github.workspace }}/.bun-install-cache
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/desktop-envelope-contract.yml
+++ b/.github/workflows/desktop-envelope-contract.yml
@@ -46,7 +46,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile --linker hoisted
+      - name: Install dependencies
+        # bun 在 Windows hoisted 模式下偶发 EEXIST 缓存复制竞争，重试两次通常可过。
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile --linker hoisted; then exit 0; fi
+            echo "bun install failed (attempt ${attempt}/3)"; sleep 15
+          done
+          exit 1
       - name: Verify Desktop contracts
         run: bun run test:desktop-contract
       - name: Verify Manager type contracts

--- a/.github/workflows/workspace-packages.yml
+++ b/.github/workflows/workspace-packages.yml
@@ -66,6 +66,14 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile --linker hoisted
+      - name: Install llmlint web island dependencies
+        if: matrix.name == 'llmlint'
+        working-directory: packages/llmlint/web
+        run: bun install --frozen-lockfile
+      - name: Prepare llmlint Nuxt types
+        if: matrix.name == 'llmlint'
+        working-directory: packages/llmlint/web
+        run: bunx nuxt prepare
       - name: Run package checks
         working-directory: ${{ matrix.directory }}
         run: ${{ matrix.commands }}

--- a/packages/neuro-book-contracts/src/product-runtime/image-contract.ts
+++ b/packages/neuro-book-contracts/src/product-runtime/image-contract.ts
@@ -159,7 +159,8 @@ const PRODUCT_RUNTIME_OWNERS: readonly ProductRuntimeImageOwner[] = [
     {name: "runtime-meta", paths: ["nitro.json", "server/package.json", "server/runtime-contract.json"]},
 ] as const;
 
-// 2026-08-20：Reference 书架归位后在当前 Windows Source 上重新完成 Product measurement；其余平台 baseline 保留各自最近一次已审查值。
+// 2026-08-24：t135 资产安装 runtime 落地后 system-assets 全平台同源增长（442 files）；
+// Windows 行尾差异使 bytes 略高，POSIX 与 darwin 实测均为 5_856_353。
 const PRODUCT_RUNTIME_OWNER_BASELINES: Partial<Record<ProductPlatform, readonly ProductRuntimeOwnerBaseline[]>> = {
     "windows-x64": [
         {name: "frontend", files: 177, bytes: 15_272_680},
@@ -176,7 +177,7 @@ const PRODUCT_RUNTIME_OWNER_BASELINES: Partial<Record<ProductPlatform, readonly 
         {name: "commands", files: 116, bytes: 10_866_185},
         {name: "authoring-kit", files: 509, bytes: 14_475_922},
         {name: "native-islands", files: 2_062, bytes: 75_144_692},
-        {name: "system-assets", files: 373, bytes: 5_229_844},
+        {name: "system-assets", files: 442, bytes: 5_856_353},
         {name: "runtime-meta", files: 3, bytes: 4_762},
     ],
     "linux-aarch64-glibc": [
@@ -185,7 +186,7 @@ const PRODUCT_RUNTIME_OWNER_BASELINES: Partial<Record<ProductPlatform, readonly 
         {name: "commands", files: 116, bytes: 10_866_185},
         {name: "authoring-kit", files: 509, bytes: 14_475_922},
         {name: "native-islands", files: 2_062, bytes: 72_567_998},
-        {name: "system-assets", files: 373, bytes: 5_229_844},
+        {name: "system-assets", files: 442, bytes: 5_856_353},
         {name: "runtime-meta", files: 3, bytes: 4_762},
     ],
     "darwin-x64": [
@@ -194,7 +195,7 @@ const PRODUCT_RUNTIME_OWNER_BASELINES: Partial<Record<ProductPlatform, readonly 
         {name: "commands", files: 116, bytes: 10_866_185},
         {name: "authoring-kit", files: 509, bytes: 14_475_922},
         {name: "native-islands", files: 2_062, bytes: 75_913_156},
-        {name: "system-assets", files: 373, bytes: 5_229_844},
+        {name: "system-assets", files: 442, bytes: 5_856_353},
         {name: "runtime-meta", files: 3, bytes: 4_762},
     ],
     "darwin-aarch64": [
@@ -203,7 +204,7 @@ const PRODUCT_RUNTIME_OWNER_BASELINES: Partial<Record<ProductPlatform, readonly 
         {name: "commands", files: 116, bytes: 10_866_185},
         {name: "authoring-kit", files: 509, bytes: 14_475_922},
         {name: "native-islands", files: 2_062, bytes: 71_965_408},
-        {name: "system-assets", files: 373, bytes: 5_229_844},
+        {name: "system-assets", files: 442, bytes: 5_856_353},
         {name: "runtime-meta", files: 3, bytes: 4_762},
     ],
 };

--- a/packages/neuro-book-manager/package.json
+++ b/packages/neuro-book-manager/package.json
@@ -17,6 +17,7 @@
         "./schema": "./dist/schema.mjs",
         "./runtime-projection": {
             "types": "./src/runtime-projection.ts",
+            "bun": "./src/runtime-projection.ts",
             "import": "./dist/runtime-projection.mjs",
             "default": "./dist/runtime-projection.mjs"
         },

--- a/packages/neuro-book-test-support/src/paths.ts
+++ b/packages/neuro-book-test-support/src/paths.ts
@@ -160,19 +160,16 @@ function canonicalPath(pathValue: string, label: string): string {
             existing = parent;
         }
     }
-    let ancestor = existing;
-    while (true) {
-        let stats;
-        try {
-            stats = lstatSync(ancestor);
-        } catch {
-            throw new Error(`${label} 无法证明路径安全：${absolute}`);
-        }
-        if (stats.isSymbolicLink()) throw new Error(`${label} 不能经过 symlink/reparse point：${absolute}`);
-        const parent = dirname(ancestor);
-        if (parent === ancestor) break;
-        ancestor = parent;
+    let stats;
+    try {
+        stats = lstatSync(existing);
+    } catch {
+        throw new Error(`${label} 无法证明路径安全：${absolute}`);
     }
+    // 仅拒绝「已存在锚点自身」是 symlink/junction：祖先链允许系统级链接
+    //（macOS 的 /var -> /private/var、Windows 用户目录 junction），逃逸防护
+    // 由下方 realpath(existing)+lexical suffix 与 assertContained 的双 realpath 比较承担。
+    if (stats.isSymbolicLink()) throw new Error(`${label} 不能经过 symlink/reparse point：${absolute}`);
     let canonicalExisting: string;
     try {
         canonicalExisting = realpathSync.native(existing);

--- a/packages/neuro-book-test-support/src/vitest.ts
+++ b/packages/neuro-book-test-support/src/vitest.ts
@@ -4,6 +4,7 @@ import {join} from "node:path";
 import {
     resolveAgentTempRoot,
     resolveAgentTestRoot,
+    resolveSystemTempRoot,
 } from "./paths";
 import {TEST_HOST_PATHS_DIR} from "./test-path";
 import {TEST_RUN_ID_ENV} from "./process";
@@ -20,6 +21,9 @@ configureWorkerTempRoot();
 
 /** Vitest globalSetup：建立 run id，并回收超时的旧 run 根。 */
 export async function setup(): Promise<void> {
+    // Worker 会把 TMPDIR/TEMP/TMP 改写到 run 根；必须先固定宿主锚点，
+    // 否则 worker 内 resolveAgentTempRoot() 漂移到 run 根，testHostPath() 指向未创建的 test-paths。
+    process.env.NBOOK_HOST_SYSTEM_TEMP_ROOT ??= resolveSystemTempRoot();
     const runId = process.env[TEST_RUN_ID_ENV] ?? randomBytes(4).toString("hex");
     process.env[TEST_RUN_ID_ENV] = runId;
     const root = resolveAgentTestRoot(runId);

--- a/packages/neuro-book-test-support/tests/paths.test.ts
+++ b/packages/neuro-book-test-support/tests/paths.test.ts
@@ -1,7 +1,8 @@
-import {mkdtemp, rm, symlink} from "node:fs/promises";
+import {mkdir, mkdtemp, rm, symlink} from "node:fs/promises";
 import {join, resolve} from "node:path";
 import {
     AGENT_PATH_LENGTH_LIMIT,
+    assertContained,
     resolveAgentAcceptanceRoot,
     resolveAgentCacheRoot,
     resolveAgentFixtureRoot,
@@ -53,6 +54,30 @@ describe("Agent 路径解析", () => {
             }))).toThrow(/symlink\/reparse|受控根/u);
         } finally {
             await rm(parent, {recursive: true, force: true});
+        }
+    });
+
+    it("允许系统级 symlink/junction 祖先；锚点自身为链接仍拒绝，逃逸仍阻断", async () => {
+        const hostRoot = resolveSystemTempRoot(env());
+        const realParent = await mkdtemp(join(hostRoot, "neuro-book-canonical-"));
+        const realRoot = join(realParent, "real-root");
+        const linkRoot = join(realParent, "link-root");
+        await mkdir(realRoot);
+        await symlink(realRoot, linkRoot, process.platform === "win32" ? "junction" : "dir");
+        const leaf = join(linkRoot, "mid", "leaf");
+        try {
+            await mkdir(leaf, {recursive: true});
+            // macOS /var -> /private/var 场景：祖先链含系统级链接时必须放行。
+            expect(() => assertContained(leaf, join(leaf, "kept"), "probe")).not.toThrow();
+            expect(() => assertContained(join(linkRoot, "mid"), leaf, "probe")).not.toThrow();
+            // 锚点自身是 symlink/junction 仍然拒绝。
+            expect(() => assertContained(linkRoot, leaf, "probe")).toThrow(/symlink\/reparse/u);
+            // 逃逸到真实父目录下、链接路径之外的目标必须阻断。
+            const escapee = join(realParent, "escaped");
+            await mkdir(escapee);
+            expect(() => assertContained(leaf, escapee, "probe")).toThrow("受控根内");
+        } finally {
+            await rm(realParent, {recursive: true, force: true});
         }
     });
 

--- a/packages/neuro-book/server/agent/harness/file-change-reminder.test.ts
+++ b/packages/neuro-book/server/agent/harness/file-change-reminder.test.ts
@@ -3,6 +3,7 @@ import {mkdir, rm} from "node:fs/promises";
 import {join} from "node:path";
 import { testHostPath } from "@notnotype/neuro-book-test-support/test-path"
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
+import {createVariableDefinitionArtifactPathContextResolver} from "nbook/server/agent/variables/definition-artifact";
 import {fauxAssistantMessage} from "@earendil-works/pi-ai";
 import {createFauxModels, type FauxModelsFixture, writeFauxProviderConfig} from "nbook/server/agent/test-utils/faux-models";
 import {Type} from "typebox";
@@ -389,6 +390,7 @@ describe("file-change notice 端到端（FauxProvider 黑盒）", () => {
             repo: new JsonlSessionRepository(agentRoot),
             modelResolver: () => faux.getModel(),
             runtimeResolver: () => faux.runtime,
+            definitionArtifactPathContextProvider: createVariableDefinitionArtifactPathContextResolver(workspaceRoot),
             enableSessionSummarizer: false,
         });
     });

--- a/packages/neuro-book/server/agent/harness/neuro-agent-harness.black-box.test.ts
+++ b/packages/neuro-book/server/agent/harness/neuro-agent-harness.black-box.test.ts
@@ -5,6 +5,7 @@ import {join, resolve} from "node:path";
 import {afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
 import {fauxAssistantMessage, fauxText, fauxToolCall} from "@earendil-works/pi-ai";
 import {createFauxModels, type FauxModelsFixture, writeFauxProviderConfig} from "nbook/server/agent/test-utils/faux-models";
+import {createVariableDefinitionArtifactPathContextResolver} from "nbook/server/agent/variables/definition-artifact";
 import {Type} from "typebox";
 import {NeuroAgentHarness} from "nbook/server/agent/harness/neuro-agent-harness";
 import type {AgentInvocationResult} from "nbook/server/agent/harness/types";
@@ -231,6 +232,7 @@ describe("NeuroAgentHarness black-box contract", () => {
             ),
             modelResolver: () => faux.getModel(),
             runtimeResolver: () => faux.runtime,
+            definitionArtifactPathContextProvider: createVariableDefinitionArtifactPathContextResolver(root),
             enableSessionSummarizer: false,
         });
     });

--- a/packages/neuro-book/server/agent/observability/context-inspection.test.tsx
+++ b/packages/neuro-book/server/agent/observability/context-inspection.test.tsx
@@ -11,6 +11,7 @@ import {randomUUID} from "node:crypto";
 import {rm} from "node:fs/promises";
 import {join, resolve} from "node:path";
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
+import {createVariableDefinitionArtifactPathContextResolver} from "nbook/server/agent/variables/definition-artifact";
 import {fauxAssistantMessage} from "@earendil-works/pi-ai";
 import {createFauxModels, type FauxModelsFixture, writeFauxProviderConfig} from "nbook/server/agent/test-utils/faux-models";
 import {Type} from "typebox";
@@ -56,6 +57,7 @@ describe("getSessionContextInspection", () => {
             ),
             modelResolver: () => faux.getModel(),
             runtimeResolver: () => faux.runtime,
+            definitionArtifactPathContextProvider: createVariableDefinitionArtifactPathContextResolver(root),
             enableSessionSummarizer: false,
         });
         harness.profiles.register(defineAgentProfile({

--- a/packages/neuro-book/server/agent/observability/harness-trace-segments.test.tsx
+++ b/packages/neuro-book/server/agent/observability/harness-trace-segments.test.tsx
@@ -12,6 +12,7 @@ import {randomUUID} from "node:crypto";
 import {readFile, readdir, rm} from "node:fs/promises";
 import {join, resolve} from "node:path";
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
+import {createVariableDefinitionArtifactPathContextResolver} from "nbook/server/agent/variables/definition-artifact";
 import {fauxAssistantMessage} from "@earendil-works/pi-ai";
 import {createFauxModels, type FauxModelsFixture, writeFauxProviderConfig} from "nbook/server/agent/test-utils/faux-models";
 import {Type} from "typebox";
@@ -58,6 +59,7 @@ describe("上下文分区归因 → trace segments", () => {
             ),
             modelResolver: () => faux.getModel(),
             runtimeResolver: () => faux.runtime,
+            definitionArtifactPathContextProvider: createVariableDefinitionArtifactPathContextResolver(root),
             enableSessionSummarizer: false,
         });
     });

--- a/packages/neuro-book/server/agent/observability/harness-trace.test.ts
+++ b/packages/neuro-book/server/agent/observability/harness-trace.test.ts
@@ -7,6 +7,7 @@ import {fauxAssistantMessage} from "@earendil-works/pi-ai";
 import {createFauxModels, type FauxModelsFixture, writeFauxProviderConfig} from "nbook/server/agent/test-utils/faux-models";
 import {Type} from "typebox";
 import {NeuroAgentHarness} from "nbook/server/agent/harness/neuro-agent-harness";
+import {createVariableDefinitionArtifactPathContextResolver} from "nbook/server/agent/variables/definition-artifact";
 import {JsonlSessionRepository} from "nbook/server/agent/session/session-repo";
 import {defineAgentProfile} from "nbook/server/agent/profiles/define-agent-profile";
 import {profileToolsFromKeys} from "nbook/server/agent/test/profile-tools";
@@ -48,6 +49,7 @@ describe("harness → pi trace 集成", () => {
             ),
             modelResolver: () => faux.getModel(),
             runtimeResolver: () => faux.runtime,
+            definitionArtifactPathContextProvider: createVariableDefinitionArtifactPathContextResolver(root),
             enableSessionSummarizer: false,
         });
     });

--- a/packages/neuro-book/server/api/agent/profiles/compile.post.test.ts
+++ b/packages/neuro-book/server/api/agent/profiles/compile.post.test.ts
@@ -1,3 +1,6 @@
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+
 import {beforeEach, describe, expect, it, vi} from "vitest";
 
 describe("POST /api/agent/profiles/compile", () => {
@@ -7,7 +10,8 @@ describe("POST /api/agent/profiles/compile", () => {
         vi.stubGlobal("defineEventHandler", (handler: unknown) => handler);
     });
 
-    it("preview 触发 Project lifecycle error 时返回稳定 PROJECT_NOT_OPEN", async () => {
+    // project-session-service 的动态导入链冷加载较慢，显式放宽以避免误报超时。
+    it("preview 触发 Project lifecycle error 时返回稳定 PROJECT_NOT_OPEN", {timeout: 30_000}, async () => {
         vi.doMock("nbook/server/utils/novel-chapter", () => ({
             validateBody: vi.fn(async () => ({
                 fileName: "builtin/writer.profile.tsx",
@@ -16,9 +20,22 @@ describe("POST /api/agent/profiles/compile", () => {
                 sessionId: "7",
             })),
         }));
-        vi.doMock("nbook/server/agent/http", () => ({
-            useAgentHarness: vi.fn(() => ({profiles: {}})),
-        }));
+        // vi.doMock 必须先注册、再动态加载被测模块才能生效（模块加载边界测试）。
+        vi.doMock("nbook/server/agent/http", async () => {
+            // t135 起 API 合同要求显式 RuntimePaths；fixture 越过守卫，
+            // 才能到达本测试针对的 Project lifecycle error 映射点。
+            const {createRuntimePaths} = await import("nbook/server/runtime/paths/runtime-paths");
+            const {absoluteFsPath} = await import("nbook/server/runtime/paths/file-path");
+            return {
+                useAgentHarness: vi.fn(() => ({
+                    profiles: {},
+                    runtimePaths: createRuntimePaths({
+                        applicationRoot: absoluteFsPath(join(tmpdir(), "nbook-profile-compile-mock", "app")),
+                        stateRoot: absoluteFsPath(join(tmpdir(), "nbook-profile-compile-mock", "state")),
+                    }),
+                })),
+            };
+        });
         vi.doMock("nbook/server/agent/profiles/profile-compile-worker", () => ({
             useProfileCompileWorker: vi.fn(() => ({
                 compile: vi.fn(async () => ({

--- a/packages/neuro-book/server/api/agent/profiles/preview-prepare.post.test.ts
+++ b/packages/neuro-book/server/api/agent/profiles/preview-prepare.post.test.ts
@@ -1,3 +1,6 @@
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+
 import {beforeEach, describe, expect, it, vi} from "vitest";
 
 describe("POST /api/agent/profiles/preview-prepare", () => {
@@ -7,7 +10,8 @@ describe("POST /api/agent/profiles/preview-prepare", () => {
         vi.stubGlobal("defineEventHandler", (handler: unknown) => handler);
     });
 
-    it("sourceOverride worker preview 触发 Project lifecycle error 时返回稳定 PROJECT_NOT_OPEN", async () => {
+    // project-session-service 的动态导入链冷加载较慢，显式放宽以避免误报超时。
+    it("sourceOverride worker preview 触发 Project lifecycle error 时返回稳定 PROJECT_NOT_OPEN", {timeout: 30_000}, async () => {
         vi.doMock("nbook/server/utils/novel-chapter", () => ({
             validateBody: vi.fn(async () => ({
                 profileKey: "writer",
@@ -18,9 +22,22 @@ describe("POST /api/agent/profiles/preview-prepare", () => {
                 },
             })),
         }));
-        vi.doMock("nbook/server/agent/http", () => ({
-            useAgentHarness: vi.fn(() => ({profiles: {}})),
-        }));
+        // vi.doMock 必须先注册、再动态加载被测模块才能生效（模块加载边界测试）。
+        vi.doMock("nbook/server/agent/http", async () => {
+            // t135 起 sourceOverride 分支要求显式 RuntimePaths；fixture 越过守卫，
+            // 才能到达本测试针对的 worker Project lifecycle error 映射点。
+            const {createRuntimePaths} = await import("nbook/server/runtime/paths/runtime-paths");
+            const {absoluteFsPath} = await import("nbook/server/runtime/paths/file-path");
+            return {
+                useAgentHarness: vi.fn(() => ({
+                    profiles: {},
+                    runtimePaths: createRuntimePaths({
+                        applicationRoot: absoluteFsPath(join(tmpdir(), "nbook-profile-preview-mock", "app")),
+                        stateRoot: absoluteFsPath(join(tmpdir(), "nbook-profile-preview-mock", "state")),
+                    }),
+                })),
+            };
+        });
         vi.doMock("nbook/server/agent/profiles/profile-http-service", () => ({
             previewAgentProfilePrepare: vi.fn(),
         }));
@@ -28,7 +45,7 @@ describe("POST /api/agent/profiles/preview-prepare", () => {
             const {ProjectNotOpenError} = await import("nbook/server/workspace-files/project-session-service");
             return {
                 useProfileCompileWorker: vi.fn(() => ({
-                compile: vi.fn(async () => {
+                    compile: vi.fn(async () => {
                         throw new ProjectNotOpenError("profile-preview-not-open");
                     }),
                 })),

--- a/packages/neuro-book/server/workspace-files/project-session-hmr.test.ts
+++ b/packages/neuro-book/server/workspace-files/project-session-hmr.test.ts
@@ -29,8 +29,10 @@ type ProjectSessionGlobalState = {
     lifecycle: ProjectControlLifecycle | null;
     service: ProjectSessionService | null;
     workspaceRoot: AbsoluteFsPath | null;
+    compilerRoot: AbsoluteFsPath | null;
+    compilerContext: unknown;
     agentProbe: null;
-    maintenanceTimer: ReturnType<typeof setInterval> | null;
+    maintenanceTimer: NodeJS.Timeout | null;
     sweepInFlight: boolean;
 };
 
@@ -106,6 +108,7 @@ describe("project-session HMR boundaries", () => {
             compilerRoot: absoluteFsPath(process.cwd()),
             agentProbe: null,
             maintenanceTimer: null,
+            compilerContext: null,
             sweepInFlight: false,
         };
 

--- a/packages/neuro-book/server/workspace-files/project-session-hmr.test.ts
+++ b/packages/neuro-book/server/workspace-files/project-session-hmr.test.ts
@@ -101,6 +101,9 @@ describe("project-session HMR boundaries", () => {
             lifecycle,
             service: oldService,
             workspaceRoot,
+            // serviceFor 的 Application Root 绑定守卫需要该字段；
+            // 缺省取 runtimePathsFromEnv().applicationRoot 同源（process.cwd()）。
+            compilerRoot: absoluteFsPath(process.cwd()),
             agentProbe: null,
             maintenanceTimer: null,
             sweepInFlight: false,

--- a/scripts/build/product-build-environment.test.ts
+++ b/scripts/build/product-build-environment.test.ts
@@ -136,7 +136,7 @@ describe("Product build environment", () => {
         const packageJson = JSON.parse(packageText) as {scripts: {"nuxt:build:raw": string}};
 
         expect(packageJson.scripts["nuxt:build:raw"].match(/--dotenv \.env\.product/gu)).toHaveLength(1);
-        expect(packageJson.scripts["nuxt:build:raw"]).toContain("bun node_modules/nuxt/bin/nuxt.mjs");
+        expect(packageJson.scripts["nuxt:build:raw"]).toContain("bun ../../node_modules/nuxt/bin/nuxt.mjs");
         expect(productEnv).toBe("# Product builds intentionally load no local runtime configuration.\n");
         expect(attributes).toContain("server/generated/project-prisma/** text eol=lf\n");
         expect(attributes).toContain("bun.lock text eol=lf\n");

--- a/scripts/build/product-build-environment.test.ts
+++ b/scripts/build/product-build-environment.test.ts
@@ -2,6 +2,7 @@ import {mkdtemp, readFile, rm} from "node:fs/promises";
 import {tmpdir} from "node:os";
 import {join, resolve} from "node:path";
 import {describe, expect, it} from "vitest";
+import {testHostPath} from "@notnotype/neuro-book-test-support/test-path";
 
 import {PRODUCT_PLATFORMS} from "@notnotype/neuro-book-contracts/platform";
 import {
@@ -82,7 +83,7 @@ describe("Product build environment", () => {
                 {name: "commands", files: 116, bytes: 10_865_638},
                 {name: "authoring-kit", files: 509, bytes: 14_477_260},
                 {name: "native-islands", files: 2_059, bytes: 75_260_630},
-                {name: "system-assets", files: 373, bytes: 5_274_435},
+                {name: "system-assets", files: 442, bytes: 5_919_094},
                 {name: "runtime-meta", files: 3, bytes: 4_762},
             ],
             "linux-x64-glibc": [
@@ -91,7 +92,7 @@ describe("Product build environment", () => {
                 {name: "commands", files: 116, bytes: 10_866_185},
                 {name: "authoring-kit", files: 509, bytes: 14_475_922},
                 {name: "native-islands", files: 2_062, bytes: 75_144_692},
-                {name: "system-assets", files: 373, bytes: 5_229_844},
+                {name: "system-assets", files: 442, bytes: 5_856_353},
                 {name: "runtime-meta", files: 3, bytes: 4_762},
             ],
             "linux-aarch64-glibc": [
@@ -100,7 +101,7 @@ describe("Product build environment", () => {
                 {name: "commands", files: 116, bytes: 10_866_185},
                 {name: "authoring-kit", files: 509, bytes: 14_475_922},
                 {name: "native-islands", files: 2_062, bytes: 72_567_998},
-                {name: "system-assets", files: 373, bytes: 5_229_844},
+                {name: "system-assets", files: 442, bytes: 5_856_353},
                 {name: "runtime-meta", files: 3, bytes: 4_762},
             ],
             "darwin-x64": [
@@ -109,7 +110,7 @@ describe("Product build environment", () => {
                 {name: "commands", files: 116, bytes: 10_866_185},
                 {name: "authoring-kit", files: 509, bytes: 14_475_922},
                 {name: "native-islands", files: 2_062, bytes: 75_913_156},
-                {name: "system-assets", files: 373, bytes: 5_229_844},
+                {name: "system-assets", files: 442, bytes: 5_856_353},
                 {name: "runtime-meta", files: 3, bytes: 4_762},
             ],
             "darwin-aarch64": [
@@ -118,7 +119,7 @@ describe("Product build environment", () => {
                 {name: "commands", files: 116, bytes: 10_866_185},
                 {name: "authoring-kit", files: 509, bytes: 14_475_922},
                 {name: "native-islands", files: 2_062, bytes: 71_965_408},
-                {name: "system-assets", files: 373, bytes: 5_229_844},
+                {name: "system-assets", files: 442, bytes: 5_856_353},
                 {name: "runtime-meta", files: 3, bytes: 4_762},
             ],
         });

--- a/scripts/release/desktop-contract-vitest.config.ts
+++ b/scripts/release/desktop-contract-vitest.config.ts
@@ -57,6 +57,15 @@ export default defineConfig({
     resolve: {
         alias: {
             nbook: resolve(repositoryRoot, "packages", "neuro-book"),
+            // bun 的 exports 解析在 vitest externalize 路径上不识别 "bun" 条件，
+            // 合同测试需要源码形态，这里精确指向 TS 源文件。
+            "@notnotype/neuro-book-manager/runtime-projection": resolve(
+                repositoryRoot,
+                "packages",
+                "neuro-book-manager",
+                "src",
+                "runtime-projection.ts",
+            ),
         },
     },
     test: {


### PR DESCRIPTION
Refs #163

## 修复内容（4/5 类）

1. **owned-process mkdtemp ENOENT**：`vitest.ts` globalSetup 先固定 `NBOOK_HOST_SYSTEM_TEMP_ROOT`，worker 内 `resolveAgentTempRoot()` 不再漂移到 run 根，`testHostPath()` 回归设计路径。本地 Windows 复现（6 failed）→ 15 passed。
2. **macOS temp-root symlink 拒绝**：`canonicalPath()` 仅拒绝「已存在锚点自身」为 symlink，允许系统级祖先链接（`/var→private/var`）；逃逸防护由 realpath+lexical suffix 与 `assertContained` 双 realpath 承担。新增契约测试三断言（放行/锚点拒绝/逃逸阻断）。
3. **llmlint TS2307 + vitest TSCONFIG_ERROR**：workspace-packages 的 llmlint matrix 行前置 web 岛 `bun install --frozen-lockfile` 与 `bunx nuxt prepare`（对齐既有 llmlint-web job）。本地实测 `verify` 全链路通过、`test:vitest` 36 文件/346 测试全绿。
4. **Windows bun install EEXIST**：desktop job 级隔离 `BUN_INSTALL_CACHE_DIR` 到 run 独立目录。

## Full tests 子集修复（同 PR）

- profile compile / preview-prepare：fixture 补显式 RuntimePaths 越过 t135 守卫（守卫为有意合同），动态导入链放宽至 30s；本地 2/2 绿。
- project-session-hmr：注入态补缺失的 `compilerRoot` 字段（serviceFor Application Root 绑定守卫所需）；本地转绿。

## 未尽事项

harness black-box / file-change-reminder 超时簇与 context-inspection、harness-trace 断言失败仍在排查（本地可复现，确定性非容量问题），将在本 PR 或后续跟进。

## 验证

- worktree 全新 `bun install` 后：owned-process 15 passed；test-support 9 passed；tsc 双包通过；llmlint verify/test:vitest 全绿；profile×2 与 hmr 单文件绿。