### PR TITLE
fix(repo): keep bun.lock workspace file specifiers POSIX-separated

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4019,9 +4019,9 @@
 
     "@notnotype/neuro-agent-harness/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
-    "@notnotype/neuro-book-manager/@notnotype/neuro-book-contracts/@notnotype/neuro-book-test-support": ["@notnotype/neuro-book-test-support@file:packages\\neuro-book-test-support", {}],
+    "@notnotype/neuro-book-manager/@notnotype/neuro-book-contracts/@notnotype/neuro-book-test-support": ["@notnotype/neuro-book-test-support@file:packages/neuro-book-test-support", {}],
 
-    "@notnotype/neuro-book-manager/@notnotype/owned-process/@notnotype/neuro-book-test-support": ["@notnotype/neuro-book-test-support@file:packages\\neuro-book-test-support", {}],
+    "@notnotype/neuro-book-manager/@notnotype/owned-process/@notnotype/neuro-book-test-support": ["@notnotype/neuro-book-test-support@file:packages/neuro-book-test-support", {}],
 
     "@nuxt/vite-builder/vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 

--- a/scripts/release/manager-release-contract.test.ts
+++ b/scripts/release/manager-release-contract.test.ts
@@ -57,4 +57,8 @@ describe("Manager release clean-checkout contract", () => {
             moduleResolution: "Bundler",
         });
     });
+    it("bun.lock对workspace file依赖保持POSIX分隔符", async () => {
+        const lockfile = await readFile(resolve(ROOT, "bun.lock"), "utf8");
+        expect(lockfile).not.toMatch(/file:[^"]*\\/u);
+    });
 });


### PR DESCRIPTION
## 根因

manager-v0.1.0-canary.56 发布 run [32812970933](https://github.com/notnotype/neuro-book/actions/runs/32812970933) 在 Linux 的 `bun install --frozen-lockfile` 失败：`Could not find folder "file:packages\\neuro-book-test-support"`。Windows 主机执行 `bun install` 时 bun 会用平台分隔符重写 lockfile 的 file: 条目，Linux 端无法解析。

## 改动

- 归一化 bun.lock 中 2 处反斜杠 file 描述符。
- `manager-release-contract.test.ts` 新增守卫：bun.lock 出现含反斜杠的 `file:` 描述符即失败，跨平台发布前必红。

## 验证

- manager-release 契约测试 2/2 绿。
- `bun install --frozen-lockfile` 本机通过。