### PR TITLE
fix(release): prepare Nuxt generated config for preflight contracts

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -45,7 +45,9 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun scripts/release/install-dependencies.ts --linker hoisted
       - name: Prepare generated sources
-        run: bun run --cwd packages/neuro-book generate
+        run: |
+          bun run --cwd packages/neuro-book generate
+          bun run --cwd packages/neuro-book nuxt:prepare
       - name: Verify release process type contracts
         run: |
           bun x tsc --noEmit -p scripts/tsconfig.json


### PR DESCRIPTION
## 根因

monorepo cutover 后 `packages/neuro-book/tsconfig.json` 改为 extends 生成物 `.nuxt/tsconfig.json`。release-container 的 preflight 只执行 `generate`（不产该文件），导致资产契约套件在 transform `shared/agent`、`interfaces/*` 时加载失败——cutover 后无应用发版，本次 v0.9.7 首次派发才暴露（run 32816511068）。

## 改动

preflight 的 Prepare generated sources 步骤追加 `bun run --cwd packages/neuro-book nuxt:prepare`，与 release-manager.yml「Verify package」先 prepare 后测试的既定顺序一致。

## 边界说明

workflow 属 tooling 层（随 dispatch ref 读取）；被测 source 仍 checkout 不可变 `inputs.revision`，Draft/tag/revision 身份不变，修复后可用原 Draft 重派。