### PR TITLE
refactor(deploy): dedupe operation ID validation into shared pattern

### DIFF
--- a/scripts/deploy/product-runtime.mjs
+++ b/scripts/deploy/product-runtime.mjs
@@ -18,6 +18,7 @@ const ACCEPTANCE_OWNER = "nbook.product-runtime-acceptance";
 const ACCEPTANCE_SCHEMA = 1;
 const STALE_ACCEPTANCE_MS = 24 * 60 * 60 * 1000;
 const HEARTBEAT_MS = 10_000;
+const OPERATION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
 
 const command = process.argv[2] ?? "stage";
 
@@ -198,7 +199,7 @@ async function readRuntimeImageIdentity(imageRoot) {
 function requestedOperationId() {
     const requested = process.env.NEURO_BOOK_PRODUCT_OPERATION_ID?.trim();
     const operationId = requested || `acceptance-${new Date().toISOString().replace(/[^0-9]/gu, "")}-${randomUUID()}`;
-    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(operationId) || operationId === "." || operationId === "..") {
+    if (!OPERATION_ID_PATTERN.test(operationId)) {
         throw new Error(`Product 验收 operation ID 无效：${JSON.stringify(operationId)}`);
     }
     return operationId;
@@ -209,7 +210,7 @@ function requestedOperationId() {
  * 缺少 owner 等同于 already-cleaned；未知 owner、路径逃逸或活动 lease 均拒绝删除。
  */
 async function cleanupProduct(operationId) {
-    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(operationId) || operationId === "." || operationId === "..") {
+    if (!OPERATION_ID_PATTERN.test(operationId)) {
         throw new Error(`Product 验收 cleanup operation ID 无效：${JSON.stringify(operationId)}`);
     }
     const stageRoot = resolveStageRoot(operationId);


### PR DESCRIPTION
来自 PR #164 合并后 code-simplification 复核：`requestedOperationId` 与 `cleanupProduct` 重复同一 operation-ID 校验，且正则首字符 `[A-Za-z0-9]` 已使 `." / "..` 特判不可达。提取共享 `OPERATION_ID_PATTERN`（保留各自错误语境）并删除两处死特判。

## 验证

- `node --check scripts/deploy/product-runtime.mjs` 通过
- `product-runtime-cleanup.test.ts` 5 passed ＋ `product-runtime-contract.test.ts` 2 passed（含 `../escape` 拒绝用例——纯正则已覆盖路径逃逸语义）
- 行为不变：删除的条件在正则下本就永假

## CI 状态（run 32794655495 / 32794655396）

- ✅ Typecheck、Governance and repository contracts
- ❌ Full tests 与四平台 Product——失败特征与 PR #164 完全一致，**全部归属 Issue #163 登记的既有失败**：macOS `NBOOK_AGENT_TEMP_ROOT 不能经过 symlink/reparse point`（#163 第 3 类）、linux owned-process mkdtemp ENOENT（第 2 类）、Full tests `injected maintenance failure`/`simulated EBUSY`/`project-session-hmr`（第 1 类）。本 PR 仅重构单脚本内正则校验，无新接触面。
- 前向修复在 `fix/i163-ci-forward-fixes`；建议该 Issue 关闭后重跑确认再行合并。