### PR TITLE
fix(profile): Agent Profile 工作台 UI 体验修复（顶栏图标化、列表独立滚动、折叠栏优化）

### DIFF
--- a/packages/neuro-book/app/components/novel-ide/settings/AgentProfileNavList.vue
+++ b/packages/neuro-book/app/components/novel-ide/settings/AgentProfileNavList.vue
@@ -56,8 +56,9 @@ function statusDotClass(status: ProfileLoadStatus): string {
 </script>
 
 <template>
-    <!-- Agent Profile 二级导航：默认设置 + 可搜索的 Profile 列表。sticky 需要 self-start 配合，否则 grid 会把 aside 拉满高度导致粘不住。 -->
-    <aside class="sticky top-0 flex flex-col self-start rounded-2xl border border-[var(--border-color)] bg-[var(--bg-panel)] p-2 shadow-sm">
+    <!-- Agent Profile 二级导航：默认设置 + 可搜索的 Profile 列表。作为 grid item 需 min-h-0 解除自动最小尺寸，
+         列表区 flex-1 min-h-0 在栏内独立滚动（Profile 过多时搜索框与默认设置入口保持可见）。 -->
+    <aside class="flex min-h-0 flex-col rounded-2xl border border-[var(--border-color)] bg-[var(--bg-panel)] p-2 shadow-sm">
         <!-- 搜索 -->
         <div class="px-1 pb-2 pt-1">
             <FormInput :model-value="props.search" type="search" :placeholder="t('settings.panels.profileModels.nav.searchPlaceholder')" @update:model-value="emit('update:search', $event)">
@@ -91,8 +92,8 @@ function statusDotClass(status: ProfileLoadStatus): string {
             <div class="mt-1 text-[11px] leading-4 text-[var(--text-secondary)] opacity-80">{{ t("settings.panels.profileModels.nav.profilesHint") }}</div>
         </div>
 
-        <!-- 列表由 Dialog body 统一滚动，不再复制 Dialog 的视口高度预算。 -->
-        <div class="flex min-h-[120px] flex-col gap-1 overflow-y-auto px-1 pb-1 custom-scrollbar">
+        <!-- 列表在左栏内独立滚动，不随右侧表单或 Dialog body 同步滚动。 -->
+        <div class="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto px-1 pb-1 custom-scrollbar">
             <button
                 v-for="item in filteredItems"
                 :key="item.profileKey"

--- a/packages/neuro-book/app/components/novel-ide/settings/NovelIdeAgentProfileModelSettingsPanel.vue
+++ b/packages/neuro-book/app/components/novel-ide/settings/NovelIdeAgentProfileModelSettingsPanel.vue
@@ -589,8 +589,10 @@ defineExpose({
 
 <template>
     <!-- Agent Profile 模型设置 -->
-    <div class="space-y-4 pt-1">
-        <div class="flex flex-wrap items-center justify-between gap-4">
+    <!-- xl 下面板绝对定位铺满 section 可视区（包含块 = L888 的 relative section），标题固定，双栏各自独立滚动；
+         若用 h-full 百分比链，滚动容子元素的百分比高度会退化为内容高度导致约束失效。小屏（<xl）保持自然流 + 外层滚动。 -->
+    <div class="space-y-4 pt-1 xl:absolute xl:inset-0 xl:flex xl:flex-col">
+        <div class="flex shrink-0 flex-wrap items-center justify-between gap-4">
             <div class="max-w-xl">
                 <h3 class="text-base font-semibold text-[var(--text-main)]">{{ isProjectScope ? t("settings.panels.profileModels.projectTitle") : t("settings.panels.profileModels.globalTitle") }}</h3>
                 <p class="mt-1 text-xs text-[var(--text-secondary)]">{{ isProjectScope ? t("settings.panels.profileModels.projectDescription", {target: props.targetLabel || t("settings.panels.profileModels.currentProject")}) : t("settings.panels.profileModels.globalDescription") }}</p>
@@ -622,8 +624,8 @@ defineExpose({
             <span class="text-sm text-[var(--text-secondary)]">{{ t("settings.panels.profileModels.loading") }}</span>
         </div>
 
-        <!-- 二级导航 + 详情双栏 -->
-        <div v-else class="grid min-h-[500px] gap-5 xl:grid-cols-[240px_minmax(0,1fr)]">
+        <!-- 二级导航 + 详情双栏：xl 下两栏各自 overflow 滚动；aside 需 min-h-0 解除 grid item 自动最小尺寸，否则行高被内容撑开 -->
+        <div v-else class="grid gap-5 xl:min-h-0 xl:flex-1 xl:grid-cols-[240px_minmax(0,1fr)]">
             <AgentProfileNavList
                 :items="navItems"
                 :active-key="activeNavKey"
@@ -633,7 +635,7 @@ defineExpose({
                 @update:search="navSearch = $event"
             />
 
-            <div class="relative min-w-0">
+            <div class="relative min-w-0 xl:overflow-y-auto">
                 <Transition name="fade-slide" mode="out-in">
                     <!-- Transition 的直接子节点必须是元素，不能直接放子组件：子组件只要编译成 Fragment 根（模板根注释就会），out-in 的离场方拿不到 afterLeave，会永久卡在 isLeaving 只渲染空占位。包一层后子组件根是什么形状都无所谓。 -->
                     <!-- 单个 Profile 详情 -->

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateCanvasPanel.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateCanvasPanel.vue
@@ -27,7 +27,7 @@ const emit = defineEmits<{
 
 <template>
     <!-- 中间模板画布：承载根节点子树和根级 drop zone -->
-    <section class="panel flex min-h-0 flex-col">
+    <section class="panel flex min-h-0 min-w-0 flex-col">
         <div class="mb-3 flex shrink-0 items-center justify-between gap-3">
             <div class="min-w-0">
                 <div class="flex items-center gap-2">

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateComponentLibraryPanel.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateComponentLibraryPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import FormInput from "nbook/app/components/common/form/FormInput.vue";
+import Tooltip from "nbook/app/components/common/Tooltip.vue";
 import ProfileTemplateLibraryItem from "nbook/app/components/profile-template-editor/ProfileTemplateLibraryItem.vue";
 import type {
     ComponentLibraryGroup,
@@ -24,15 +25,17 @@ const emit = defineEmits<{
 
 <template>
     <!-- 左侧组件库：组件拖入画布或点击快速添加 -->
-    <aside class="panel flex min-h-0 flex-col">
+    <aside class="panel flex min-h-0 min-w-0 flex-col">
         <div class="mb-3 flex items-start justify-between gap-2">
             <div>
                 <div class="panel-title">组件库</div>
                 <div class="mt-1 text-[11px] text-[var(--text-muted)]">拖拽组件到画布中编辑</div>
             </div>
-            <button type="button" class="panel-icon-btn" title="收起组件库" @click="emit('collapse')">
-                <span class="i-lucide-panel-left-close h-4 w-4"></span>
-            </button>
+            <Tooltip text="收起组件库" placement="bottom">
+                <button type="button" class="panel-icon-btn" aria-label="收起组件库" @click="emit('collapse')">
+                    <span class="i-lucide-panel-left-close h-4 w-4"></span>
+                </button>
+            </Tooltip>
         </div>
         <div class="relative mb-3">
             <span class="i-lucide-search absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--text-muted)]"></span>

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateHeader.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import FormSelect from "nbook/app/components/common/form/FormSelect.vue";
+import Tooltip from "nbook/app/components/common/Tooltip.vue";
 import type {SelectOption} from "nbook/app/components/profile-template-editor/profile-template-editor-ui";
 
 const props = defineProps<{
@@ -59,98 +60,99 @@ const emit = defineEmits<{
             </div>
         </div>
 
-        <FormSelect :model-value="props.selectedTemplate" :options="props.templateOptions" placeholder="选择模板" dropdown-direction="down" class="min-w-[320px]" @update:model-value="emit('update:selectedTemplate', $event)" />
+        <FormSelect :model-value="props.selectedTemplate" :options="props.templateOptions" placeholder="选择模板" dropdown-direction="down" class="min-w-0 max-w-[320px] flex-1" @update:model-value="emit('update:selectedTemplate', $event)" />
 
-        <div class="ml-auto flex items-center gap-2">
+        <div class="ml-auto flex shrink-0 items-center gap-2">
             <span class="hidden items-center gap-1 text-xs text-[var(--status-success)] md:flex">
                 <span class="i-lucide-circle-check h-3.5 w-3.5"></span>
                 <span>{{ props.editorStatusText }}</span>
             </span>
             <div class="mx-2 hidden h-4 w-px bg-[var(--border-color)] lg:block"></div>
-            <button class="icon-btn" title="撤销 Ctrl+Z" :disabled="!props.canUndo" @click="emit('undo')">
-                <span class="i-lucide-undo-2 h-4 w-4"></span>
-            </button>
-            <button class="icon-btn" title="重做 Ctrl+Shift+Z" :disabled="!props.canRedo" @click="emit('redo')">
-                <span class="i-lucide-redo-2 h-4 w-4"></span>
-            </button>
-            <button class="toolbar-btn" :disabled="props.previewing || !props.sourceText" @click="emit('preview')">
-                <span class="i-lucide-play h-3.5 w-3.5"></span>
-                <span>预览</span>
-            </button>
-            <button v-if="!props.compileEnabled" class="toolbar-btn" :disabled="props.validating || !props.sourceText" @click="emit('validate')">
-                <span class="i-lucide-badge-check h-3.5 w-3.5"></span>
-                <span>{{ props.validateLabel ?? "验证" }}</span>
-            </button>
-            <button v-if="props.compileEnabled" class="toolbar-btn" :disabled="props.compiling || props.compilingAll || props.saving || props.parsingSource || !props.sourceText" @click="emit('compile')">
-                <span class="i-lucide-hammer h-3.5 w-3.5"></span>
-                <span>编译</span>
-            </button>
-            <button v-if="props.compileAllEnabled" class="toolbar-btn" :disabled="props.compilingAll || props.compiling || props.saving" @click="emit('compileAll')">
-                <span class="i-lucide-package-check h-3.5 w-3.5"></span>
-                <span>编译全部</span>
-            </button>
-            <button v-if="props.restoreEnabled" class="toolbar-btn" :disabled="props.restoring || props.saving || !props.sourceText" @click="emit('restore')">
-                <span class="i-lucide-rotate-ccw h-3.5 w-3.5"></span>
-                <span>恢复系统版本</span>
-            </button>
-            <button v-if="props.createEnabled" class="toolbar-btn" :disabled="props.saving" @click="emit('create')">
-                <span class="i-lucide-file-plus-2 h-3.5 w-3.5"></span>
-                <span>新建</span>
-            </button>
-            <button v-if="props.runEnabled" class="toolbar-btn" :disabled="props.saving || props.issueCount > 0 || props.runDisabled" @click="emit('run')">
-                <span class="i-lucide-message-circle-plus h-3.5 w-3.5"></span>
-                <span>创建 Session</span>
-            </button>
-            <button class="toolbar-btn primary" :disabled="props.saving || props.parsingSource || !props.sourceText || (!props.allowSaveWithIssues && props.issueCount > 0)" @click="emit('save')">
-                <span class="i-lucide-save h-3.5 w-3.5"></span>
-                <span>保存</span>
-                <span class="i-lucide-chevron-down h-3.5 w-3.5 opacity-80"></span>
-            </button>
-            <button v-if="props.closable" class="icon-btn" title="关闭" @click="emit('close')">
-                <span class="i-lucide-x h-4 w-4"></span>
-            </button>
+            <Tooltip text="撤销 Ctrl+Z" placement="bottom">
+                <button class="icon-btn" aria-label="撤销" :disabled="!props.canUndo" @click="emit('undo')">
+                    <span class="i-lucide-undo-2 h-4 w-4"></span>
+                </button>
+            </Tooltip>
+            <Tooltip text="重做 Ctrl+Shift+Z" placement="bottom">
+                <button class="icon-btn" aria-label="重做" :disabled="!props.canRedo" @click="emit('redo')">
+                    <span class="i-lucide-redo-2 h-4 w-4"></span>
+                </button>
+            </Tooltip>
+            <Tooltip text="预览" placement="bottom">
+                <button class="icon-btn" aria-label="预览" :disabled="props.previewing || !props.sourceText" @click="emit('preview')">
+                    <span class="i-lucide-play h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="!props.compileEnabled" :text="props.validateLabel ?? '验证'" placement="bottom">
+                <button class="icon-btn" aria-label="验证" :disabled="props.validating || !props.sourceText" @click="emit('validate')">
+                    <span class="i-lucide-badge-check h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.compileEnabled" text="编译" placement="bottom">
+                <button class="icon-btn" aria-label="编译" :disabled="props.compiling || props.compilingAll || props.saving || props.parsingSource || !props.sourceText" @click="emit('compile')">
+                    <span class="i-lucide-hammer h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.compileAllEnabled" text="编译全部" placement="bottom">
+                <button class="icon-btn" aria-label="编译全部" :disabled="props.compilingAll || props.compiling || props.saving" @click="emit('compileAll')">
+                    <span class="i-lucide-package-check h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.restoreEnabled" text="恢复系统版本" placement="bottom">
+                <button class="icon-btn" aria-label="恢复系统版本" :disabled="props.restoring || props.saving || !props.sourceText" @click="emit('restore')">
+                    <span class="i-lucide-rotate-ccw h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.createEnabled" text="新建" placement="bottom">
+                <button class="icon-btn" aria-label="新建" :disabled="props.saving" @click="emit('create')">
+                    <span class="i-lucide-file-plus-2 h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.runEnabled" text="创建 Session" placement="bottom">
+                <button class="icon-btn" aria-label="创建 Session" :disabled="props.saving || props.issueCount > 0 || props.runDisabled" @click="emit('run')">
+                    <span class="i-lucide-message-circle-plus h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip text="保存" placement="bottom">
+                <button class="icon-btn primary" aria-label="保存" :disabled="props.saving || props.parsingSource || !props.sourceText || (!props.allowSaveWithIssues && props.issueCount > 0)" @click="emit('save')">
+                    <span class="i-lucide-save h-3.5 w-3.5"></span>
+                </button>
+            </Tooltip>
+            <Tooltip v-if="props.closable" text="关闭" placement="bottom">
+                <button class="icon-btn" aria-label="关闭" @click="emit('close')">
+                    <span class="i-lucide-x h-4 w-4"></span>
+                </button>
+            </Tooltip>
         </div>
     </header>
 </template>
 
 <style scoped>
-.toolbar-btn,
 .icon-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 6px;
     border: 1px solid var(--border-color);
     border-radius: 7px;
     background: var(--bg-input);
     color: var(--text-secondary);
     font-size: 12px;
+    height: 32px;
+    width: 32px;
     transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
 }
 
-.toolbar-btn {
-    height: 32px;
-    padding: 0 12px;
-}
-
-.toolbar-btn.primary {
+.icon-btn.primary {
     border-color: var(--accent-main);
     background: var(--accent-main);
-    color: white;
+    color: var(--text-inverse);
 }
 
-.icon-btn {
-    height: 32px;
-    width: 32px;
-}
-
-.toolbar-btn:hover:not(:disabled),
 .icon-btn:hover:not(:disabled) {
     background: var(--bg-hover);
     color: var(--text-main);
 }
 
-.toolbar-btn:disabled,
 .icon-btn:disabled {
     cursor: not-allowed;
     opacity: 0.45;

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateHeader.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateHeader.vue
@@ -49,8 +49,8 @@ const emit = defineEmits<{
 
 <template>
     <!-- TSX Profile 顶部工具栏 -->
-    <header class="flex h-12 shrink-0 items-center gap-4 border-b border-[var(--border-color)] bg-[var(--bg-panel)] px-4">
-        <div class="flex min-w-0 items-center gap-3">
+    <header class="profile-template-header flex min-h-12 shrink-0 flex-wrap items-center gap-x-4 gap-y-2 border-b border-[var(--border-color)] bg-[var(--bg-panel)] px-4 py-2">
+        <div class="profile-template-header__identity flex min-w-0 items-center gap-3">
             <div class="flex h-7 w-7 items-center justify-center rounded-md border border-[var(--border-color)] bg-[var(--accent-main)] text-xs font-semibold text-[var(--text-inverse)] shadow-sm">TS</div>
             <div class="min-w-0">
                 <div class="flex items-center gap-2 text-[13px] font-semibold">
@@ -58,68 +58,87 @@ const emit = defineEmits<{
                     <span v-if="props.subtitle" class="truncate text-[12px] font-medium text-[var(--text-muted)]">{{ props.subtitle }}</span>
                 </div>
             </div>
+            <FormSelect :model-value="props.selectedTemplate" :options="props.templateOptions" placeholder="选择模板" dropdown-direction="down" class="min-w-0 max-w-[320px] flex-1" @update:model-value="emit('update:selectedTemplate', $event)" />
         </div>
 
-        <FormSelect :model-value="props.selectedTemplate" :options="props.templateOptions" placeholder="选择模板" dropdown-direction="down" class="min-w-0 max-w-[320px] flex-1" @update:model-value="emit('update:selectedTemplate', $event)" />
-
-        <div class="ml-auto flex shrink-0 items-center gap-2">
-            <span class="hidden items-center gap-1 text-xs text-[var(--status-success)] md:flex">
-                <span class="i-lucide-circle-check h-3.5 w-3.5"></span>
-                <span>{{ props.editorStatusText }}</span>
+        <div class="profile-template-header__actions flex min-w-0 max-w-full shrink-0 flex-wrap items-center gap-2">
+            <span class="hidden min-w-0 items-center gap-1 text-xs text-[var(--status-success)] md:flex">
+                <span class="i-lucide-circle-check h-3.5 w-3.5 shrink-0"></span>
+                <span class="min-w-0 truncate">{{ props.editorStatusText }}</span>
             </span>
             <div class="mx-2 hidden h-4 w-px bg-[var(--border-color)] lg:block"></div>
             <Tooltip text="撤销 Ctrl+Z" placement="bottom">
-                <button class="icon-btn" aria-label="撤销" :disabled="!props.canUndo" @click="emit('undo')">
-                    <span class="i-lucide-undo-2 h-4 w-4"></span>
-                </button>
+                <span class="profile-template-tooltip-trigger">
+                    <button type="button" class="icon-btn disabled:pointer-events-none" aria-label="撤销" :disabled="!props.canUndo" @click="emit('undo')">
+                        <span class="i-lucide-undo-2 h-4 w-4"></span>
+                    </button>
+                </span>
             </Tooltip>
             <Tooltip text="重做 Ctrl+Shift+Z" placement="bottom">
-                <button class="icon-btn" aria-label="重做" :disabled="!props.canRedo" @click="emit('redo')">
-                    <span class="i-lucide-redo-2 h-4 w-4"></span>
-                </button>
+                <span class="profile-template-tooltip-trigger">
+                    <button type="button" class="icon-btn disabled:pointer-events-none" aria-label="重做" :disabled="!props.canRedo" @click="emit('redo')">
+                        <span class="i-lucide-redo-2 h-4 w-4"></span>
+                    </button>
+                </span>
             </Tooltip>
             <Tooltip text="预览" placement="bottom">
-                <button class="icon-btn" aria-label="预览" :disabled="props.previewing || !props.sourceText" @click="emit('preview')">
-                    <span class="i-lucide-play h-3.5 w-3.5"></span>
-                </button>
+                <span class="profile-template-tooltip-trigger">
+                    <button type="button" class="icon-btn disabled:pointer-events-none" aria-label="预览" :disabled="props.previewing || !props.sourceText" @click="emit('preview')">
+                        <span class="i-lucide-play h-3.5 w-3.5"></span>
+                    </button>
+                </span>
             </Tooltip>
             <Tooltip v-if="!props.compileEnabled" :text="props.validateLabel ?? '验证'" placement="bottom">
-                <button class="icon-btn" aria-label="验证" :disabled="props.validating || !props.sourceText" @click="emit('validate')">
-                    <span class="i-lucide-badge-check h-3.5 w-3.5"></span>
-                </button>
+                <span class="profile-template-tooltip-trigger">
+                    <button type="button" class="icon-btn disabled:pointer-events-none" aria-label="验证" :disabled="props.validating || !props.sourceText" @click="emit('validate')">
+                        <span class="i-lucide-badge-check h-3.5 w-3.5"></span>
+                    </button>
+                </span>
             </Tooltip>
             <Tooltip v-if="props.compileEnabled" text="编译" placement="bottom">
-                <button class="icon-btn" aria-label="编译" :disabled="props.compiling || props.compilingAll || props.saving || props.parsingSource || !props.sourceText" @click="emit('compile')">
-                    <span class="i-lucide-hammer h-3.5 w-3.5"></span>
-                </button>
+                <span class="profile-template-tooltip-trigger">
+                    <button type="button" class="icon-btn disabled:pointer-events-none" aria-label="编译" :disabled="props.compiling || props.compilingAll || props.saving || props.parsingSource || !props.sourceText" @click="emit('compile')">
+                        <span class="i-lucide-hammer h-3.5 w-3.5"></span>
+                    </button>
+                </span>
             </Tooltip>
             <Tooltip v-if="props.compileAllEnabled" text="编译全部" placement="bottom">
-                <button class="icon-btn" aria-label="编译全部" :disabled="props.compilingAll || props.compiling || props.saving" @click="emit('compileAll')">
-                    <span class="i-lucide-package-check h-3.5 w-3.5"></span>
-                </button>
+                <span class="profile-template-tooltip-trigger">
+                    <button type="button" class="icon-btn disabled:pointer-events-none" aria-label="编译全部" :disabled="props.compilingAll || props.compiling || props.saving" @click="emit('compileAll')">
+                        <span class="i-lucide-package-check h-3.5 w-3.5"></span>
+                    </button>
+                </span>
             </Tooltip>
             <Tooltip v-if="props.restoreEnabled" text="恢复系统版本" placement="bottom">
-                <button class="icon-btn" aria-label="恢复系统版本" :disabled="props.restoring || props.saving || !props.sourceText" @click="emit('restore')">
-                    <span class="i-lucide-rotate-ccw h-3.5 w-3.5"></span>
-                </button>
+                <span class="profile-template-tooltip-trigger">
+                    <button type="button" class="icon-btn disabled:pointer-events-none" aria-label="恢复系统版本" :disabled="props.restoring || props.saving || !props.sourceText" @click="emit('restore')">
+                        <span class="i-lucide-rotate-ccw h-3.5 w-3.5"></span>
+                    </button>
+                </span>
             </Tooltip>
             <Tooltip v-if="props.createEnabled" text="新建" placement="bottom">
-                <button class="icon-btn" aria-label="新建" :disabled="props.saving" @click="emit('create')">
-                    <span class="i-lucide-file-plus-2 h-3.5 w-3.5"></span>
-                </button>
+                <span class="profile-template-tooltip-trigger">
+                    <button type="button" class="icon-btn disabled:pointer-events-none" aria-label="新建" :disabled="props.saving" @click="emit('create')">
+                        <span class="i-lucide-file-plus-2 h-3.5 w-3.5"></span>
+                    </button>
+                </span>
             </Tooltip>
             <Tooltip v-if="props.runEnabled" text="创建 Session" placement="bottom">
-                <button class="icon-btn" aria-label="创建 Session" :disabled="props.saving || props.issueCount > 0 || props.runDisabled" @click="emit('run')">
-                    <span class="i-lucide-message-circle-plus h-3.5 w-3.5"></span>
-                </button>
+                <span class="profile-template-tooltip-trigger">
+                    <button type="button" class="icon-btn disabled:pointer-events-none" aria-label="创建 Session" :disabled="props.saving || props.issueCount > 0 || props.runDisabled" @click="emit('run')">
+                        <span class="i-lucide-message-circle-plus h-3.5 w-3.5"></span>
+                    </button>
+                </span>
             </Tooltip>
             <Tooltip text="保存" placement="bottom">
-                <button class="icon-btn primary" aria-label="保存" :disabled="props.saving || props.parsingSource || !props.sourceText || (!props.allowSaveWithIssues && props.issueCount > 0)" @click="emit('save')">
-                    <span class="i-lucide-save h-3.5 w-3.5"></span>
-                </button>
+                <span class="profile-template-tooltip-trigger">
+                    <button type="button" class="icon-btn primary disabled:pointer-events-none" aria-label="保存" :disabled="props.saving || props.parsingSource || !props.sourceText || (!props.allowSaveWithIssues && props.issueCount > 0)" @click="emit('save')">
+                        <span class="i-lucide-save h-3.5 w-3.5"></span>
+                    </button>
+                </span>
             </Tooltip>
             <Tooltip v-if="props.closable" text="关闭" placement="bottom">
-                <button class="icon-btn" aria-label="关闭" @click="emit('close')">
+                <button type="button" class="icon-btn" aria-label="关闭" @click="emit('close')">
                     <span class="i-lucide-x h-4 w-4"></span>
                 </button>
             </Tooltip>
@@ -156,5 +175,27 @@ const emit = defineEmits<{
 .icon-btn:disabled {
     cursor: not-allowed;
     opacity: 0.45;
+}
+
+.profile-template-header__actions {
+    margin-left: auto;
+    white-space: nowrap;
+}
+
+/* 窄容器（含 Dialog 内 1120px 上限场景）：动作区整行换行，左对齐铺开，避免与选择器争宽 */
+@container (max-width: 900px) {
+    .profile-template-header__actions {
+        flex-basis: 100%;
+        margin-left: 0;
+        justify-content: flex-start;
+    }
+}
+
+.profile-template-tooltip-trigger {
+    display: inline-flex;
+}
+
+.profile-template-tooltip-trigger:has(.icon-btn:disabled) {
+    cursor: not-allowed;
 }
 </style>

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateInspectorPanel.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateInspectorPanel.vue
@@ -253,7 +253,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     <!-- 右侧属性检查器：属性、变量、运行时变量 -->
     <section class="panel flex min-w-0 min-h-0 flex-1 flex-col overflow-hidden">
         <div class="mb-3 flex shrink-0 items-center gap-2 border-b border-[var(--border-color)]">
-            <div class="flex min-w-0 flex-1 overflow-x-auto custom-scrollbar">
+            <div class="flex min-w-0 flex-1 overflow-x-auto custom-scrollbar no-scrollbar">
                 <button
                     v-for="tab in props.tabs"
                     :key="tab.value"
@@ -269,7 +269,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
             </button>
         </div>
 
-        <div class="min-h-0 flex-1 overflow-auto pr-1 custom-scrollbar">
+        <div class="min-h-0 flex-1 overflow-auto pr-1 custom-scrollbar no-scrollbar">
             <div v-if="props.activeTab === 'source'" class="h-full min-h-[520px]">
                 <ProfileTemplateSourcePanel
                     :source-text="props.sourceText"
@@ -409,6 +409,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 </template>
 
 <style scoped>
+.no-scrollbar {
+    scrollbar-width: none;
+    scrollbar-color: transparent transparent;
+    -ms-overflow-style: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
+}
+
 .panel {
     border: 1px solid var(--border-color);
     border-radius: 8px;
@@ -419,8 +431,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 .panel-icon-btn {
     display: inline-flex;
-    height: 28px;
-    width: 28px;
+    height: 32px;
+    width: 32px;
     flex-shrink: 0;
     align-items: center;
     justify-content: center;

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateInspectorPanel.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateInspectorPanel.vue
@@ -4,6 +4,7 @@ import FormInput from "nbook/app/components/common/form/FormInput.vue";
 import FormSelect from "nbook/app/components/common/form/FormSelect.vue";
 import FormTextarea from "nbook/app/components/common/form/FormTextarea.vue";
 import StructuredTextEditor from "nbook/app/components/common/form/StructuredTextEditor.vue";
+import Tooltip from "nbook/app/components/common/Tooltip.vue";
 import ProfileTemplateSourcePanel from "nbook/app/components/profile-template-editor/ProfileTemplateSourcePanel.vue";
 import ProfileTemplateVariableGroups from "nbook/app/components/profile-template-editor/ProfileTemplateVariableGroups.vue";
 import type {
@@ -264,11 +265,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
                     {{ tab.label }}
                 </button>
             </div>
-            <button type="button" class="panel-icon-btn" title="收起右侧面板" @click="emit('collapse')">
-                <span class="i-lucide-panel-right-close h-4 w-4"></span>
-            </button>
+            <Tooltip text="收起右侧面板" placement="bottom">
+                <button type="button" class="panel-icon-btn" aria-label="收起右侧面板" @click="emit('collapse')">
+                    <span class="i-lucide-panel-right-close h-4 w-4"></span>
+                </button>
+            </Tooltip>
         </div>
-
         <div class="min-h-0 flex-1 overflow-auto pr-1 custom-scrollbar no-scrollbar">
             <div v-if="props.activeTab === 'source'" class="h-full min-h-[520px]">
                 <ProfileTemplateSourcePanel

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateLibraryItem.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateLibraryItem.vue
@@ -40,7 +40,7 @@ const {isDragging} = useDraggable({
         </span>
         <span class="min-w-0 flex-1">
             <span class="block truncate text-xs font-semibold text-[var(--text-main)]">{{ props.label }}</span>
-            <span class="mt-1 block text-[11px] leading-4 text-[var(--text-muted)]">{{ props.description }}</span>
+            <span class="mt-1 block break-words text-[11px] leading-4 text-[var(--text-muted)]">{{ props.description }}</span>
         </span>
     </button>
 </template>

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateVisualEditor.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateVisualEditor.vue
@@ -2190,160 +2190,159 @@ onBeforeUnmount(() => {
 
 <template>
     <div ref="themeHostRef" class="tsx-profile-editor-page flex h-full min-h-0 flex-col overflow-hidden bg-[var(--bg-main)] text-[var(--text-main)] transition-colors duration-300" :class="props.mode === 'system-template' ? 'h-screen' : ''">
-        <ProfileTemplateHeader
-            v-model:selected-template="selectedTemplate"
-            :title="props.mode === 'user-profile' ? 'TSX Profile 工作台' : 'TSX Profile 可视化编辑器'"
-            :subtitle="props.mode === 'user-profile' ? '用户资产' : ''"
-            :template-options="templateOptions"
-            :editor-status-text="editorStatusText"
-            :can-undo="canUndo"
-            :can-redo="canRedo"
-            :previewing="previewing"
-            :validating="validating"
-            :saving="saving"
-            :restoring="restoring"
-            :compiling="compileState === 'running'"
-            :compiling-all="compilingAll"
-            :parsing-source="parsingSource"
-            :source-text="sourceText"
-            :issue-count="issueCount"
-            :restore-enabled="canRestoreSelectedTemplate"
-            :create-enabled="props.mode === 'user-profile'"
-            :run-enabled="props.mode === 'user-profile'"
-            :compile-enabled="props.mode === 'user-profile'"
-            :compile-all-enabled="props.mode === 'user-profile'"
-            :run-disabled="!profileCompileReady"
-            :allow-save-with-issues="props.mode === 'user-profile'"
-            :validate-label="props.mode === 'user-profile' ? '编译' : '验证'"
-            :closable="props.closable"
-            @undo="undoEdit"
-            @redo="redoEdit"
-            @preview="void openPreviewDialog()"
-            @validate="void validateTemplate()"
-            @compile="void compileSelectedProfile()"
-            @compile-all="void compileAllProfiles()"
-            @restore="void restoreTemplate()"
-            @create="openCreateProfileDialog"
-            @run="void createSessionForProfile()"
-            @save="void saveTemplate()"
-            @close="emit('close')"
-        />
+        <div class="profile-editor-shell">
+            <ProfileTemplateHeader
+                v-model:selected-template="selectedTemplate"
+                :title="props.mode === 'user-profile' ? 'TSX Profile 工作台' : 'TSX Profile 可视化编辑器'"
+                :subtitle="props.mode === 'user-profile' ? '用户资产' : ''"
+                :template-options="templateOptions"
+                :editor-status-text="editorStatusText"
+                :can-undo="canUndo"
+                :can-redo="canRedo"
+                :previewing="previewing"
+                :validating="validating"
+                :saving="saving"
+                :restoring="restoring"
+                :compiling="compileState === 'running'"
+                :compiling-all="compilingAll"
+                :parsing-source="parsingSource"
+                :source-text="sourceText"
+                :issue-count="issueCount"
+                :restore-enabled="canRestoreSelectedTemplate"
+                :create-enabled="props.mode === 'user-profile'"
+                :run-enabled="props.mode === 'user-profile'"
+                :compile-enabled="props.mode === 'user-profile'"
+                :compile-all-enabled="props.mode === 'user-profile'"
+                :run-disabled="!profileCompileReady"
+                :allow-save-with-issues="props.mode === 'user-profile'"
+                :validate-label="props.mode === 'user-profile' ? '编译' : '验证'"
+                :closable="props.closable"
+                @undo="undoEdit"
+                @redo="redoEdit"
+                @preview="void openPreviewDialog()"
+                @validate="void validateTemplate()"
+                @compile="void compileSelectedProfile()"
+                @compile-all="void compileAllProfiles()"
+                @restore="void restoreTemplate()"
+                @create="openCreateProfileDialog"
+                @run="void createSessionForProfile()"
+                @save="void saveTemplate()"
+                @close="emit('close')"
+            />
 
-        <DragDropProvider
-            :sensors="dndSensors"
-            @drag-start="handleNodeDragStart"
-            @drag-over="handleNodeDragOver"
-            @drag-end="handleNodeDragEnd"
-        >
-            <main
-                class="grid min-h-0 min-w-0 flex-1 gap-3 overflow-x-auto p-3"
-                :class="[
-                    libraryPanelCollapsed ? 'grid-cols-[52px_minmax(560px,1fr)_minmax(360px,30vw)]' : 'grid-cols-[290px_minmax(560px,1fr)_minmax(360px,30vw)]',
-                    inspectorPanelCollapsed ? (libraryPanelCollapsed ? '!grid-cols-[52px_minmax(560px,1fr)_52px]' : '!grid-cols-[290px_minmax(560px,1fr)_52px]') : '',
-                ]"
+            <DragDropProvider
+                :sensors="dndSensors"
+                @drag-start="handleNodeDragStart"
+                @drag-over="handleNodeDragOver"
+                @drag-end="handleNodeDragEnd"
             >
-            <aside v-if="libraryPanelCollapsed" class="component-rail">
-                <Tooltip text="展开组件库" placement="right">
-                    <button type="button" class="rail-icon-btn" @click="libraryPanelCollapsed = false">
-                        <span class="i-lucide-panel-left-open h-4 w-4"></span>
+                <main
+                    class="profile-editor-main grid min-h-0 min-w-0 flex-1 gap-3 overflow-hidden p-3"
+                    :class="{ 'library-collapsed': libraryPanelCollapsed, 'inspector-collapsed': inspectorPanelCollapsed }"
+                >
+                <aside v-if="libraryPanelCollapsed" class="component-rail">
+                    <Tooltip text="展开组件库" placement="right">
+                        <button type="button" class="rail-icon-btn" aria-label="展开组件库" @click="libraryPanelCollapsed = false">
+                            <span class="i-lucide-panel-left-open h-4 w-4"></span>
+                        </button>
+                    </Tooltip>
+                    <div class="rail-divider"></div>
+                    <div class="component-rail-scroll custom-scrollbar">
+                        <template v-for="group in compactComponentGroups" :key="group.group">
+                            <div class="rail-group-divider" :title="group.label"></div>
+                            <Tooltip
+                                v-for="item in group.items"
+                                :key="item.type"
+                                :text="`${group.label} / ${item.label}：${item.description}`"
+                                placement="right"
+                            >
+                                <button
+                                    type="button"
+                                    class="rail-icon-btn"
+                                    :class="`library-node-${item.type}`"
+                                    @click="addNode(item.type)"
+                                >
+                                    <span :class="item.iconClass" class="h-4 w-4"></span>
+                                </button>
+                            </Tooltip>
+                        </template>
+                    </div>
+                </aside>
+                <ProfileTemplateComponentLibraryPanel
+                    v-else
+                    v-model:search="componentSearch"
+                    v-model:active-group="activeComponentGroup"
+                    :group-tabs="componentGroupTabs"
+                    :component-groups="filteredComponentGroups"
+                    @collapse="libraryPanelCollapsed = true"
+                    @add-node="addNode"
+                />
+
+                <ProfileTemplateCanvasPanel
+                    :loading="loading"
+                    :display-root="displayRoot"
+                    :selected-node-id="selectedNodeId"
+                    :node-count="nodeCount"
+                    :disabled-drop-node-ids="disabledDropNodeIds"
+                    :can-have-children="canHaveChildren"
+                    :is-root-drop-active="isRootDropActive"
+                    @select="selectedNodeId = $event"
+                    @prepare-drag="prepareNodeDrag"
+                    @duplicate="duplicateNode"
+                    @delete="deleteNode"
+                    @add-message="addNode('Message')"
+                />
+
+                <!-- 右侧源码、属性与变量面板 -->
+                <Tooltip v-if="inspectorPanelCollapsed" text="展开右侧面板" placement="bottom">
+                    <button type="button" class="panel-rail" aria-label="展开右侧面板" @click="inspectorPanelCollapsed = false">
+                        <span class="i-lucide-panel-right-open h-4 w-4"></span>
+                        <span class="rail-label">面板</span>
                     </button>
                 </Tooltip>
-                <div class="rail-divider"></div>
-                <div class="component-rail-scroll custom-scrollbar">
-                    <template v-for="group in compactComponentGroups" :key="group.group">
-                        <div class="rail-group-divider" :title="group.label"></div>
-                        <Tooltip
-                            v-for="item in group.items"
-                            :key="item.type"
-                            :text="`${group.label} / ${item.label}：${item.description}`"
-                            placement="right"
-                        >
-                            <button
-                                type="button"
-                                class="rail-icon-btn"
-                                :class="`library-node-${item.type}`"
-                                @click="addNode(item.type)"
-                            >
-                                <span :class="item.iconClass" class="h-4 w-4"></span>
-                            </button>
-                        </Tooltip>
-                    </template>
-                </div>
-            </aside>
-            <ProfileTemplateComponentLibraryPanel
-                v-else
-                v-model:search="componentSearch"
-                v-model:active-group="activeComponentGroup"
-                :group-tabs="componentGroupTabs"
-                :component-groups="filteredComponentGroups"
-                @collapse="libraryPanelCollapsed = true"
-                @add-node="addNode"
-            />
-
-            <ProfileTemplateCanvasPanel
-                :loading="loading"
-                :display-root="displayRoot"
-                :selected-node-id="selectedNodeId"
-                :node-count="nodeCount"
-                :disabled-drop-node-ids="disabledDropNodeIds"
-                :can-have-children="canHaveChildren"
-                :is-root-drop-active="isRootDropActive"
-                @select="selectedNodeId = $event"
-                @prepare-drag="prepareNodeDrag"
-                @duplicate="duplicateNode"
-                @delete="deleteNode"
-                @add-message="addNode('Message')"
-            />
-
-            <!-- 右侧源码、属性与变量面板 -->
-            <Tooltip v-if="inspectorPanelCollapsed" text="展开右侧面板" placement="bottom">
-                <aside class="panel-rail" @click="inspectorPanelCollapsed = false">
-                    <span class="i-lucide-panel-right-open h-4 w-4"></span>
-                    <span class="rail-label">面板</span>
+                <aside v-else class="flex min-w-0 min-h-0 flex-col">
+                    <ProfileTemplateInspectorPanel
+                        v-model:active-tab="inspectorTab"
+                        v-model:variable-search="variableSearch"
+                        :tabs="inspectorTabs"
+                        :selected-node="selectedNode"
+                        :selected-prop-entries="selectedPropEntries"
+                        :selected-text-length="selectedTextLength"
+                        :source-text="sourceText"
+                        :source-line-count="sourceLineCount"
+                        :parsing-source="parsingSource"
+                        :selected-template-file-name="selectedTemplateFileName"
+                        :issues="issues"
+                        :variable-groups="variableGroups"
+                        :filtered-variable-groups="filteredVariableGroups"
+                        :filtered-runtime-variable-groups="filteredRuntimeVariableGroups"
+                        :role-options="roleOptions"
+                        :tool-status-options="toolStatusOptions"
+                        :source-options="sourceOptions"
+                        :theme="theme"
+                        :monaco-preferences="sourceEditorPreferences"
+                        :is-expression-value="isExpressionValue"
+                        :prop-input-value="propInputValue"
+                        :prop-label="propLabel"
+                        :node-title="nodeTitle"
+                        :issue-detail="issueDetail"
+                        :format-variable-value="formatVariableValue"
+                        :is-variable-group-collapsed="isVariableGroupCollapsed"
+                        :profile-detail="profileDetail"
+                        @collapse="inspectorPanelCollapsed = true"
+                        @source-change="handleSourceTextChange"
+                        @source-save-request="void saveTemplate()"
+                        @update-prop="updateProp"
+                        @update-expression-prop="updateExpressionProp"
+                        @update-text="updateText"
+                        @commit-message-text="commitMessageText"
+                        @toggle-variable-group="toggleVariableGroup"
+                        @save-schema="saveProfileSchema"
+                    />
                 </aside>
-            </Tooltip>
-            <aside v-else class="flex min-w-0 min-h-0 flex-col">
-                <ProfileTemplateInspectorPanel
-                    v-model:active-tab="inspectorTab"
-                    v-model:variable-search="variableSearch"
-                    :tabs="inspectorTabs"
-                    :selected-node="selectedNode"
-                    :selected-prop-entries="selectedPropEntries"
-                    :selected-text-length="selectedTextLength"
-                    :source-text="sourceText"
-                    :source-line-count="sourceLineCount"
-                    :parsing-source="parsingSource"
-                    :selected-template-file-name="selectedTemplateFileName"
-                    :issues="issues"
-                    :variable-groups="variableGroups"
-                    :filtered-variable-groups="filteredVariableGroups"
-                    :filtered-runtime-variable-groups="filteredRuntimeVariableGroups"
-                    :role-options="roleOptions"
-                    :tool-status-options="toolStatusOptions"
-                    :source-options="sourceOptions"
-                    :theme="theme"
-                    :monaco-preferences="sourceEditorPreferences"
-                    :is-expression-value="isExpressionValue"
-                    :prop-input-value="propInputValue"
-                    :prop-label="propLabel"
-                    :node-title="nodeTitle"
-                    :issue-detail="issueDetail"
-                    :format-variable-value="formatVariableValue"
-                    :is-variable-group-collapsed="isVariableGroupCollapsed"
-                    :profile-detail="profileDetail"
-                    @collapse="inspectorPanelCollapsed = true"
-                    @source-change="handleSourceTextChange"
-                    @source-save-request="void saveTemplate()"
-                    @update-prop="updateProp"
-                    @update-expression-prop="updateExpressionProp"
-                    @update-text="updateText"
-                    @commit-message-text="commitMessageText"
-                    @toggle-variable-group="toggleVariableGroup"
-                    @save-schema="saveProfileSchema"
-                />
-            </aside>
-            </main>
-        </DragDropProvider>
+                </main>
+            </DragDropProvider>
+        </div>
 
         <ProfileTemplatePreviewDialog
             v-model="previewDialogOpen"
@@ -2638,5 +2637,123 @@ onBeforeUnmount(() => {
     color: var(--text-secondary);
     font-size: 12px;
     font-weight: 700;
+}
+
+/* 编辑器外壳：容器查询宿主。以编辑器实际宽度切换布局（Dialog 内上限 1120px，视口断点不可靠）。
+   不能放在主题宿主根节点上——layout containment 会改变 position:fixed 的定位基准，破坏 Tooltip 浮层。 */
+.profile-editor-shell {
+    display: flex;
+    min-height: 0;
+    flex: 1;
+    flex-direction: column;
+    container-type: inline-size;
+}
+
+/* 默认（窄容器）：单列三行堆叠，主容器自身不产生横向滚动 */
+.profile-editor-main {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.profile-editor-main:where(:not(.library-collapsed):not(.inspector-collapsed)) {
+    grid-template-rows: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.profile-editor-main:where(.library-collapsed:not(.inspector-collapsed)) {
+    grid-template-rows: 52px minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.profile-editor-main:where(.inspector-collapsed:not(.library-collapsed)) {
+    grid-template-rows: minmax(0, 1fr) minmax(0, 1fr) 52px;
+}
+
+.profile-editor-main:where(.library-collapsed.inspector-collapsed) {
+    grid-template-rows: 52px minmax(0, 1fr) 52px;
+}
+
+/* 窄容器下折叠 rail 变横向条，图标横向滚动 */
+.component-rail {
+    flex-direction: row;
+    padding: 6px 10px;
+}
+
+.rail-divider {
+    height: 24px;
+    width: 1px;
+}
+
+.component-rail-scroll {
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+.rail-group-divider {
+    height: 18px;
+    width: 1px;
+    margin: 0 2px;
+}
+
+.panel-rail {
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 10px;
+}
+
+.rail-label {
+    writing-mode: horizontal-tb;
+}
+
+/* 宽容器：恢复原三栏轨道与纵向 rail */
+@container (min-width: 1259px) {
+    .profile-editor-main {
+        grid-template-rows: minmax(0, 1fr);
+        grid-template-columns: 290px minmax(560px, 1fr) minmax(360px, 30vw);
+    }
+
+    .profile-editor-main.library-collapsed {
+        grid-template-columns: 52px minmax(560px, 1fr) minmax(360px, 30vw);
+    }
+
+    .profile-editor-main.inspector-collapsed {
+        grid-template-columns: 290px minmax(560px, 1fr) 52px;
+    }
+
+    .profile-editor-main.library-collapsed.inspector-collapsed {
+        grid-template-columns: 52px minmax(560px, 1fr) 52px;
+    }
+
+    .component-rail {
+        flex-direction: column;
+        padding: 8px 3px;
+    }
+
+    .rail-divider {
+        height: 1px;
+        width: 24px;
+    }
+
+    .component-rail-scroll {
+        flex-direction: column;
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+
+    .rail-group-divider {
+        height: 1px;
+        width: 18px;
+        margin: 4px 0 2px;
+    }
+
+    .panel-rail {
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+        padding: 14px 4px 12px;
+    }
+
+    .rail-label {
+        writing-mode: vertical-rl;
+    }
 }
 </style>

--- a/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateVisualEditor.vue
+++ b/packages/neuro-book/app/components/profile-template-editor/ProfileTemplateVisualEditor.vue
@@ -11,6 +11,7 @@ import ProfileTemplateComponentLibraryPanel from "nbook/app/components/profile-t
 import ProfileTemplateHeader from "nbook/app/components/profile-template-editor/ProfileTemplateHeader.vue";
 import ProfileTemplateInspectorPanel from "nbook/app/components/profile-template-editor/ProfileTemplateInspectorPanel.vue";
 import ProfileTemplatePreviewDialog from "nbook/app/components/profile-template-editor/ProfileTemplatePreviewDialog.vue";
+import Tooltip from "nbook/app/components/common/Tooltip.vue";
 import {
     componentGroupTabs,
     componentLibrary,
@@ -74,6 +75,7 @@ import {
 } from "nbook/app/components/profile-template-editor/profile-template-tree-utils";
 import {buildNovelIdeClientVariables} from "nbook/app/components/novel-ide/agent/client-variables";
 import {useIdeTheme} from "nbook/app/composables/useIdeTheme";
+import {IDE_THEME_HOST_CLASS} from "nbook/app/utils/theme/theme-tokens";
 import {useAgentSessionApi} from "nbook/app/composables/useAgentSessionApi";
 import {useNotification} from "nbook/app/composables/useNotification";
 import {useNovelIdeStore} from "nbook/app/stores/novel-ide";
@@ -2158,7 +2160,11 @@ watch(selectedThreadId, async () => {
 });
 
 onMounted(async () => {
-    mountThemeHost(themeHostRef.value);
+    // 已处于既有主题宿主内（如工作台 Dialog 内嵌场景）时不重复创建嵌套宿主；
+    // 否则 Tooltip 等 fixed 浮层会被 Teleport 进 transform 容器内的嵌套宿主，fixed 定位基准失效。
+    if (!themeHostRef.value?.closest(`.${IDE_THEME_HOST_CLASS}`)) {
+        mountThemeHost(themeHostRef.value);
+    }
     keyboardListener = handleEditorKeydown;
     window.addEventListener("keydown", keyboardListener);
     await Promise.all([
@@ -2230,31 +2236,37 @@ onBeforeUnmount(() => {
             @drag-end="handleNodeDragEnd"
         >
             <main
-                class="grid min-h-0 flex-1 gap-3 p-3"
+                class="grid min-h-0 min-w-0 flex-1 gap-3 overflow-x-auto p-3"
                 :class="[
-                    libraryPanelCollapsed ? 'grid-cols-[42px_minmax(560px,1fr)_minmax(360px,30vw)]' : 'grid-cols-[290px_minmax(560px,1fr)_minmax(360px,30vw)]',
-                    inspectorPanelCollapsed ? (libraryPanelCollapsed ? '!grid-cols-[42px_minmax(560px,1fr)_42px]' : '!grid-cols-[290px_minmax(560px,1fr)_42px]') : '',
+                    libraryPanelCollapsed ? 'grid-cols-[52px_minmax(560px,1fr)_minmax(360px,30vw)]' : 'grid-cols-[290px_minmax(560px,1fr)_minmax(360px,30vw)]',
+                    inspectorPanelCollapsed ? (libraryPanelCollapsed ? '!grid-cols-[52px_minmax(560px,1fr)_52px]' : '!grid-cols-[290px_minmax(560px,1fr)_52px]') : '',
                 ]"
             >
             <aside v-if="libraryPanelCollapsed" class="component-rail">
-                <button type="button" class="rail-icon-btn" title="展开组件库" @click="libraryPanelCollapsed = false">
-                    <span class="i-lucide-panel-left-open h-4 w-4"></span>
-                </button>
+                <Tooltip text="展开组件库" placement="right">
+                    <button type="button" class="rail-icon-btn" @click="libraryPanelCollapsed = false">
+                        <span class="i-lucide-panel-left-open h-4 w-4"></span>
+                    </button>
+                </Tooltip>
                 <div class="rail-divider"></div>
-                <div class="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto overflow-x-hidden pr-0.5 custom-scrollbar">
+                <div class="component-rail-scroll custom-scrollbar">
                     <template v-for="group in compactComponentGroups" :key="group.group">
                         <div class="rail-group-divider" :title="group.label"></div>
-                        <button
+                        <Tooltip
                             v-for="item in group.items"
                             :key="item.type"
-                            type="button"
-                            class="rail-icon-btn"
-                            :class="`library-node-${item.type}`"
-                            :title="`${group.label} / ${item.label}：${item.description}`"
-                            @click="addNode(item.type)"
+                            :text="`${group.label} / ${item.label}：${item.description}`"
+                            placement="right"
                         >
-                            <span :class="item.iconClass" class="h-4 w-4"></span>
-                        </button>
+                            <button
+                                type="button"
+                                class="rail-icon-btn"
+                                :class="`library-node-${item.type}`"
+                                @click="addNode(item.type)"
+                            >
+                                <span :class="item.iconClass" class="h-4 w-4"></span>
+                            </button>
+                        </Tooltip>
                     </template>
                 </div>
             </aside>
@@ -2284,10 +2296,12 @@ onBeforeUnmount(() => {
             />
 
             <!-- 右侧源码、属性与变量面板 -->
-            <aside v-if="inspectorPanelCollapsed" class="panel-rail" title="展开右侧面板" @click="inspectorPanelCollapsed = false">
-                <span class="i-lucide-panel-right-open h-4 w-4"></span>
-                <span class="rail-label">面板</span>
-            </aside>
+            <Tooltip v-if="inspectorPanelCollapsed" text="展开右侧面板" placement="bottom">
+                <aside class="panel-rail" @click="inspectorPanelCollapsed = false">
+                    <span class="i-lucide-panel-right-open h-4 w-4"></span>
+                    <span class="rail-label">面板</span>
+                </aside>
+            </Tooltip>
             <aside v-else class="flex min-w-0 min-h-0 flex-col">
                 <ProfileTemplateInspectorPanel
                     v-model:active-tab="inspectorTab"
@@ -2399,16 +2413,17 @@ onBeforeUnmount(() => {
 <style scoped>
 .panel-rail {
     display: flex;
+    width: 100%;
     min-height: 0;
     cursor: pointer;
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
-    gap: 8px;
+    gap: 10px;
     border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border-radius: 10px;
     background: var(--bg-panel);
-    padding: 10px 6px;
+    padding: 14px 4px 12px;
     color: var(--text-muted);
     box-shadow: 0 16px 44px color-mix(in srgb, var(--shadow-color) 5%, transparent);
     transition: border-color 0.18s ease, background-color 0.18s ease, color 0.18s ease;
@@ -2416,15 +2431,38 @@ onBeforeUnmount(() => {
 
 .component-rail {
     display: flex;
+    width: 100%;
     min-height: 0;
     flex-direction: column;
     align-items: center;
     gap: 6px;
     border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border-radius: 10px;
     background: var(--bg-panel);
-    padding: 8px 5px;
+    padding: 8px 3px;
     box-shadow: 0 16px 44px color-mix(in srgb, var(--shadow-color) 5%, transparent);
+}
+
+.component-rail-scroll {
+    display: flex;
+    min-height: 0;
+    width: 100%;
+    flex: 1;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding-inline: 1px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    scrollbar-width: none;
+    scrollbar-color: transparent transparent;
+    -ms-overflow-style: none;
+}
+
+.component-rail-scroll::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
 }
 
 .rail-icon-btn {
@@ -2433,8 +2471,8 @@ onBeforeUnmount(() => {
     --component-border: color-mix(in srgb, var(--component-accent) 34%, var(--border-color));
     --component-icon-color: color-mix(in srgb, var(--component-accent) 80%, var(--text-main));
     display: inline-flex;
-    height: 30px;
-    width: 30px;
+    height: 28px;
+    width: 28px;
     flex-shrink: 0;
     align-items: center;
     justify-content: center;

--- a/packages/neuro-book/app/components/profile-template-editor/profile-template-responsive.contract.test.ts
+++ b/packages/neuro-book/app/components/profile-template-editor/profile-template-responsive.contract.test.ts
@@ -1,0 +1,131 @@
+import {readFile} from "node:fs/promises";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+
+const headerPath = fileURLToPath(new URL("./ProfileTemplateHeader.vue", import.meta.url));
+const libraryPanelPath = fileURLToPath(new URL("./ProfileTemplateComponentLibraryPanel.vue", import.meta.url));
+const inspectorPanelPath = fileURLToPath(new URL("./ProfileTemplateInspectorPanel.vue", import.meta.url));
+const canvasPanelPath = fileURLToPath(new URL("./ProfileTemplateCanvasPanel.vue", import.meta.url));
+const visualEditorPath = fileURLToPath(new URL("./ProfileTemplateVisualEditor.vue", import.meta.url));
+
+describe("Profile Template 工作台响应式契约", () => {
+    it("顶栏窄容器可换行，动作按钮完整可达且带语义标签", async () => {
+        const source = (await readFile(headerPath, "utf8")).replace(/\r\n/g, "\n");
+
+        expect(source).toContain('class="profile-template-header__actions flex min-w-0 max-w-full shrink-0 flex-wrap items-center gap-2"');
+        // 品牌块与模板选择器同处 identity 容器：用 div 配对边界证明嵌套，而非仅顺序
+        const identityOpen = source.indexOf('class="profile-template-header__identity');
+        const selectOpen = source.indexOf("<FormSelect");
+        const actionsOpen = source.indexOf('class="profile-template-header__actions');
+        expect(identityOpen).toBeGreaterThanOrEqual(0);
+        expect(selectOpen).toBeGreaterThan(identityOpen);
+        expect(actionsOpen).toBeGreaterThan(selectOpen);
+        const divPattern = /<div\b|<\/div>/g;
+        divPattern.lastIndex = identityOpen;
+        let depth = 1;
+        let identityClose = -1;
+        let match: RegExpExecArray | null;
+        while ((match = divPattern.exec(source)) !== null) {
+            depth += match[0].startsWith("</") ? -1 : 1;
+            if (depth === 0) {
+                identityClose = match.index;
+                break;
+            }
+        }
+        expect(identityClose).toBeGreaterThan(selectOpen);
+        expect(identityClose).toBeLessThan(actionsOpen);
+        expect(source).not.toContain("flex h-12 shrink-0 items-center");
+        expect(source).toContain("profile-template-header__identity flex min-w-0 items-center gap-3");
+        expect(source).toContain("@container (max-width: 900px)");
+        // 状态文本可无限长（可能拼接服务端错误信息），必须可收缩截断而非撑爆动作区
+        expect(source).toContain('class="hidden min-w-0 items-center gap-1 text-xs text-[var(--status-success)] md:flex"');
+        expect(source).toContain('class="min-w-0 truncate">{{ props.editorStatusText }}');
+
+        // 全部图标按钮逐个关联 type 与 aria-label，且不依赖原生 title
+        const buttonTags = source.match(/<button[^>]*>/g) ?? [];
+        expect(buttonTags.length).toBeGreaterThanOrEqual(11);
+        for (const tag of buttonTags) {
+            expect(tag).toContain('type="button"');
+            expect(tag).toContain("aria-label=");
+        }
+        expect(source).not.toMatch(/\stitle="/);
+
+        // disabled 按钮的 Tooltip 触发包装：每个 :disabled 按钮必须被真实盒模型 span 包裹，
+        // 且该按钮携带 disabled:pointer-events-none；wrapper 数与 disabled 按钮数相等，不允许样例式存在
+        const disabledButtonTags = buttonTags.filter((tag) => tag.includes(":disabled="));
+        const wrappedButtonTags = source.match(/profile-template-tooltip-trigger">\s*<button[^>]*>/g) ?? [];
+        expect(disabledButtonTags.length).toBeGreaterThanOrEqual(10);
+        expect(wrappedButtonTags.length).toBe(disabledButtonTags.length);
+        for (const tag of wrappedButtonTags) {
+            expect(tag).toContain(":disabled=");
+            expect(tag).toContain("disabled:pointer-events-none");
+        }
+    });
+
+    it("组件库与检查器折叠按钮统一使用 Tooltip，不再使用原生 title", async () => {
+        const librarySource = (await readFile(libraryPanelPath, "utf8")).replace(/\r\n/g, "\n");
+        const inspectorSource = (await readFile(inspectorPanelPath, "utf8")).replace(/\r\n/g, "\n");
+
+        expect(librarySource).toContain('import Tooltip from "nbook/app/components/common/Tooltip.vue"');
+        expect(librarySource).toContain('<Tooltip text="收起组件库" placement="bottom">');
+        expect(librarySource).toContain('aria-label="收起组件库"');
+        expect(librarySource).not.toContain('title="收起组件库"');
+
+        expect(inspectorSource).toContain('import Tooltip from "nbook/app/components/common/Tooltip.vue"');
+        expect(inspectorSource).toContain('<Tooltip text="收起右侧面板" placement="bottom">');
+        expect(inspectorSource).toContain('aria-label="收起右侧面板"');
+        expect(inspectorSource).not.toContain('title="收起右侧面板"');
+    });
+
+    it("主网格按容器宽度分层：窄容器单列无横向滚动，宽容器恢复三栏轨道", async () => {
+        const source = (await readFile(visualEditorPath, "utf8")).replace(/\r\n/g, "\n");
+
+        expect(source).toContain("profile-editor-main grid min-h-0 min-w-0 flex-1 gap-3 overflow-hidden p-3");
+        expect(source).toContain("'library-collapsed'");
+        expect(source).toContain("'inspector-collapsed'");
+        expect(source).not.toContain("overflow-x-auto");
+        expect(source).not.toContain("!grid-cols-");
+
+        expect(source).toContain("container-type: inline-size");
+        expect(source).toContain("@container (min-width: 1259px)");
+        // 规则块级断言：轨道声明必须绑定在对应状态选择器的规则内，防止字符串挪动规则仍假绿
+        const mainRules = source.match(/\.profile-editor-main[^{]*\{[^}]*\}/g) ?? [];
+        const expectRule = (selectorPart: string, declaration: string) => {
+            const rule = mainRules.find((candidate) => candidate.includes(selectorPart) && candidate.includes(declaration));
+            expect(rule, `缺少规则 ${selectorPart} → ${declaration}`).toBeDefined();
+        };
+        // 窄容器：四种折叠状态的行轨道与状态选择器一一绑定
+        expectRule(":where(:not(.library-collapsed):not(.inspector-collapsed))", "grid-template-rows: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr)");
+        expectRule(":where(.library-collapsed:not(.inspector-collapsed))", "grid-template-rows: 52px minmax(0, 1fr) minmax(0, 1fr)");
+        expectRule(":where(.inspector-collapsed:not(.library-collapsed))", "grid-template-rows: minmax(0, 1fr) minmax(0, 1fr) 52px");
+        expectRule(":where(.library-collapsed.inspector-collapsed)", "grid-template-rows: 52px minmax(0, 1fr) 52px");
+        // 宽容器：基础规则同时锁定单行与全展开列轨道；三种折叠列轨道与状态选择器一一绑定
+        const wideBaseRule = mainRules.find((candidate) => candidate.includes("grid-template-rows: minmax(0, 1fr);") && candidate.includes("grid-template-columns: 290px minmax(560px, 1fr) minmax(360px, 30vw)"));
+        expect(wideBaseRule).toBeDefined();
+        expectRule(".profile-editor-main.library-collapsed {", "grid-template-columns: 52px minmax(560px, 1fr) minmax(360px, 30vw)");
+        expectRule(".profile-editor-main.inspector-collapsed {", "grid-template-columns: 290px minmax(560px, 1fr) 52px");
+        expectRule(".profile-editor-main.library-collapsed.inspector-collapsed {", "grid-template-columns: 52px minmax(560px, 1fr) 52px");
+        // 特异性守卫：窄态单折叠规则的状态匹配必须整体收进 :where()，
+        // 否则 :not() 贡献的 (0,1,0) 会让窄态行规则 (0,2,0) 压过宽容器 @container 规则 (0,1,0)。
+        // 精确否定两种回归形态，避免误伤合法的 :where(:not(..):not(..)) 全展开规则。
+        expect(source).not.toContain(".profile-editor-main:where(.library-collapsed):not(");
+        expect(source).not.toContain(".profile-editor-main:where(.inspector-collapsed):not(");
+    });
+
+    it("折叠态面板入口是语义按钮并保留 Tooltip", async () => {
+        const source = (await readFile(visualEditorPath, "utf8")).replace(/\r\n/g, "\n");
+
+        expect(source).toContain('<button type="button" class="panel-rail" aria-label="展开右侧面板"');
+        expect(source).not.toContain('<aside class="panel-rail"');
+        expect(source).toContain('<Tooltip text="展开组件库" placement="right">');
+        expect(source).toContain('aria-label="展开组件库"');
+    });
+
+    it("单列布局下面板根节点允许收缩，不被内容最小宽度撑开", async () => {
+        const librarySource = (await readFile(libraryPanelPath, "utf8")).replace(/\r\n/g, "\n");
+        const canvasSource = (await readFile(canvasPanelPath, "utf8")).replace(/\r\n/g, "\n");
+
+        expect(librarySource).toContain('class="panel flex min-h-0 min-w-0 flex-col"');
+        expect(canvasSource).toContain('class="panel flex min-h-0 min-w-0 flex-col"');
+    });
+});


### PR DESCRIPTION
## 关联 Issue

Closes #124

## 范围

- **范围内**：Agent Profile 工作台 UI 体验修复 —— 顶栏图标化、Profile 列表独立滚动、面板折叠栏优化。涉及 6 个组件（156+/101-）：
  - `AgentProfileNavList.vue`：Profile 列表独立滚动
  - `NovelIdeAgentProfileModelSettingsPanel.vue`：设置面板布局调整
  - `ProfileTemplateHeader.vue`：顶栏图标化（122 行重构）
  - `ProfileTemplateInspectorPanel.vue`：折叠栏优化
  - `ProfileTemplateLibraryItem.vue`：列表项细节
  - `ProfileTemplateVisualEditor.vue`：Tooltip 定位修复（基于上游 TooltipPlacement 支持的 right/bottom）
- **不在范围内**：无其它功能改动。

## 用户可见结果

- 工作台顶栏从文字改为图标化，节省横向空间
- Profile 列表在面板内独立滚动，不再带动整体页面滚动
- 面板折叠栏交互优化

## 技术实现

- VisualEditor 中 `placement="left"` 改为上游支持的 `"bottom"`（上游 TooltipPlacement 输入侧仅 right/bottom）
- 顶栏 Tooltip 定位改为基于既有主题宿主，避免 fixed 浮层定位基准失效

## 验证

- `bun --cwd packages/neuro-book run typecheck`：✅ 通过（vue-tsc 0 error）
- 聚焦测试（profile-template-editor + novel-ide/profile）：✅ 4 files / 10 tests 全部通过
- 浏览器人工验收：未运行

## 已知限制

- 未做浏览器人工验收，仅静态类型与组件测试覆盖
