### PR TITLE
fix(agent): Agent 会话头部按钮 title 替换为 Tooltip 提示

### DIFF
--- a/packages/neuro-book/app/components/novel-ide/agent/AgentChatSurface.vue
+++ b/packages/neuro-book/app/components/novel-ide/agent/AgentChatSurface.vue
@@ -14,6 +14,7 @@ import {applyAgentCommandResult} from "nbook/app/components/novel-ide/agent/agen
 import {useAgentSessionApi} from "nbook/app/composables/useAgentSessionApi";
 import {useCostDisplay} from "nbook/app/composables/useCostDisplay";
 import Dropdown from "nbook/app/components/common/Dropdown.vue";
+import Tooltip from "nbook/app/components/common/Tooltip.vue";
 import AgentChatFlow from "nbook/app/components/novel-ide/agent/AgentChatFlow.vue";
 import AgentSystemPromptPanel from "nbook/app/components/novel-ide/agent/AgentSystemPromptPanel.vue";
 import AgentComposer from "nbook/app/components/novel-ide/agent/AgentComposer.vue";
@@ -2762,34 +2763,50 @@ function saveLastSessionId(sessionId: number): void {
                     </div>
                 </div>
                 <div class="flex shrink-0 items-center gap-1">
-                    <Dropdown v-if="canChooseCreateProfile" :items="createProfileDropdownItems" root-class="relative inline-block" menu-class="right-0 top-full mt-1.5 w-44" compact @select="void createSessionFromHeader($event)">
-                        <button class="rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-40" :title="t('agent.session.newChat')" :disabled="loadingSession">
+                    <Tooltip v-if="canChooseCreateProfile" :text="t('agent.session.newChat')" placement="bottom">
+                        <Dropdown :items="createProfileDropdownItems" root-class="relative inline-block" menu-class="right-0 top-full mt-1.5 w-44" compact @select="void createSessionFromHeader($event)">
+                            <button class="rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-40" :disabled="loadingSession">
+                                <span class="i-lucide-plus h-4 w-4"></span>
+                            </button>
+                        </Dropdown>
+                    </Tooltip>
+                    <Tooltip v-else :text="t('agent.session.newChat')" placement="bottom">
+                        <button class="rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-40" :disabled="loadingSession" @click="void createSessionFromHeader()">
                             <span class="i-lucide-plus h-4 w-4"></span>
                         </button>
-                    </Dropdown>
-                    <button v-else class="rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-40" :title="t('agent.session.newChat')" :disabled="loadingSession" @click="void createSessionFromHeader()">
-                        <span class="i-lucide-plus h-4 w-4"></span>
-                    </button>
-                    <button class="flex items-center gap-1 rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-40" :class="{'bg-[var(--bg-hover)] text-[var(--accent-main)]': attachmentPanelOpen}" title="查看当前 Session 的全部附件" :disabled="!activeSessionId" @click="toggleAttachmentPanel">
-                        <span class="i-lucide-paperclip h-4 w-4"></span>
-                        <span v-if="sessionAttachmentUniqueTotal" class="rounded-sm bg-[var(--accent-main)] px-1 text-[9px] font-bold text-[var(--text-inverse)]">{{ sessionAttachmentUniqueTotal }}</span>
-                    </button>
-                    <button class="flex items-center gap-1.5 rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" :class="{'bg-[var(--bg-hover)] text-[var(--accent-main)]': linkedAgentPanelOpen}" :title="t('agent.chatSurface.linkedAgentsTitle')" @click="linkedAgentPanelOpen = !linkedAgentPanelOpen">
-                        <span class="i-lucide-users h-4 w-4"></span>
-                        <span v-if="linkedAgentCount" class="rounded-sm bg-[var(--accent-main)] px-1 text-[9px] font-bold text-[var(--text-inverse)]">{{ linkedAgentCount }}</span>
-                    </button>
-                    <button class="rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-40" :title="t('agent.chatSurface.sessionTreeTitle')" :disabled="!activeSessionId || !activeInteraction.canMutateHistory" @click="sessionTreeDialogOpen = true">
-                        <span class="i-lucide-git-branch h-4 w-4"></span>
-                    </button>
-                    <button class="rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-40" :class="{'bg-[var(--bg-hover)] text-[var(--accent-main)]': systemPromptPanelOpen}" :title="t('agent.systemPrompt.open')" :disabled="!activeSessionId" @click="systemPromptPanelOpen = !systemPromptPanelOpen">
-                        <span class="i-lucide-terminal-square h-4 w-4"></span>
-                    </button>
-                    <button class="rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" :title="t('agent.chatSurface.sessionListTitle')" @click="openSessionDialog()">
-                        <span class="i-lucide-messages-square h-4 w-4"></span>
-                    </button>
-                    <button class="rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" @click="emit('close')">
-                        <span class="i-lucide-x h-4 w-4"></span>
-                    </button>
+                    </Tooltip>
+                    <Tooltip :text="t('agent.chatSurface.attachments')" placement="bottom">
+                        <button class="flex items-center gap-1 rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-40" :class="{'bg-[var(--bg-hover)] text-[var(--accent-main)]': attachmentPanelOpen}" :disabled="!activeSessionId" @click="toggleAttachmentPanel">
+                            <span class="i-lucide-paperclip h-4 w-4"></span>
+                            <span v-if="sessionAttachmentUniqueTotal" class="rounded-sm bg-[var(--accent-main)] px-1 text-[9px] font-bold text-[var(--text-inverse)]">{{ sessionAttachmentUniqueTotal }}</span>
+                        </button>
+                    </Tooltip>
+                    <Tooltip :text="t('agent.chatSurface.linkedAgentsTitle')" placement="bottom">
+                        <button class="flex items-center gap-1.5 rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" :class="{'bg-[var(--bg-hover)] text-[var(--accent-main)]': linkedAgentPanelOpen}" @click="linkedAgentPanelOpen = !linkedAgentPanelOpen">
+                            <span class="i-lucide-users h-4 w-4"></span>
+                            <span v-if="linkedAgentCount" class="rounded-sm bg-[var(--accent-main)] px-1 text-[9px] font-bold text-[var(--text-inverse)]">{{ linkedAgentCount }}</span>
+                        </button>
+                    </Tooltip>
+                    <Tooltip :text="t('agent.chatSurface.sessionTreeTitle')" placement="bottom">
+                        <button class="rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-40" :disabled="!activeSessionId || !activeInteraction.canMutateHistory" @click="sessionTreeDialogOpen = true">
+                            <span class="i-lucide-git-branch h-4 w-4"></span>
+                        </button>
+                    </Tooltip>
+                    <Tooltip :text="t('agent.systemPrompt.open')" placement="bottom">
+                        <button class="rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)] disabled:cursor-not-allowed disabled:opacity-40" :class="{'bg-[var(--bg-hover)] text-[var(--accent-main)]': systemPromptPanelOpen}" :disabled="!activeSessionId" @click="systemPromptPanelOpen = !systemPromptPanelOpen">
+                            <span class="i-lucide-terminal-square h-4 w-4"></span>
+                        </button>
+                    </Tooltip>
+                    <Tooltip :text="t('agent.chatSurface.sessionListTitle')" placement="bottom">
+                        <button class="rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" @click="openSessionDialog()">
+                            <span class="i-lucide-messages-square h-4 w-4"></span>
+                        </button>
+                    </Tooltip>
+                    <Tooltip :text="t('agent.chatSurface.closePanel')" placement="bottom">
+                        <button class="rounded p-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-main)]" @click="emit('close')">
+                            <span class="i-lucide-x h-4 w-4"></span>
+                        </button>
+                    </Tooltip>
                 </div>
             </div>
 

--- a/packages/neuro-book/app/i18n/locales/en-US.ts
+++ b/packages/neuro-book/app/i18n/locales/en-US.ts
@@ -2065,6 +2065,8 @@ const enUS = {
             linkedAgentsTitle: "Linked Agents",
             sessionTreeTitle: "Session Tree",
             sessionListTitle: "Session List",
+            closePanel: "Close panel",
+            attachments: "Show all session attachments",
         },
         traceViewer: {
             title: "Pi Request Traces",

--- a/packages/neuro-book/app/i18n/locales/zh-CN.ts
+++ b/packages/neuro-book/app/i18n/locales/zh-CN.ts
@@ -2063,6 +2063,8 @@ const zhCN = {
             linkedAgentsTitle: "关联 Agent",
             sessionTreeTitle: "Session Tree",
             sessionListTitle: "Session 列表",
+            closePanel: "关闭面板",
+            attachments: "查看当前 Session 的全部附件",
         },
         traceViewer: {
             title: "Pi 请求记录",


### PR DESCRIPTION
## 关联 Issue

Closes #175

## 范围

- **范围内**：Agent 会话头部操作按钮的原生 `title` 提示替换为项目 Tooltip 组件（`AgentChatSurface.vue`，69 行改动 + i18n 2 个新 key）。覆盖新建会话（Dropdown/直接按钮两种形态）、附件、关联 Agent、Session Tree、系统提示、会话列表、关闭按钮。
- **不在范围内**：Plot 面板 Tab 遮挡修复（独立主题，未包含）。

## 用户可见结果

- 头部按钮悬停显示统一的 Tooltip 提示（替代延迟出现的原生 title）
- 新增 i18n：`chatSurface.closePanel`、`chatSurface.attachments`

## 验证

- `vue-tsc --noEmit`（主应用）：✅ 0 error
- i18n key 无冲突（`chatSurface.attachments` 为新增嵌套 key）
- 浏览器人工验收：未运行

## 已知限制

- 未做浏览器人工验收
