### PR TITLE
fix(release): pin preflight zod through a transform-safe shim

### DIFF
--- a/scripts/release/release-assets-vitest.config.ts
+++ b/scripts/release/release-assets-vitest.config.ts
@@ -12,6 +12,8 @@ export const releaseAssetsVitestConfig = {
         alias: {
             "#scripts": resolve(rootDir, "scripts"),
             nbook: resolve(rootDir, "packages/neuro-book"),
+            // vite-node 转换 zod 官方入口的 namespace 再导出会丢失 `z`，钉到等价 shim。
+            zod: resolve(rootDir, "scripts/release/zod-shim.mjs"),
         },
     },
     test: {

--- a/scripts/release/release-assets.test.ts
+++ b/scripts/release/release-assets.test.ts
@@ -423,7 +423,7 @@ describe("Product Release宿主合同", () => {
         expect(publicManagerVerifier).toContain('["cat-file", "-e", `${publicPackage.gitHead}^{commit}`]');
         expect(publicManagerVerifier).toContain('["fetch", "--no-tags", "origin", publicPackage.gitHead]');
         expect(publicManagerVerifier).not.toContain('"--depth=1"');
-        const generatedSourcesStep = workflow.jobs.preflight.steps.findIndex(({run}) => run === "bun run --cwd packages/neuro-book generate");
+        const generatedSourcesStep = workflow.jobs.preflight.steps.findIndex(({run}) => run === "bun run --cwd packages/neuro-book generate && bun run --cwd packages/neuro-book nuxt:prepare");
         const productGraphStep = workflow.jobs.preflight.steps.findIndex(({run}) => run?.includes("scripts/deploy/product-start.test.ts"));
         const agentStateRootStep = workflow.jobs.preflight.steps.find(({run}) => run?.includes("packages/neuro-book/scripts/deploy/product-agent-state-root-smoke.ts"));
         expect(generatedSourcesStep).toBeGreaterThan(-1);

--- a/scripts/release/zod-shim.mjs
+++ b/scripts/release/zod-shim.mjs
@@ -1,0 +1,10 @@
+// Release preflight 专用 zod shim。
+// vite-node 对「`export { z }` 再导出 namespace import 绑定」的转换会丢失该绑定
+// （zod 官方入口 index.js 恰好用此模式），导致 `z` 为 undefined；本 shim 改为
+// 先 const 再导出的等价形态，并保留与官方入口一致的命名空间语义。
+import * as ns from "../../node_modules/zod/v4/classic/external.js";
+
+const z = ns;
+export {z};
+export * from "../../node_modules/zod/v4/classic/external.js";
+export default z;


### PR DESCRIPTION
## 根因

release-container 的 preflight「Verify release asset contracts」在依赖图加载阶段崩溃：`z.object` undefined（run 32820900100 等 4 次实证）。逐层排除后定位为 **vitest/vite-node 转换缺陷**：zod 官方入口 `index.js` 采用 `import * as z from ...; export { z }` 的 namespace 再导出模式，vite-node 转换后 `z` 绑定丢失；纯 Bun/Node 导入均正常。该套件是 cutover 后首个进入应用共享模块（shared/agent → zod）的 scripts 侧套件，此前从未在真实发版中执行。

## 改动

- 新增 `scripts/release/zod-shim.mjs`：等价但避免 namespace 再导出模式（先 `const z = ns` 再导出），保留与官方入口一致的命名空间语义。
- `release-assets-vitest.config.ts`：`zod` 别名钉到 shim。
- `release-assets.test.ts`：生成步骤匹配器同步为链式 `generate && nuxt:prepare` 精确等值（#186 引入的步骤形态）。

## 验证（CI 同型命令）

`bun node_modules/vitest/vitest.mjs run --config scripts/release/release-assets-vitest.config.ts` → 4 files / 32 tests 全绿；修复前同命令稳定复现 z.object 加载崩溃。