### PR TITLE
fix(release): install public manager deps inside verify sandbox

### DIFF
--- a/scripts/release/verify-public-manager.ts
+++ b/scripts/release/verify-public-manager.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import {mkdtemp, rm} from "node:fs/promises";
+import {mkdtemp, rm, writeFile} from "node:fs/promises";
 import {tmpdir} from "node:os";
 import {join, resolve} from "node:path";
 
@@ -35,7 +35,12 @@ try {
     if (changedInputs) {
         throw new Error(`当前Manager构建输入晚于npm公开gitHead ${publicPackage.gitHead}：\n${changedInputs}`);
     }
-    const reportedVersion = (await runCapture("bun", [publicPackage.executable, "--version"], {cwd: ROOT})).trim();
+    // 隔离安装公开包及其生产依赖：验证不得依赖宿主任意 node_modules（bun auto-install
+    // 或家目录残留都会让结果不可信）。
+    await writeFile(join(temporaryRoot, "package.json"), "{\"private\":true}\n", "utf8");
+    await run("bun", ["add", join(temporaryRoot, "public-manager.tgz"), "--cwd", temporaryRoot], temporaryRoot);
+    const installedExecutable = join(temporaryRoot, "node_modules", "@notnotype", "neuro-book-manager", "dist", "neuro-book.mjs");
+    const reportedVersion = (await runCapture("bun", [installedExecutable, "--version"], {cwd: ROOT})).trim();
     if (reportedVersion !== packageJson.version) {
         throw new Error(`npm公开Manager --version错误：${reportedVersion}`);
     }


### PR DESCRIPTION
## 根因

`verify-public-manager.ts` 只解压公开 tarball 即运行 CLI，yaml/semver 等 production 依赖依赖宿主环境兜底解析。本机 `C:\Users\<user>\node_modules\yaml@0.2.3` 杂散残留使 `$VERSION --version` 报 `Export named 'parse' not found`，应用 canary 发布的强制前置门禁被环境污染卡死。

## 改动

与 `pack-check.mjs` 同型：临时根写入 `{"private":true}` 后 `bun add` 公开 tarball，从 `node_modules/@notnotype/neuro-book-manager/dist/neuro-book.mjs` 运行 `$--version` 验证。gitHead/构建输入漂移检查不变。

## 验证

- 本机污染环境红（yaml@0.2.3 崩溃）→ 修复后绿：`Manager 0.1.0-canary.57已由gitHead 0a04b2a2…公开，当前构建输入未漂移`。