### PR TITLE
fix(build): exclude nested generated dirs from gitless source identity

### DIFF
--- a/packages/neuro-book/package.json
+++ b/packages/neuro-book/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notnotype/neuro-book",
-  "version": "0.9.7-canary.20260825.060352Z.2ee1594b",
+  "version": "0.9.7-canary.20260825.074349Z.d2dc543a",
   "description": "A local AI workspace for long-form novel writing, integrating a file-based workspace, Markdown Studio, story structure management, and multi-agent writing workflows.",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/scripts/build/product-runtime-image-builder.test.ts
+++ b/scripts/build/product-runtime-image-builder.test.ts
@@ -546,6 +546,11 @@ describe("ProductRuntimeImageBuilder", {timeout: 30_000}, () => {
         await rm(join(root, ".git"), {recursive: true, force: true});
         await mkdir(join(root, "server", "generated", "prisma"), {recursive: true});
         await writeFile(join(root, "server", "generated", "prisma", "client.ts"), "generated-v1\n", "utf8");
+        // monorepo 嵌套目录先于首个快照存在，构建期只写入内容。
+        const nestedGenerated = join(root, "packages", "neuro-book", "node_modules", ".cache", "nuxt", ".nuxt");
+        const nestedSource = join(root, "packages", "neuro-book", "src");
+        await mkdir(nestedGenerated, {recursive: true});
+        await mkdir(nestedSource, {recursive: true});
         const builder = new ProductRuntimeImageBuilder(root);
 
         await expect(simpleImage(builder, "gitless-without-identity")).rejects.toThrow(
@@ -563,6 +568,8 @@ describe("ProductRuntimeImageBuilder", {timeout: 30_000}, () => {
                 await writeRuntimeFixture(imageRoot);
                 await writeFile(join(root, "logs", "server-current.jsonl"), "generated during build\n", "utf8");
                 await writeFile(join(root, "server", "generated", "prisma", "client.ts"), "generated-v2\n", "utf8");
+                // monorepo 嵌套生成态目录（packages/<app>/node_modules/.cache/nuxt/.nuxt）不得进入 Source 身份。
+                await writeFile(join(nestedGenerated, "app.config.mjs"), "generated-v1\n", "utf8");
             },
         });
         expect(image.manifest).toMatchObject({revision, dirty: false});
@@ -576,6 +583,8 @@ describe("ProductRuntimeImageBuilder", {timeout: 30_000}, () => {
                 await mkdir(join(imageRoot, "server"), {recursive: true});
                 await writeFile(join(imageRoot, "server", "index.mjs"), "race", "utf8");
                 await writeFile(join(root, "src", "input.ts"), "export const input = 2;\n", "utf8");
+                // 嵌套真实源码变更仍必须触发失败。
+                await writeFile(join(nestedSource, "input.ts"), "export const nestedInput = 1;\n", "utf8");
             },
         })).rejects.toThrow("Source 输入发生变化");
     });

--- a/scripts/build/product-runtime-image-builder.ts
+++ b/scripts/build/product-runtime-image-builder.ts
@@ -101,7 +101,11 @@ const GITLESS_SOURCE_PATH_EXCLUDES = new Set(["server/generated/prisma"]);
 
 function isGitlessSourceExcluded(segments: readonly string[], entryName: string): boolean {
     const relativePath = [...segments, entryName].join("/");
-    return GITLESS_SOURCE_PATH_EXCLUDES.has(relativePath)
+    // 通用生成态目录必须在任意深度排除：monorepo 收敛后应用生成物位于
+    // packages/<app>/node_modules/.cache/nuxt/.nuxt 等嵌套路径，仅根层短路
+    // 会让构建期写入的缓存进入 Source 身份并误报「Source 输入发生变化」。
+    return GITLESS_SOURCE_EXCLUDES.has(entryName)
+        || GITLESS_SOURCE_PATH_EXCLUDES.has(relativePath)
         || (segments[0] === "packages" && (entryName === "data.db" || entryName.startsWith("data.db-")))
         || (segments[0] === "packages" && relativePath.endsWith("/server/generated/prisma"));
 }


### PR DESCRIPTION
## 根因

run [32823035151](https://github.com/notnotype/neuro-book/actions/runs/32823035151) 构建失败：`assertSameSource` 报 sourceDigest 变化，差异全为 `packages/neuro-book/node_modules/.cache/nuxt/.nuxt/**`。`gitlessSourcePaths` 的通用排除集只在根层（`segments.length===0`）生效，`isGitlessSourceExcluded` 只查 PATH_EXCLUDES/data.db/prisma——monorepo 收敛后应用生成物全部位于嵌套路径，构建期 nuxt 缓存写入进入 Source 身份。

## 改动

- `isGitlessSourceExcluded` 增加任意深度 `GITLESS_SOURCE_EXCLUDES.has(entryName)`。
- 回归测试：嵌套 `node_modules/.cache/nuxt/.nuxt` 写入不触发；嵌套 `src/input.ts` 写入仍拒绝。

## 验证

`product-runtime-image-builder.test.ts` 17/17 通过（修复前新用例触发 ENOENT/误报两类失败）。