### PR TITLE
ci: simplify PR check workflows

### DIFF
--- a/.github/workflows/code-baseline.yml
+++ b/.github/workflows/code-baseline.yml
@@ -54,7 +54,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_OPTIONS: --max-old-space-size=4096
 
 jobs:

--- a/.github/workflows/community-docs.yml
+++ b/.github/workflows/community-docs.yml
@@ -1,6 +1,34 @@
 name: Community and Docs Checks
 
 on:
+  push:
+    branches: [master]
+    paths:
+      - "CONTRIBUTING.md"
+      - "CONTRIBUTING.en.md"
+      - "README.md"
+      - "README.en.md"
+      - "AGENTS.md"
+      - "PROJECT-STATUS.md"
+      - "WATCHDOG.md"
+      - "CONTEXT.md"
+      - "RELEASE.md"
+      - ".omp/**"
+      - "docs/**"
+      - "vitepress/**"
+      - "packages/neuro-book/assets/reference/**"
+      - "packages/llmlint/docs/promo/**"
+      - ".github/**"
+      - "scripts/ci/validate-community-files.ts"
+      - "scripts/ci/validate-nitropack-patch.ts"
+      - "scripts/ci/check-documentation*"
+      - "scripts/ci/stage-docs-locales*"
+      - "patches/**"
+      - "packages/neuro-book/**"
+      - "packages/neuro-book/nuxt.config.ts"
+      - "packages/neuro-book/tsconfig.json"
+      - "package.json"
+      - "bun.lock"
   pull_request:
     paths:
       - "CONTRIBUTING.md"

--- a/.github/workflows/community-docs.yml
+++ b/.github/workflows/community-docs.yml
@@ -37,7 +37,6 @@ concurrency:
   group: community-docs-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
 jobs:
   community-docs:
     name: Community files and docs

--- a/.github/workflows/community-docs.yml
+++ b/.github/workflows/community-docs.yml
@@ -1,34 +1,6 @@
 name: Community and Docs Checks
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - "CONTRIBUTING.md"
-      - "CONTRIBUTING.en.md"
-      - "README.md"
-      - "README.en.md"
-      - "AGENTS.md"
-      - "PROJECT-STATUS.md"
-      - "WATCHDOG.md"
-      - "CONTEXT.md"
-      - "RELEASE.md"
-      - ".omp/**"
-      - "docs/**"
-      - "vitepress/**"
-      - "packages/neuro-book/assets/reference/**"
-      - "packages/llmlint/docs/promo/**"
-      - ".github/**"
-      - "scripts/ci/validate-community-files.ts"
-      - "scripts/ci/validate-nitropack-patch.ts"
-      - "scripts/ci/check-documentation*"
-      - "scripts/ci/stage-docs-locales*"
-      - "patches/**"
-      - "packages/neuro-book/**"
-      - "packages/neuro-book/nuxt.config.ts"
-      - "packages/neuro-book/tsconfig.json"
-      - "package.json"
-      - "bun.lock"
   pull_request:
     paths:
       - "CONTRIBUTING.md"

--- a/.github/workflows/community-docs.yml
+++ b/.github/workflows/community-docs.yml
@@ -38,8 +38,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   community-docs:
     name: Community files and docs

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -68,10 +68,6 @@ jobs:
 
       - name: Prepare Nuxt types
         run: bun run --cwd packages/neuro-book nuxt:prepare
-
-      - name: Validate community files
-        run: bun scripts/ci/validate-community-files.ts
-
       - name: Check documentation governance
         run: bun run docs:check
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -39,7 +39,6 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
-env:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,8 +40,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Prepare Nuxt types
         run: bun run --cwd packages/neuro-book nuxt:prepare
 
+      - name: Validate community files
+        run: bun scripts/ci/validate-community-files.ts
+
       - name: Check documentation governance
         run: bun run docs:check
 

--- a/.github/workflows/desktop-envelope-contract.yml
+++ b/.github/workflows/desktop-envelope-contract.yml
@@ -22,8 +22,6 @@ permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   contracts:
     name: ${{ matrix.platform }} desktop contracts

--- a/.github/workflows/desktop-envelope-contract.yml
+++ b/.github/workflows/desktop-envelope-contract.yml
@@ -21,7 +21,6 @@ on:
 permissions:
   contents: read
 
-env:
 jobs:
   contracts:
     name: ${{ matrix.platform }} desktop contracts

--- a/.github/workflows/product-platforms.yml
+++ b/.github/workflows/product-platforms.yml
@@ -1,6 +1,27 @@
 name: Product Platform Checks
 
 on:
+  push:
+    branches: [master]
+    paths:
+      - ".github/workflows/product-platforms.yml"
+      - ".github/workflows/release-container.yml"
+      - "packages/neuro-book/Dockerfile*"
+      - "packages/neuro-book/**"
+      - "packages/neuro-book-contracts/**"
+      - "packages/neuro-book-test-support/**"
+      - "packages/neuro-book-manager/**"
+      - "packages/owned-process/**"
+      - "packages/file-snapshot-cache/**"
+      - "packages/nb-history/**"
+      - "packages/nb-workflow/**"
+      - "packages/nb-memory/**"
+      - "packages/nb-ui/**"
+      - "packages/neuro-agent-harness/**"
+      - "packages/llmlint/**"
+      - "scripts/**"
+      - "bun.lock"
+      - "package.json"
   pull_request:
     paths:
       - ".github/workflows/product-platforms.yml"
@@ -31,37 +52,40 @@ env:
   NODE_OPTIONS: --max-old-space-size=4096
 
 jobs:
+  select-platforms:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+    steps:
+      - id: select
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          entries='[
+            {"platform":"linux-x64-glibc","runner":"ubuntu-latest","command":"release:product:linux","archive":"neuro-book-product-linux-x64-glibc.tar.gz","port":39223,"browser":"playwright","pr_gate":true},
+            {"platform":"linux-aarch64-glibc","runner":"ubuntu-24.04-arm","command":"release:product:linux-aarch64","archive":"neuro-book-product-linux-aarch64-glibc.tar.gz","port":39224,"browser":"playwright"},
+            {"platform":"darwin-x64","runner":"macos-15-intel","command":"release:product:darwin","archive":"neuro-book-product-darwin-x64.tar.gz","port":39225,"browser":"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"},
+            {"platform":"darwin-aarch64","runner":"macos-15","command":"release:product:darwin-aarch64","archive":"neuro-book-product-darwin-aarch64.tar.gz","port":39226,"browser":"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"}
+          ]'
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            selected="$(jq -c '[.[] | select(.pr_gate == true) | del(.pr_gate)]' <<<"$entries")"
+          else
+            selected="$(jq -c '[.[] | del(.pr_gate)]' <<<"$entries")"
+          fi
+          {
+            echo "matrix<<MATRIX_JSON"
+            echo "{\"include\": ${selected}}"
+            echo "MATRIX_JSON"
+          } >> "$GITHUB_OUTPUT"
+
   product:
+    needs: select-platforms
     name: ${{ matrix.platform }} Product
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - platform: linux-x64-glibc
-            runner: ubuntu-latest
-            command: release:product:linux
-            archive: neuro-book-product-linux-x64-glibc.tar.gz
-            port: 39223
-            browser: playwright
-          - platform: linux-aarch64-glibc
-            runner: ubuntu-24.04-arm
-            command: release:product:linux-aarch64
-            archive: neuro-book-product-linux-aarch64-glibc.tar.gz
-            port: 39224
-            browser: playwright
-          - platform: darwin-x64
-            runner: macos-15-intel
-            command: release:product:darwin
-            archive: neuro-book-product-darwin-x64.tar.gz
-            port: 39225
-            browser: /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
-          - platform: darwin-aarch64
-            runner: macos-15
-            command: release:product:darwin-aarch64
-            archive: neuro-book-product-darwin-aarch64.tar.gz
-            port: 39226
-            browser: /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+      matrix: ${{ fromJSON(needs.select-platforms.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/product-platforms.yml
+++ b/.github/workflows/product-platforms.yml
@@ -48,7 +48,6 @@ permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_OPTIONS: --max-old-space-size=4096
 
 jobs:

--- a/.github/workflows/product-runtime-baselines.yml
+++ b/.github/workflows/product-runtime-baselines.yml
@@ -7,7 +7,6 @@ permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NEURO_BOOK_SOURCE_REVISION: ${{ github.sha }}
   NODE_OPTIONS: --max-old-space-size=4096
 

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -27,7 +27,6 @@ permissions:
   packages: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_OPTIONS: --max-old-space-size=4096
 
 concurrency:

--- a/.github/workflows/workspace-packages.yml
+++ b/.github/workflows/workspace-packages.yml
@@ -23,8 +23,6 @@ permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   package:
     name: ${{ matrix.name }}

--- a/.github/workflows/workspace-packages.yml
+++ b/.github/workflows/workspace-packages.yml
@@ -22,7 +22,6 @@ on:
 permissions:
   contents: read
 
-env:
 jobs:
   package:
     name: ${{ matrix.name }}

--- a/scripts/ci/workspace-workflows.test.ts
+++ b/scripts/ci/workspace-workflows.test.ts
@@ -140,10 +140,10 @@ describe("迁移后九个 CI 工作流结构合同", () => {
         expect(checkout?.with?.["fetch-depth"]).toBe(0);
     });
 
-    it("Community 与 Deploy Docs 的 runtime paths 指向应用 owner", async () => {
+    it("Community 与 Deploy Docs 的 push/PR runtime paths 指向应用 owner", async () => {
         const community = await readWorkflow("community-docs.yml");
-        expect(community.on?.push).toBeUndefined();
-        expect(community.on?.pull_request?.paths).toEqual(expect.arrayContaining([
+        expect(community.on?.push?.paths).toEqual(community.on?.pull_request?.paths);
+        expect(community.on?.push?.paths).toEqual(expect.arrayContaining([
             "packages/neuro-book/**",
             "packages/neuro-book/tsconfig.json",
             "scripts/ci/stage-docs-locales*",
@@ -162,7 +162,6 @@ describe("迁移后九个 CI 工作流结构合同", () => {
         expect(commands(deploy)).toContain("bun run --cwd packages/neuro-book nuxt:prepare");
         expect(commands(community)).toContain("bun run docs:check");
         expect(commands(deploy)).toContain("bun run docs:check");
-        expect(commands(deploy)).toContain("bun scripts/ci/validate-community-files.ts");
     });
 
     it("六自治包 matrix 与 llmlint Web island 保留 owner、命令、路径和 artifact", async () => {

--- a/scripts/ci/workspace-workflows.test.ts
+++ b/scripts/ci/workspace-workflows.test.ts
@@ -139,10 +139,10 @@ describe("迁移后九个 CI 工作流结构合同", () => {
         expect(checkout?.with?.["fetch-depth"]).toBe(0);
     });
 
-    it("Community 与 Deploy Docs 的 push/PR runtime paths 指向应用 owner", async () => {
+    it("Community 与 Deploy Docs 的 runtime paths 指向应用 owner", async () => {
         const community = await readWorkflow("community-docs.yml");
-        expect(community.on?.push?.paths).toEqual(community.on?.pull_request?.paths);
-        expect(community.on?.push?.paths).toEqual(expect.arrayContaining([
+        expect(community.on?.push).toBeUndefined();
+        expect(community.on?.pull_request?.paths).toEqual(expect.arrayContaining([
             "packages/neuro-book/**",
             "packages/neuro-book/tsconfig.json",
             "scripts/ci/stage-docs-locales*",
@@ -161,6 +161,7 @@ describe("迁移后九个 CI 工作流结构合同", () => {
         expect(commands(deploy)).toContain("bun run --cwd packages/neuro-book nuxt:prepare");
         expect(commands(community)).toContain("bun run docs:check");
         expect(commands(deploy)).toContain("bun run docs:check");
+        expect(commands(deploy)).toContain("bun scripts/ci/validate-community-files.ts");
     });
 
     it("六自治包 matrix 与 llmlint Web island 保留 owner、命令、路径和 artifact", async () => {

--- a/scripts/ci/workspace-workflows.test.ts
+++ b/scripts/ci/workspace-workflows.test.ts
@@ -5,6 +5,7 @@ import {describe, expect, it} from "vitest";
 import {parse} from "yaml";
 
 type WorkflowStep = {
+    id?: string;
     name?: string;
     run?: string;
     uses?: string;
@@ -221,6 +222,12 @@ describe("迁移后九个 CI 工作流结构合同", () => {
             "bun.lock",
             "package.json",
         ]));
+        expect(platforms.jobs.product?.strategy?.matrix).toBe("${{ fromJSON(needs.select-platforms.outputs.matrix) }}");
+        const selectRun = String(platforms.jobs["select-platforms"]?.steps?.find((step) => step.id === "select")?.run ?? "");
+        for (const platform of ["linux-x64-glibc", "linux-aarch64-glibc", "darwin-x64", "darwin-aarch64"]) {
+            expect(selectRun).toContain(platform);
+        }
+        expect(selectRun).toContain("pull_request");
         expect(commands(platforms)).toContain("bun run --cwd packages/neuro-book nuxt:build");
         expect(commands(platforms)).toContain("./packages/neuro-book/package.json");
         expect(commands(platforms)).toContain("bun run test:install");

--- a/scripts/ci/workspace-workflows.test.ts
+++ b/scripts/ci/workspace-workflows.test.ts
@@ -1,4 +1,4 @@
-import {readFile} from "node:fs/promises";
+import {readFile, readdir} from "node:fs/promises";
 import {resolve} from "node:path";
 
 import {describe, expect, it} from "vitest";
@@ -291,6 +291,18 @@ describe("迁移后九个 CI 工作流结构合同", () => {
                 expect(staleRootConfigs.has(triggerPath), `${name}: ${triggerPath}`).toBe(false);
             }
             expect(commands(workflow), name).not.toMatch(/(?:^|\n)\s*bun run (?:generate|nuxt:prepare|nuxt:build|runtime:typecheck|test:agent-state-root)(?:\s|$)/u);
+        }
+    });
+
+    it("code-baseline 与 product-platforms 的 PR paths 覆盖全部 packages 目录", async () => {
+        const dirents = await readdir(resolve(root, "packages"), {withFileTypes: true});
+        const packageDirs = dirents.filter((d) => d.isDirectory()).map((d) => d.name);
+        expect(packageDirs.length).toBeGreaterThanOrEqual(12);
+        for (const name of ["code-baseline.yml", "product-platforms.yml"]) {
+            const prPaths = (await readWorkflow(name)).on?.pull_request?.paths ?? [];
+            for (const dir of packageDirs) {
+                expect(prPaths, `${name}: packages/${dir}`).toContain(`packages/${dir}/**`);
+            }
         }
     });
 });


### PR DESCRIPTION
## 关联 Issue / Related issue

- Refs #198 / Partially addresses #198。本 PR 不关闭该 Issue；master push 四平台 Product matrix 验证需合并后在 master 上观察确认。
- 另：PR #183 的历史 CI 失败已由 PR #181 修复；当前 master 的 `.github/workflows/release-container.yml` jobless startup failure 仍单独未定位。

## 解决的问题 / Problem

本仓库的 PR workflow 检查存在两类维护成本：

1. `product-platforms.yml` 在 pull request 上为每个平台执行完整 Product 构建和 smoke，跨平台 runner 成本高；master push 与发布前流程更适合承担完整四平台验证。
2. 实际 `packages/*` 目录是否都被 PR 门禁 paths 覆盖，过去依赖人工维护，新增包可能漏挂；8 个 workflow 还保留了已无作用的 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`。
3. 动态 matrix 使读取静态 `matrix.include` 的测试消费者断裂（`release-assets.test.ts` 在 release preflight 确定性 TypeError），且 selector 行为缺少可执行的三事件合同。

边界澄清：

- PR #183 旧 head `511a1c4b` 的 8 项失败是 `bun.lock` 中 Windows 反斜杠 `file:` 描述符导致 Linux 安装失败，已由 PR #181 修复；不是本 PR 的根因或改动。
- 当时 master head `0a04b2a2` 曾有两个已核实的 `.github/workflows/release-container.yml` jobless startup failure（runs `32813783653`、`32813786634`，均为 `push`、`jobs=0`、`failure`）。其触发机制未定位，本 PR 不宣称修复它。

## 本次范围 / Scope

包含 / In scope:

- 在 `product-platforms.yml` 中按事件选择 Product matrix：pull request 只运行 `linux-x64-glibc`，master push 和手动运行保留四个平台。
- 将矩阵数据与选择逻辑提取为可测试模块 `scripts/build/product-platform-matrix.ts`（单一数据源），workflow 与全部静态消费者统一迁移到该模块。
- 固化 `code-baseline.yml` 与 `product-platforms.yml` 对全部 `packages/*` 目录的 PR paths 覆盖合同。
- 从 8 个 workflow 删除无效的 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`；删除随之变空的 4 个 `env:` 键。它们与首轮 jobless startup failure 同时存在于同一中间态；移除后当前 head 恢复正常，但该 run 无 jobs 且同时包含已撤回的 community push 改动，根因未完全隔离。
- 保留 `community-docs.yml` 既有 master push、与 PR 完全一致的 paths，以及社区校验器要求的命令顺序。

不包含 / Out of scope:

- 不修改 `bun.lock`，不重复 PR #181 的修复。
- 不猜测或修复 `release-container.yml` 的未定位 startup failure。
- 不删除 community workflow 的 master push；现有 `validate-community-files.ts` 明确要求该合同。
- 不修改产品运行时、用户界面、数据库、版本号、`RELEASE.md`、部署或发布资产。

## 用户可见结果与实现 / User-visible result and implementation

维护者可见结果：

- Product workflow 在 pull request 上只执行 `select-platforms` 与 `linux-x64-glibc Product`；selector 本身显示为一个额外 check。master push / workflow_dispatch 选择原四平台 Product matrix。
- 新增包目录时，workflow 合同测试会在缺少 `packages/<dir>/**` paths 时失败。
- 删除无效 Actions Node 24 环境变量，保留其它 workflow 环境变量和命令。
- 无终端用户 UI 或产品功能变化。

实现合同：

- 新增 `scripts/build/product-platform-matrix.ts`：导出 `PRODUCT_PLATFORM_MATRIX_ENTRIES`、纯函数 `selectProductPlatformMatrix(eventName)` 与 CLI 入口（stdout 输出 `{include: [...]}` 紧凑 JSON，事件名取 `$1` 或 `EVENT_NAME`）。
- `select-platforms` job 先 `actions/checkout@v5` 再调用该 CLI 写入 `$GITHUB_OUTPUT`；`product` job 使用 `fromJSON(needs.select-platforms.outputs.matrix)`。
- 静态消费者迁移到模块数据：`scripts/release/release-assets.test.ts`（改为消费 `selectProductPlatformMatrix("push")` 并保留 `fromJSON` 结构绑定断言）、`scripts/build/product-runtime-measurement-contract.test.ts`（push 事件平台覆盖断言）。
- `scripts/ci/workspace-workflows.test.ts` 断言三事件精确输出（pull_request 单条目对象、push/workflow_dispatch 四平台）、`push.branches === ["master"]`、push/pull_request paths 对等，以及 select 步骤调用脚本的结构绑定。
- `community-docs` 的 push/PR paths 与既有完整命令合同保持不变。

## 验证 / Verification

实际执行的完整命令和结果 / Exact commands and results:

```text
bun install --frozen-lockfile --linker hoisted
1531 packages installed [170.58s]

bun scripts/build/product-platform-matrix.ts pull_request
{"include":[{"platform":"linux-x64-glibc","runner":"ubuntu-latest","command":"release:product:linux","archive":"neuro-book-product-linux-x64-glibc.tar.gz","port":39223,"browser":"playwright"}]}
（push / EVENT_NAME=workflow_dispatch 同法验证：四条目且不含 prGate 字段）

bun x vitest run --config scripts/vitest.config.ts scripts/ci/workspace-workflows.test.ts scripts/build/product-runtime-measurement-contract.test.ts
Test Files  2 passed (2); Tests  14 passed (14)

bun run --cwd packages/neuro-book nuxt:prepare
Types generated in .nuxt

bun x vitest run --config scripts/release/release-assets-vitest.config.ts
Test Files  4 passed (4); Tests  32 passed (32)

bun scripts/ci/validate-community-files.ts
贡献体系校验通过：31 个标签、5 个 Issue Form、16 个 YAML。

bun x tsc --noEmit -p scripts/tsconfig.json
通过（exit code 0，无输出）

git diff --check
通过（无输出）
```

Hosted verification:

- PR head `a9cb968f`（分支已改名 `chore/i198-simplify-pr-checks`）：16/16 checks success；其中 `select-platforms`（checkout + 矩阵脚本，2s）与 `linux-x64-glibc Product` 均通过。
- 受控 workflow_dispatch run `32833016369`（ref `chore/i198-simplify-pr-checks`）：见下方补充记录。

未运行的检查及原因 / Checks not run and why:

- 本地完整产品测试、完整 Vitest 全量套件：未运行；聚焦配置已覆盖改动路径，避免重复高成本全量流程。
- 合并后的 master push 四平台 Product matrix：未运行；PR 尚未合并，不能在 pull request 事件上证明 push 分支；workflow_dispatch 不能替代 branches/paths/event 上下文验证。
- `release-container.yml` 的 workflow_dispatch 发布验证：未运行；涉及发布流程，超出本 PR 验证范围。
- 浏览器人工验收、截图、录屏：未运行；本 PR 无用户界面改动。
- `release-container.yml` startup failure 的根因验证：未完成；对照实验不能归因，故不提交猜测修复。

## 界面证据 / UI evidence

无前端或用户界面改动；未运行浏览器人工验收，无截图或录屏。

## 文档与记录 / Documentation and records

- [x] 已确认不需要更新用户文档 / User documentation not needed：本 PR 只改变 CI 检查调度和治理合同测试。
- [x] 已确认不需要更新 Task walkthrough / Task walkthrough not needed：本次没有对应实现 Task。
- [x] 已确认不需要更新 Reference、ADR 与 `PROJECT-STATUS.md` / Reference, ADR, and `PROJECT-STATUS.md` not needed：不改变产品行为合同。
- [x] 已说明受影响合同 / Affected contracts recorded：`scripts/build/product-platform-matrix.ts`、`scripts/ci/workspace-workflows.test.ts`、`scripts/ci/validate-community-files.ts`。
- [x] 本 PR 不修改版本号或 `RELEASE.md` / This PR does not change version or `RELEASE.md`。

## 风险与边界 / Risks and boundaries

- 数据结构或迁移 / Data shape or migration: 无；不修改数据库、文件格式或持久化数据。
- 配置、安装或发布 / Configuration, installation, or release: 修改 GitHub Actions 触发和矩阵配置；发布前四平台验证保留，但 master push 路径尚未 hosted 验证。安装命令和产品发布资产未修改。
- 安全与隐私 / Security and privacy: 无新增权限、密钥、用户数据或网络边界。
- 已知限制与后续事项 / Known limitations and follow-ups: `select-platforms` 会增加一个 PR check；community push 删除方案被现有治理合同否决；`release-container.yml` jobless startup failure 机制未定位；PR 合并后需再观察 master push 四平台矩阵并据此关闭 #198。

## 提交者确认 / Contributor confirmation

- [x] 一个连贯目标之外没有夹带其它改动 / This PR contains no unrelated changes outside one coherent CI workflow goal。
- [x] 我已审查并能解释全部改动，包括开发 Agent 生成的内容 / I reviewed and can explain every change, including coding-agent output。
- [x] 验证结果真实，聚焦测试没有被描述成全量测试 / Verification is accurate; focused tests are not presented as the full suite。
- [x] 日志、截图和 fixture 不含密钥、小说正文、私人会话或未授权内容 / Logs, screenshots, and fixtures contain no secrets, manuscripts, private sessions, or unlicensed material。
