### PR TITLE
fix(release): point owned-process fixture at monorepo layout

### DIFF
--- a/scripts/deploy/windows-owned-process-smoke.ts
+++ b/scripts/deploy/windows-owned-process-smoke.ts
@@ -67,7 +67,7 @@ async function verifyBackgroundTermination(
     agentBin: string,
 ): Promise<void> {
     const statePath = join(root, `background-${reason}.json`);
-    const fixture = resolve(import.meta.dir, "..", "..", "server", "agent", "tools", "fixtures", "owned-process-root.ts");
+    const fixture = resolve(import.meta.dir, "..", "..", "packages", "neuro-book", "server", "agent", "tools", "fixtures", "owned-process-root.ts");
     const command = [process.execPath, fixture, statePath]
         .map((path) => `'${windowsPathForBash(path).replaceAll("'", "'\\''")}'`)
         .join(" ");
@@ -117,7 +117,7 @@ async function verifyTermination(
     agentBin: string,
 ): Promise<void> {
     const statePath = join(root, `${reason}.json`);
-    const fixture = resolve(import.meta.dir, "..", "..", "server", "agent", "tools", "fixtures", "owned-process-root.ts");
+    const fixture = resolve(import.meta.dir, "..", "..", "packages", "neuro-book", "server", "agent", "tools", "fixtures", "owned-process-root.ts");
     const command = [process.execPath, fixture, statePath]
         .map((path) => `'${windowsPathForBash(path).replaceAll("'", "'\\''")}'`)
         .join(" ");


### PR DESCRIPTION
monorepo cutover 后 `server/` 移入 `packages/neuro-book/server/`，`windows-owned-process-smoke.ts` 两处 fixture 的 `resolve(../.., server/...)` 仍指向仓库根旧路径：Git Bash 内 bun 报 `Module not found`、bash 快速退出，product-windows 每轮发布在此步骤失败（run 32827884349 两次）。本机修复后完整生命周期（timeout/abort/cancel/shutdown）通过：`{"status":"passed",...}`。需要新 Draft 重派（revision 内容修复）。