### PR TITLE
docs(tasks): link notification task to theme spec

### DIFF
--- a/.agents/tasks/00158-notification-contrast-fix/README.md
+++ b/.agents/tasks/00158-notification-contrast-fix/README.md
@@ -31,6 +31,10 @@ agentWorkflow:
 
 Issue #177 报告通知卡片使用硬编码 Tailwind 状态色导致主题下对比度不足且对齐不一致。fork 作者提交了 PR #178（读 `themeVarsSnapshot` + `color-mix(..., #000000)` 压黑 + 固定白字），审查判定其核心验收不成立：8 套内置主题静态计算中 Dracula/warning 白字对比度仅约 1.70:1；同时该 PR 无说明地移除玻璃拟态并引入违反主题变量合同的固定黑色。
 
+## 关联规范 / Spec
+
+- [主题系统参考](../../../docs/specs/theme/system.md)：主题变量、内置主题、自定义主题与通知视口消费边界。
+
 ## 实现摘要
 
 - 新增 `app/utils/theme/notification-tone.ts`：tone→状态变量三件套映射；背景为 `--status-*-bg` 与 `--bg-panel` 的 14% 合成色，前景取 `--text-main` 同源配对；`sanitizeNotificationVars` 对消费字段做语法校验，非法值逐字段回退当前明暗家族内置预设（light→sepia，dark→dark）。


### PR DESCRIPTION
## 关联 Issue

Refs #177。

## 问题

`bun run docs:check` 拒绝当前 Task README：`.agents/tasks/00158-notification-contrast-fix/README.md` 没有链接具体 Spec，也没有明确说明“行为合同未变”。

## 修复

补充现有已实现规范 [主题系统参考](https://github.com/notnotype/neuro-book/blob/master/docs/specs/theme/system.md) 的关联链接。仅修改该 Task README，不改变主题实现、测试或 PR #199。

## 验证

- `bun run docs:check`：`failures: []`，检查 5274 个文件。
- `git diff --check`：通过。

## 边界

本 PR 只修复 Task 文档治理合同；Full tests 与 PR #199 的 workflow 精简问题不在本 PR 范围内。