### PR TITLE
fix(release): pin Windows job Bun to 1.3.14

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -343,6 +343,8 @@ jobs:
           ref: ${{ inputs.revision }}
       - id: setup-bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
       - id: windows-dependencies
         name: Restore Windows Bun dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
bun 1.4.0（Windows）复制 `file:` workspace 依赖时确定性 `EEXIST: failed copying files from cache to destination`（run 32825450095 两次重跑同错）。product-windows 的 setup-bun 钉 `bun-version: 1.3.14`（0.9.6 发布同版本全绿），与 preflight 钉版同型。workflow 层改动，revision 不变，可同 Draft 重派。