### PR TITLE
fix(release): point manager release typecheck at app workspace

### DIFF
--- a/scripts/release/manager-release.ts
+++ b/scripts/release/manager-release.ts
@@ -56,7 +56,7 @@ async function releaseManager(channel: "stable" | "canary", options: ReleaseOpti
     packageJson.version = version;
     await writeFile(PACKAGE_PATH, `${JSON.stringify(packageJson, null, 4)}\n`, "utf8");
     await run("bun", ["install", "--lockfile-only"], {cwd: ROOT});
-    await run("bun", ["run", "runtime:typecheck"], {cwd: ROOT});
+    await run("bun", ["run", "--cwd", "packages/neuro-book", "runtime:typecheck"], {cwd: ROOT});
     await run("bun", ["run", "manager:typecheck"], {cwd: ROOT});
     await run("bun", ["run", "manager:test"], {cwd: ROOT});
     await run("bun", ["run", "manager:pack"], {cwd: ROOT});


### PR DESCRIPTION
monorepo 收敛后根 package.json 不再有 `runtime:typecheck`（脚本在 packages/neuro-book 内，release-manager.yml 已用 `bun run --cwd packages/neuro-book runtime:typecheck`）。`manager-release.ts` 仍以根 cwd 调用，导致 `bun run manager:release` 在版本 bump 后立即失败（exit 1，Script not found）。改为与发布 workflow 相同的调用形式。