### PR TITLE
fix(release): restore runCapture import in Windows portable packager

### DIFF
--- a/scripts/deploy/windows-portable-manager.ts
+++ b/scripts/deploy/windows-portable-manager.ts
@@ -20,6 +20,7 @@ import {once} from "node:events";
 import {fileURLToPath} from "node:url";
 import {Command} from "commander";
 import {Unzip, UnzipInflate} from "fflate";
+import {runCapture} from "#scripts/utils/process.mjs";
 
 import {
     ensureStateFiles,


### PR DESCRIPTION
monorepo cutover（31ea615b）删除了 `windows-portable-manager.ts` 的 `#scripts/utils/process.mjs` 导入但保留 `verifyPortableExecutables` 内的调用：打包在可执行文件校验处必抛 `runCapture is not defined`（run [32846922132](https://github.com/notnotype/neuro-book/actions/runs/32846922132)）。恢复导入；需要新 Draft 重派。