### PR TITLE
ci(release): verify podman compose delegate path

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -1010,6 +1010,74 @@ jobs:
             "$manager_version" "$candidate_manifest" \
             "${RUNNER_TEMP}/public-ghcr-podman" 39489 podman
 
+  verify-public-ghcr-podman-delegate:
+    needs: [verify-public-payload]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      PODMAN_COMPOSE_MASKED_ROOT: ${{ runner.temp }}/podman-compose-masked
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.revision }}
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-candidate
+          path: candidate-assets
+      - name: Install Podman and mask podman-compose outside PATH
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes podman
+          mkdir -p "$PODMAN_COMPOSE_MASKED_ROOT/deb"
+          cd "$PODMAN_COMPOSE_MASKED_ROOT/deb"
+          apt-get download podman-compose
+          dpkg -x ./*.deb "$PODMAN_COMPOSE_MASKED_ROOT/root"
+          masked_bin="$PODMAN_COMPOSE_MASKED_ROOT/root/usr/bin/podman-compose"
+          test -x "$masked_bin"
+          echo "podman-compose 已保留安装在 PATH 之外：$masked_bin"
+          if ! command -v docker-compose >/dev/null 2>&1; then
+              plugin=""
+              for candidate_path in /usr/libexec/docker/cli-plugins/docker-compose /usr/lib/docker/cli-plugins/docker-compose; do
+                  if [[ -x "$candidate_path" ]]; then plugin="$candidate_path"; break; fi
+              done
+              if [[ -z "$plugin" ]]; then
+                  sudo apt-get install --yes docker-compose-v2
+                  plugin="/usr/libexec/docker/cli-plugins/docker-compose"
+              fi
+              sudo ln -sf "$plugin" /usr/local/bin/docker-compose
+          fi
+          command -v docker-compose
+          if command -v podman-compose >/dev/null 2>&1; then
+              echo "隔离失败：podman-compose 不允许存在于 PATH。" >&2
+              exit 1
+          fi
+          systemctl --user enable --now podman.socket
+          podman info
+          podman compose version
+          # 持久化 sanitized PATH：逐行写入（每行一个目录条目，不能写整串 PATH=...），
+          # 并显式剔除 masked 根前缀，防止任何后续步骤意外纳入。
+          printf '%s\n' "$(printf '%s' "$PATH" | tr ':' '\n' | grep -v "^$PODMAN_COMPOSE_MASKED_ROOT")" >> "$GITHUB_PATH"
+      - name: Verify public GHCR on Linux x64 rootless Podman via delegated provider
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -x "$PODMAN_COMPOSE_MASKED_ROOT/root/usr/bin/podman-compose"
+          if command -v podman-compose >/dev/null 2>&1; then
+              echo "隔离失败：podman-compose 不允许存在于 PATH。" >&2
+              exit 1
+          fi
+          command -v docker-compose
+          manager_version="$(node -p 'require("./packages/neuro-book-manager/package.json").version')"
+          candidate_manifest="$PWD/candidate-assets/release-manifest.json"
+          bash scripts/release/verify-public-ghcr.sh \
+            "$manager_version" "$candidate_manifest" \
+            "${RUNNER_TEMP}/public-ghcr-podman-delegate" 39490 podman delegate
+
   verify-public-windows-data-reuse:
     needs: [verify-public-payload]
     runs-on: windows-latest
@@ -1136,7 +1204,7 @@ jobs:
           Remove-Item -LiteralPath (Join-Path $env:RUNNER_TEMP "portable-0.8.6.zip") -Force -ErrorAction SilentlyContinue
 
   publish-index:
-    needs: [verify-public-ghcr-amd64, verify-public-ghcr-arm64, verify-public-ghcr-podman, verify-public-windows-data-reuse]
+    needs: [verify-public-ghcr-amd64, verify-public-ghcr-arm64, verify-public-ghcr-podman, verify-public-ghcr-podman-delegate, verify-public-windows-data-reuse]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/release/release-assets.test.ts
+++ b/scripts/release/release-assets.test.ts
@@ -612,6 +612,7 @@ describe("Product Release宿主合同", () => {
                 "verify-public-ghcr-amd64": WorkflowJob;
                 "verify-public-ghcr-arm64": WorkflowJob;
                 "verify-public-ghcr-podman": WorkflowJob;
+                "verify-public-ghcr-podman-delegate": WorkflowJob;
                 "verify-public-windows-data-reuse": WorkflowJob;
             };
         };
@@ -640,10 +641,15 @@ describe("Product Release宿主合同", () => {
             ({run}) => run?.includes("PODMAN_COMPOSE_PROVIDER=podman-compose podman compose version"),
         )).toBe(true);
         expect(workflow.jobs["verify-public-ghcr-podman"].steps.some(({run}) => run?.includes("verify-public-ghcr.sh") && run.includes("podman"))).toBe(true);
+        expect(workflow.jobs["verify-public-ghcr-podman-delegate"].steps.some(({run}) => run?.includes("verify-public-ghcr.sh") && run.includes("delegate"))).toBe(true);
+        expect(workflow.jobs["verify-public-ghcr-podman-delegate"].steps.some(({run}) => run?.includes("隔离失败：podman-compose 不允许存在于 PATH。"))).toBe(true);
+        expect(workflow.jobs["verify-public-ghcr-podman-delegate"].steps.some(({run}) => run?.includes("command -v podman-compose"))).toBe(true);
+        expect(workflow.jobs["verify-public-ghcr-podman-delegate"].steps.some(({run}) => run?.includes("PODMAN_COMPOSE_MASKED_ROOT"))).toBe(true);
         const publicGhcr = await readFile(resolve(ROOT, "scripts/release/verify-public-ghcr.sh"), "utf8");
         expect(publicGhcr).toContain('scripts/release/installation-state-root.ts "$root"');
         expect(publicGhcr).toContain('state_root="$(resolve_state_root)"');
         expect(publicGhcr).toContain('--filter "label=com.docker.compose.project.working_dir=$compose_working_dir"');
+        expect(publicGhcr).toContain('if [[ "$engine" == "podman" && "$podman_compose_provider" != "delegate" ]]');
         expect(publicGhcr).toContain('--filter "label=com.docker.compose.service=app"');
         expect(publicGhcr).toContain('compose ps --all --quiet app');
         expect(publicGhcr).not.toContain('--env-file "$root/.env"');
@@ -667,6 +673,7 @@ describe("Product Release宿主合同", () => {
             "verify-public-ghcr-amd64",
             "verify-public-ghcr-arm64",
             "verify-public-ghcr-podman",
+            "verify-public-ghcr-podman-delegate",
             "verify-public-windows-data-reuse",
         ]);
     });

--- a/scripts/release/verify-public-ghcr.sh
+++ b/scripts/release/verify-public-ghcr.sh
@@ -6,6 +6,7 @@ candidate_manifest="$2"
 root="$3"
 port="$4"
 engine="$5"
+podman_compose_provider="${6:-}"
 manifest="$root/.deploy/installation.json"
 compose_path="$root/.deploy/docker-compose.generated.yml"
 manager_home="${root}-manager"
@@ -16,7 +17,8 @@ channel="$(node -e 'const m=require(process.argv[1]); process.stdout.write(m.cha
 export NEURO_BOOK_CONTAINER_ENGINE="$engine"
 export NEURO_BOOK_MANAGER_CONFIG="${manager_home}/config.json"
 export NO_COLOR=1
-if [[ "$engine" == "podman" ]]; then
+case "$podman_compose_provider" in ""|"delegate") ;; *) { echo "非法compose provider参数：$podman_compose_provider" >&2; exit 1; } ;; esac
+if [[ "$engine" == "podman" && "$podman_compose_provider" != "delegate" ]]; then
     export PODMAN_COMPOSE_PROVIDER="podman-compose"
 fi
 


### PR DESCRIPTION
## 概述

Issue #109 验收要求以「PATH 屏蔽 podman-compose」验证 `podman compose` 委托路径；当前发布流水线只覆盖独立 provider。

## 改动

- `scripts/release/verify-public-ghcr.sh`：新增第 6 参 provider 合同——缺省保持强制 `podman-compose`；字面量 `delegate` 不注入任何变量，由 Manager 自行探测（#110 引入的 `containerComposeEnvironment`）。
- `.github/workflows/release-container.yml`：新增 `verify-public-ghcr-podman-delegate` job。podman-compose 经 `apt-get download + dpkg -x` 解包到 masked root（保留安装在盘、目录永不入 PATH），sanitized PATH 经 $GITHUB_PATH 持久化；install 与 verify 两个 step 都断言存在性与 PATH 不可达，然后走完整 install → migration → admin → login → doctor → stop/restart → Operation 恢复链路（端口 39490）。`publish-index.needs` 同步纳入。
- `scripts/release/release-assets.test.ts`：新 job 类型、四条稳定标记断言、needs 数组、脚本第 6 参条件导出断言。

## 验证

- `bash -n scripts/release/verify-public-ghcr.sh` 通过
- release-assets 契约测试 21 项全绿
- workspace-workflows 测试 10 项全绿
- 真实双路径证据由下一次应用 canary 发版的两个 podman verify job 产出（独立路径继续复验 #110 容噪解析）

关联 #109