### PR TITLE
fix(release): build Manager bundle before Windows portable packaging

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -370,6 +370,8 @@ jobs:
           name: source
           path: ${{ env.NEURO_BOOK_RELEASE_DIR }}
       - run: bun run release:product:windows
+      - name: Build Manager bundle for portable embedding
+        run: bun run manager:build
       - run: bun run package:windows-portable
       - uses: actions/upload-artifact@v4
         with:

--- a/scripts/release/release-assets.test.ts
+++ b/scripts/release/release-assets.test.ts
@@ -459,9 +459,12 @@ describe("Product Release宿主合同", () => {
         expect(macosRun).toContain("bun run test:install");
         expect(macosRun).toContain("bun run manager:test");
         const windowsRun = workflow.jobs["product-windows"].steps.map(({run}) => run ?? "").join("\n");
-        expect(windowsRun).toContain("bun run --cwd packages/neuro-book nuxt:prepare");
         expect(windowsRun.indexOf("bun run --cwd packages/neuro-book nuxt:prepare")).toBeLessThan(
             windowsRun.indexOf("bun run manager:test"),
+        );
+        expect(windowsRun).toContain("bun run manager:build");
+        expect(windowsRun.indexOf("bun run manager:build")).toBeLessThan(
+            windowsRun.indexOf("bun run package:windows-portable"),
         );
     });
 


### PR DESCRIPTION
run [32843085769](https://github.com/notnotype/neuro-book/actions/runs/32843085769)：`package:windows-portable` 报 `Cannot find module '@notnotype/neuro-book-manager/portable'`——cutover 后经 workspace symlink 解析到 `packages/neuro-book-manager/dist/portable.mjs`，而 product-windows job 无 manager 构建步骤。在打包前加 `bun run manager:build`，契约测试锁定其先于打包执行。workflow 层改动，revision 不变可同 Draft 重派。