### PR TITLE
fix(release): repair stale gitattributes paths and surface dirty files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@ packages/neuro-book/assets/workspace/.nbook/agent/bin/workspace text eol=lf
 packages/neuro-book/assets/workspace/.nbook/agent/bin/profile text eol=lf
 packages/neuro-book/assets/workspace/.nbook/agent/bin/*.cmd text eol=crlf
 packages/neuro-book/assets/workspace/.nbook/agent/scripts/*.ts text eol=lf
-server/generated/project-prisma/** text eol=lf
+packages/neuro-book/server/generated/project-prisma/** text eol=lf
 bun.lock text eol=lf
 packages/neuro-book/.env.product text eol=lf
 *.mjs text eol=lf
@@ -10,7 +10,3 @@ packages/neuro-book/.env.product text eol=lf
 **/.agents/tasks/**/*.png -text
 **/.agents/tasks/**/*.wsb -text
 **/.agents/tasks/**/*.ps1 -text
-docs/tasks/** text eol=lf
-docs/tasks/**/*.png -text
-docs/tasks/**/*.wsb -text
-docs/tasks/**/*.ps1 -text

--- a/scripts/release/release-output.ts
+++ b/scripts/release/release-output.ts
@@ -90,7 +90,15 @@ export async function readReleaseGeneration(projectRoot: string): Promise<Releas
         readFile(resolve(projectRoot, "bun.lock")),
     ]);
     if (statusOutput.length > 0) {
-        throw new Error("正式 Release Source 必须来自干净 Git checkout；当前 Source dirty=true。");
+        // -z 输出按 NUL 分隔；发布失败时必须直接给出脏路径，否则 Windows/CI 只剩不可定位的 dirty=true。
+        const entries = statusOutput.split("\0")
+            .filter((entry) => entry.length > 0)
+            .slice(0, 20)
+            .map((entry) => `- ${entry.slice(0, 300)}`);
+        throw new Error([
+            "正式 Release Source 必须来自干净 Git checkout；当前 Source dirty=true。",
+            ...entries,
+        ].join("\n"));
     }
     const revision = revisionOutput.trim();
     if (!/^[0-9a-f]{40,64}$/iu.test(revision)) {


### PR DESCRIPTION
## 根因

run [32827884349](https://github.com/notnotype/neuro-book/actions/runs/32827884349) product-windows 在 `release:product:windows` 的干净检查失败（dirty=true，无路径细节）。本地复刻确认：`.gitattributes` 的 `server/generated/project-prisma/** text eol=lf` 为根锚定模式，cutover 后对该嵌套路径失效（`git check-attr` unspecified），Windows autocrlf checkout 写 CRLF、构建再生成写 LF → status 幻影 dirty。`docs/tasks/**` 四条同指已删目录。

## 改动

- prisma 属性行改 `packages/neuro-book/server/generated/project-prisma/**`；删除 docs/tasks 四条（已被 `**/.agents/tasks/**` 覆盖）。
- `readReleaseGeneration` dirty 抛错附带 porcelain 路径列表（前 20 条），后续任何 dirty 失败可直接定位。

## 验证

- 本地：属性修正后该批文件的幻影 M 消失路径判定正确；worktree 哈希三方一致。
- 契约：release-assets 32/32、builder 17/17 全绿。