### PR TITLE
fix(release): pin preflight Bun and track chained prepare step

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -43,11 +43,11 @@ jobs:
         with:
           ref: ${{ inputs.revision }}
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
       - run: bun scripts/release/install-dependencies.ts --linker hoisted
       - name: Prepare generated sources
-        run: |
-          bun run --cwd packages/neuro-book generate
-          bun run --cwd packages/neuro-book nuxt:prepare
+        run: bun run --cwd packages/neuro-book generate && bun run --cwd packages/neuro-book nuxt:prepare
       - name: Verify release process type contracts
         run: |
           bun x tsc --noEmit -p scripts/tsconfig.json


### PR DESCRIPTION
- preflight `setup-bun` 钉 `bun-version: 1.3.14`：Bun 1.4 下资产契约套件在 `.nuxt/tsconfig.json` 装配后仍于 `zod` 命名导入崩溃（run 32818140770），同树本地 1.3.14 全绿；发版工具链需可复现。
- 契约匹配器同步为链式 prepare 步骤（#186 引入）的精确等值匹配。