### PR TITLE
fix(manager): move contracts to devDependency and guard packed manifest

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -367,18 +367,18 @@
     },
     "packages/neuro-book-manager": {
       "name": "@notnotype/neuro-book-manager",
-      "version": "0.1.0-canary.54",
+      "version": "0.1.0-canary.55",
       "bin": {
         "neuro-book": "dist/neuro-book.mjs",
       },
       "dependencies": {
-        "@notnotype/neuro-book-contracts": "file:../neuro-book-contracts",
         "proper-lockfile": "^4.1.2",
         "semver": "^7.8.5",
         "yaml": "^2.8.2",
       },
       "devDependencies": {
         "@clack/prompts": "^1.0.0",
+        "@notnotype/neuro-book-contracts": "file:../neuro-book-contracts",
         "@notnotype/neuro-book-test-support": "file:../neuro-book-test-support",
         "@notnotype/owned-process": "file:../owned-process",
         "@types/blessed": "^0.1.27",
@@ -4019,9 +4019,9 @@
 
     "@notnotype/neuro-agent-harness/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
-    "@notnotype/neuro-book-manager/@notnotype/neuro-book-contracts/@notnotype/neuro-book-test-support": ["@notnotype/neuro-book-test-support@file:packages/neuro-book-test-support", { "devDependencies": { "@types/node": "^25.6.0", "typescript": "^5.9.3", "vitest": "^4.1.2" } }],
+    "@notnotype/neuro-book-manager/@notnotype/neuro-book-contracts/@notnotype/neuro-book-test-support": ["@notnotype/neuro-book-test-support@file:packages\\neuro-book-test-support", {}],
 
-    "@notnotype/neuro-book-manager/@notnotype/owned-process/@notnotype/neuro-book-test-support": ["@notnotype/neuro-book-test-support@file:packages/neuro-book-test-support", { "devDependencies": { "@types/node": "^25.6.0", "typescript": "^5.9.3", "vitest": "^4.1.2" } }],
+    "@notnotype/neuro-book-manager/@notnotype/owned-process/@notnotype/neuro-book-test-support": ["@notnotype/neuro-book-test-support@file:packages\\neuro-book-test-support", {}],
 
     "@nuxt/vite-builder/vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 

--- a/packages/neuro-book-manager/package.json
+++ b/packages/neuro-book-manager/package.json
@@ -58,6 +58,7 @@
     },
     "devDependencies": {
         "@notnotype/owned-process": "file:../owned-process",
+        "@notnotype/neuro-book-contracts": "file:../neuro-book-contracts",
         "@clack/prompts": "^1.0.0",
         "@types/blessed": "^0.1.27",
         "@types/bun": "^1.3.14",
@@ -75,7 +76,6 @@
         "access": "public"
     },
     "dependencies": {
-        "@notnotype/neuro-book-contracts": "file:../neuro-book-contracts",
         "proper-lockfile": "^4.1.2",
         "semver": "^7.8.5",
         "yaml": "^2.8.2"

--- a/packages/neuro-book-manager/scripts/pack-check.mjs
+++ b/packages/neuro-book-manager/scripts/pack-check.mjs
@@ -25,6 +25,9 @@ try {
     if (packageJson.dependencies?.["@notnotype/owned-process"]) {
         throw new Error("Manager npm包不应携带私有Owned Process production dependency；实现必须内联进单文件bundle。" );
     }
+    if (packageJson.dependencies?.["@notnotype/neuro-book-contracts"]) {
+        throw new Error("Manager npm包不应携带私有Contracts production dependency；实现必须内联进单文件bundle。");
+    }
     const managerVersion = await runCapture([
         "bun",
         join(temporaryRoot, "node_modules", "@notnotype", "neuro-book-manager", "dist", "neuro-book.mjs"),


### PR DESCRIPTION
## 根因

`bun run manager:release` 的 publish 门禁 `pack:check` 在 CI 干净环境失败：tarball 的 dependencies 含 `@notnotype/neuro-book-contracts": "file:../neuro-book-contracts"`，隔离安装无法解析（run 32812416487）。dist 单文件 bundle 已完整内联 contracts 代码——该依赖只在构建期需要。本地此前放行是共享 bun 缓存存在同名解析产物的假阳性。

## 改动

- `@notnotype/neuro-book-contracts` 移入 devDependencies。
- `pack-check.mjs` 新增守卫：打包产物 manifest 的 dependencies 出现 contracts 即失败（与既有 owned-process 守卫同型）。

## 验证

- `pack:check` 全绿（构建 + 隔离安装 + --version/start/status/instances/install dry-run 冒烟）。