### PR TITLE
fix(release): move delegate job env to step level

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -1016,8 +1016,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    env:
-      PODMAN_COMPOSE_MASKED_ROOT: ${{ runner.temp }}/podman-compose-masked
     steps:
       - uses: actions/checkout@v5
         with:
@@ -1029,6 +1027,8 @@ jobs:
           path: candidate-assets
       - name: Install Podman and mask podman-compose outside PATH
         shell: bash
+        env:
+          PODMAN_COMPOSE_MASKED_ROOT: ${{ runner.temp }}/podman-compose-masked
         run: |
           set -euo pipefail
           sudo apt-get update
@@ -1064,6 +1064,8 @@ jobs:
           printf '%s\n' "$(printf '%s' "$PATH" | tr ':' '\n' | grep -v "^$PODMAN_COMPOSE_MASKED_ROOT")" >> "$GITHUB_PATH"
       - name: Verify public GHCR on Linux x64 rootless Podman via delegated provider
         shell: bash
+        env:
+          PODMAN_COMPOSE_MASKED_ROOT: ${{ runner.temp }}/podman-compose-masked
         run: |
           set -euo pipefail
           test -x "$PODMAN_COMPOSE_MASKED_ROOT/root/usr/bin/podman-compose"


### PR DESCRIPTION
`jobs.<id>.env` 不支持 `runner` 上下文；应用 canary 发版派发 release-container 时被 GitHub 以 HTTP 422 拒绝（`Unrecognized named-value: 'runner'`）。将 `PODMAN_COMPOSE_MASKED_ROOT` 从 job 级下沉到 install/verify 两个 step 的 env。`runner.temp` 其余用法均在 step 级，不受影响。修复后以原 Draft（release_id 376176592）重新派发。