### PR TITLE
fix(model-settings): Provider 列表在长滚动时保持可见（sticky）

### DIFF
--- a/packages/neuro-book/app/components/novel-ide/settings/NovelIdeModelSettingsPanel.vue
+++ b/packages/neuro-book/app/components/novel-ide/settings/NovelIdeModelSettingsPanel.vue
@@ -453,9 +453,9 @@ defineExpose({dirty, loading, saving, saveSettings, restoreSettings});
         </div>
 
         <!-- 模型设置双栏布局 -->
-        <div v-else-if="!isProjectScope" class="grid min-h-[500px] gap-5 xl:grid-cols-[260px_minmax(0,1fr)]">
+        <div v-else-if="!isProjectScope" class="grid min-h-[500px] items-start gap-5 xl:grid-cols-[260px_minmax(0,1fr)]">
             <!-- 左侧 Provider 列表 -->
-            <aside class="flex flex-col rounded-2xl border border-[var(--border-color)] bg-[var(--bg-panel)] p-2 shadow-sm">
+            <aside class="sticky top-4 flex h-fit flex-col rounded-2xl border border-[var(--border-color)] bg-[var(--bg-panel)] p-2 shadow-sm">
                 <div class="px-3 pb-3 pt-2">
                     <div class="text-[11px] font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">Providers</div>
                     <div class="mt-1 text-xs text-[var(--text-secondary)] opacity-80">{{ t("settings.panels.models.providersHint") }}</div>

--- a/packages/neuro-book/app/components/novel-ide/settings/NovelIdeModelSettingsPanel.vue
+++ b/packages/neuro-book/app/components/novel-ide/settings/NovelIdeModelSettingsPanel.vue
@@ -453,9 +453,9 @@ defineExpose({dirty, loading, saving, saveSettings, restoreSettings});
         </div>
 
         <!-- 模型设置双栏布局 -->
-        <div v-else-if="!isProjectScope" class="grid min-h-[500px] items-start gap-5 xl:grid-cols-[260px_minmax(0,1fr)]">
+        <div v-else-if="!isProjectScope" class="grid min-h-[500px] xl:items-start gap-5 xl:grid-cols-[260px_minmax(0,1fr)]">
             <!-- 左侧 Provider 列表 -->
-            <aside class="sticky top-4 flex h-fit flex-col rounded-2xl border border-[var(--border-color)] bg-[var(--bg-panel)] p-2 shadow-sm">
+            <aside class="flex flex-col xl:sticky xl:top-4 xl:h-fit rounded-2xl border border-[var(--border-color)] bg-[var(--bg-panel)] p-2 shadow-sm">
                 <div class="px-3 pb-3 pt-2">
                     <div class="text-[11px] font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">Providers</div>
                     <div class="mt-1 text-xs text-[var(--text-secondary)] opacity-80">{{ t("settings.panels.models.providersHint") }}</div>

--- a/packages/neuro-book/app/utils/novel-ide-settings-responsive.contract.test.ts
+++ b/packages/neuro-book/app/utils/novel-ide-settings-responsive.contract.test.ts
@@ -4,6 +4,7 @@ import {describe, expect, it} from "vitest";
 
 const settingsDialogPath = fileURLToPath(new URL("../components/novel-ide/NovelIdeSettingsDialog.vue", import.meta.url));
 const profileNavPath = fileURLToPath(new URL("../components/novel-ide/settings/AgentProfileNavList.vue", import.meta.url));
+const modelPanelPath = fileURLToPath(new URL("../components/novel-ide/settings/NovelIdeModelSettingsPanel.vue", import.meta.url));
 
 describe("Novel IDE Settings responsive contract", () => {
     it("窄屏使用横向导航和上下布局，桌面保留侧栏", async () => {
@@ -29,5 +30,14 @@ describe("Novel IDE Settings responsive contract", () => {
 
         expect(source).not.toContain("90vh");
         expect(source).toContain("overflow-y-auto");
+    });
+
+    it("模型设置双栏的 sticky 定位只作用于 xl 桌面断点", async () => {
+        const source = (await readFile(modelPanelPath, "utf8")).replace(/\r\n/g, "\n");
+
+        expect(source).toContain("xl:sticky xl:top-4");
+        expect(source).toContain("xl:items-start");
+        expect(source).not.toContain("sticky top-4");
+        expect(source).not.toContain("flex h-fit flex-col");
     });
 });

--- a/packages/neuro-book/vitest.config.ts
+++ b/packages/neuro-book/vitest.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
             "app/components/markdown-studio/**/*.test.ts",
             "app/components/profile-template-editor/**/*.test.ts",
             "app/stores/**/*.test.ts",
+            "app/utils/novel-ide-settings-responsive.contract.test.ts",
             "server/**/*.test.ts",
             "server/**/*.test.tsx",
             "shared/**/*.test.ts",


### PR DESCRIPTION
## 关联 Issue

Closes #173

## 范围

- **范围内**：模型设置面板 Provider 列表 sticky 定位（`NovelIdeModelSettingsPanel.vue`，2+/2-）。双栏布局容器加 `items-start`，左侧 Provider 列表 `aside` 加 `sticky top-4 flex h-fit`。
- **不在范围内**：无其它改动。

## 用户可见结果

- 模型设置面板在右侧配置内容较长时，左侧 Provider 列表保持在视口内，切换 Provider 无需上下滚动
- 窄屏（单栏）布局不受影响（sticky 只在双栏 xl 断点生效）

## 验证

- `vue-tsc --noEmit`（主应用）：✅ 0 error
- 浏览器人工验收：未运行

## 已知限制

- 未做浏览器人工验收
