### PR TITLE
fix(tool-panel): Novel IDE 工具面板与导航整理（书架入口去重、用户资产页内导航、上传按钮对齐）

### DIFF
--- a/packages/neuro-book/app/components/common/Dropdown.vue
+++ b/packages/neuro-book/app/components/common/Dropdown.vue
@@ -45,7 +45,7 @@ onClickOutside(rootRef, () => {
 <template>
     <!-- 下拉菜单容器 -->
     <div ref="rootRef" :class="props.rootClass">
-        <div class="w-full" @click.stop="toggle">
+        <div class="flex w-full items-center" @click.stop="toggle">
             <slot />
         </div>
 

--- a/packages/neuro-book/app/components/novel-ide/NovelIdeToolPanel.vue
+++ b/packages/neuro-book/app/components/novel-ide/NovelIdeToolPanel.vue
@@ -362,11 +362,6 @@ function handleSyncDiffAction(payload: DiffWorkbenchActionPayload): void {
 
             <div class="shrink-0 border-b border-[var(--border-color)]">
                 <div v-if="!props.userAssetsMode" class="flex h-9 items-center gap-1 border-b border-[var(--border-color)] px-2">
-                    <Tooltip :text="t('ide.header.bookshelfTitle')" placement="bottom">
-                        <button type="button" class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" @click="emit('openHome')">
-                            <span class="i-lucide-library h-4 w-4"></span>
-                        </button>
-                    </Tooltip>
                     <Dropdown
                         v-if="!props.userAssetsMode"
                         class="min-w-0 flex-1"

--- a/packages/neuro-book/app/components/novel-ide/NovelIdeToolPanel.vue
+++ b/packages/neuro-book/app/components/novel-ide/NovelIdeToolPanel.vue
@@ -400,13 +400,13 @@ function handleSyncDiffAction(payload: DiffWorkbenchActionPayload): void {
                                 <span :class="uploadingSingleFile ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-file-up'" class="h-4 w-4"></span>
                             </button>
                         </Tooltip>
-                        <Dropdown class="!w-auto" :items="projectUploadItems" menu-class="right-0 top-full mt-1 w-36" @select="selectProjectUploadMode">
-                            <Tooltip :text="t('ide.toolPanel.uploadProjectTitle')" placement="bottom">
+                        <Tooltip :text="t('ide.toolPanel.uploadProjectTitle')" placement="bottom">
+                            <Dropdown root-class="relative inline-flex items-center" :items="projectUploadItems" menu-class="right-0 top-full mt-1 w-36" @select="selectProjectUploadMode">
                                 <button class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-50" :disabled="uploadingProject">
                                     <span :class="uploadingProject ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-folder-up'" class="h-4 w-4"></span>
                                 </button>
-                            </Tooltip>
-                        </Dropdown>
+                            </Dropdown>
+                        </Tooltip>
                         <Tooltip :text="downloadButtonTitle" placement="bottom">
                             <button class="rounded-2 p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-50" :disabled="downloadingWorkspace" @click="openDownloadConfirm">
                                 <span :class="downloadingWorkspace ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-download'" class="h-4 w-4"></span>

--- a/packages/neuro-book/app/components/novel-ide/NovelIdeToolPanel.vue
+++ b/packages/neuro-book/app/components/novel-ide/NovelIdeToolPanel.vue
@@ -361,7 +361,7 @@ function handleSyncDiffAction(payload: DiffWorkbenchActionPayload): void {
             </div>
 
             <div class="shrink-0 border-b border-[var(--border-color)]">
-                <div class="flex h-9 items-center gap-1 border-b border-[var(--border-color)] px-2">
+                <div v-if="!props.userAssetsMode" class="flex h-9 items-center gap-1 border-b border-[var(--border-color)] px-2">
                     <Tooltip :text="t('ide.header.bookshelfTitle')" placement="bottom">
                         <button type="button" class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" @click="emit('openHome')">
                             <span class="i-lucide-library h-4 w-4"></span>
@@ -382,7 +382,7 @@ function handleSyncDiffAction(payload: DiffWorkbenchActionPayload): void {
                             <span class="i-lucide-chevron-down h-3.5 w-3.5 shrink-0"></span>
                         </button>
                     </Dropdown>
-                    <div v-else class="min-w-0 flex-1 truncate px-2 text-xs text-[var(--text-secondary)]">{{ props.workspaceTitle }}</div>
+
                 </div>
 
                 <div class="flex items-center justify-between px-3 py-2">

--- a/packages/neuro-book/app/pages/index.vue
+++ b/packages/neuro-book/app/pages/index.vue
@@ -1310,6 +1310,9 @@ const openProjectFromPicker = async (projectRoot: string): Promise<void> => {
  * 因此其它窗口仍能继续持有同一个 Project。取消时保持 URL 原样，不留下多余的历史记录。
  */
 const openProjectPicker = async (): Promise<void> => {
+    if (isUserAssetsWorkspace.value) {
+        await releaseProjectSurface();
+    }
     await router.push("/");
 };
 

--- a/packages/neuro-book/app/pages/index.vue
+++ b/packages/neuro-book/app/pages/index.vue
@@ -1833,9 +1833,8 @@ const openPlotWorkbench = async (): Promise<void> => {
 /**
  * 打开全局用户 assets 工作区。
  */
-const openUserAssets = (): void => {
-    const resolved = router.resolve(buildProjectRoute(USER_ASSETS_PROJECT_TARGET));
-    window.open(resolved.href, "_blank", "noopener,noreferrer");
+const openUserAssets = async (): Promise<void> => {
+    await router.push(buildProjectRoute(USER_ASSETS_PROJECT_TARGET));
 };
 
 /**
@@ -2529,7 +2528,7 @@ onBeforeUnmount(() => {
 
         <div class="relative flex min-w-0 flex-1 flex-col overflow-hidden">
         <!-- 未选择 Project：项目选择界面接管整页 -->
-        <ProjectPickerScreen v-if="projectPickerActive" @open="void openProjectFromPicker($event)" @open-user-assets="openUserAssets" />
+        <ProjectPickerScreen v-if="projectPickerActive" @open="void openProjectFromPicker($event)" @open-user-assets="void openUserAssets()" />
         <WorldEngineWorkbenchDialog v-if="projectSurfaceActive && !isUserAssetsWorkspace" v-model="worldEngineWorkbenchOpen" :project-root="currentProjectRoot" :project-title="displayNovelTitle" @has-unsaved-drafts-change="worldEngineWorkbenchHasUnsavedDrafts = $event" @saving-change="worldEngineWorkbenchSaving = $event" @open-workspace-path="void openWelcomeWorkspacePath($event)" />
 
         <div v-if="projectSurfaceActive" class="flex min-h-0 flex-1 overflow-hidden">

--- a/packages/neuro-book/app/utils/workbench-chrome.test.ts
+++ b/packages/neuro-book/app/utils/workbench-chrome.test.ts
@@ -22,7 +22,7 @@ describe("Workbench Chrome", () => {
         })).toBe("compact");
     });
 
-    it("keeps the desktop activity bar focused on project tools and moves global navigation into the title bar", () => {
+    it("在桌面端和 Web 端都显示书架管理入口，全局导航移至标题栏", () => {
         const bookshelf = createWorkbenchActivityItems({
             desktopAvailable: true,
             surfaceActive: false,
@@ -30,6 +30,7 @@ describe("Workbench Chrome", () => {
         });
 
         expect(bookshelf.primary.map((item) => [item.id, item.disabled])).toEqual([
+            ["home", false],
             ["files", true],
             ["characters", true],
             ["plot", true],

--- a/packages/neuro-book/app/utils/workbench-chrome.ts
+++ b/packages/neuro-book/app/utils/workbench-chrome.ts
@@ -65,7 +65,7 @@ export function createWorkbenchActivityItems(
     const novelOnlyDisabled = projectDisabled || context.userAssetsMode;
     return {
         primary: [
-            ...(!context.desktopAvailable ? [{id: "home" as const, disabled: false}] : []),
+            {id: "home" as const, disabled: false},
             {id: "files", disabled: projectDisabled},
             {id: "characters", disabled: novelOnlyDisabled},
             {id: "plot", disabled: novelOnlyDisabled},


### PR DESCRIPTION
## 关联 Issue

Closes #126

## 范围

- **范围内**：Novel IDE 工具面板与导航整理 —— 书架入口去重、用户资产页内导航、上传按钮对齐。4 个提交、5 个文件（16+/18-）：
  - `NovelIdeToolPanel.vue`：上传按钮 Tooltip/Dropdown 结构对齐；用户资产模式下隐藏顶部书架导航条；移除顶部重复的书架导航按钮
  - `pages/index.vue`：用户资产页内导航优化、书架管理按钮跳转修复
  - `workbench-chrome.ts` + test：书架管理入口在桌面端和 Web 端都显示，全局导航移至标题栏
  - `Dropdown.vue`：上传下拉按钮对齐微调
- **不在范围内**：无其它功能改动。

## 用户可见结果

- 顶部工具栏不再有重复的书架入口（书架导航在标题栏保留）
- 用户资产页面内导航更清晰，书架管理按钮跳转正确
- 上传项目按钮与相邻按钮水平对齐

## 技术实现

- 用户资产模式（`userAssetsMode`）下隐藏顶部书架工具条，避免与标题栏全局导航重复
- Dropdown 与 Tooltip 包裹层级调整，修正对齐

## 验证

- `vue-tsc --noEmit`（主应用）：✅ 0 error
- `workbench-chrome.test.ts`：✅ 3/3 通过
- `test:desktop-contract` 套件：20 个失败均为 Electron 打包契约环境问题（master 基线同样失败，需构建产物），与本改动无关
- 浏览器人工验收：未运行

## 已知限制

- 未做浏览器人工验收，仅静态类型与单元测试覆盖
