### PR TITLE
fix(plot): 剧本编排面板 Tab 栏窄视口下自动换行

### DIFF
--- a/packages/neuro-book/app/components/novel-ide/plot/NovelPlotPanel.vue
+++ b/packages/neuro-book/app/components/novel-ide/plot/NovelPlotPanel.vue
@@ -1725,12 +1725,12 @@ watch(plotRefreshVersion, async (version, previousVersion) => {
         </div>
 
         <!-- Plot 工作台入口 -->
-        <div class="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--border-color)] bg-[var(--bg-panel)] px-3 py-2">
+        <div class="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-[var(--border-color)] bg-[var(--bg-panel)] px-3 py-2">
             <div class="min-w-0">
                 <div class="truncate text-[12px] font-semibold text-[var(--text-main)]">剧情编排</div>
                 <div class="truncate text-[11px] text-[var(--text-muted)]">Thread / Scene / World Anchor</div>
             </div>
-            <div class="flex shrink-0 items-center gap-2">
+            <div class="flex flex-wrap items-center gap-2">
                 <!-- 规划层计数入口:点击打开工作台对应 tab;0 计数弱化显示但不隐藏(入口可发现性) -->
                 <button
                     type="button"


### PR DESCRIPTION
## 关联 Issue

Closes #182

## 范围

- **范围内**：剧情编排面板顶部 Tab 栏窄视口遮挡修复（`NovelPlotPanel.vue`，2+/2-）。Tab 栏容器加 `flex-wrap`，按钮组容器同步加 `flex-wrap`，窄视口下按钮自动换行。
- **不在范围内**：无其它改动。

## 用户可见结果

- 窄视口下剧情编排面板顶部按钮（承诺 / 未决 / 章节 / 剧本工作台）完整可见，不再被容器裁剪
- 正常视口布局不变

## 验证

- `vue-tsc --noEmit`（主应用）：✅ 0 error
- 浏览器人工验收：未运行

## 已知限制

- 未做浏览器人工验收
