### PR TITLE
fix(release): restore ROOT constant and runCapture import in portable packager

### DIFF
--- a/scripts/deploy/windows-portable-manager.ts
+++ b/scripts/deploy/windows-portable-manager.ts
@@ -55,6 +55,7 @@ import {
 import {sanitizeZipEntryName, writeZipArchive} from "#scripts/utils/zip";
 
 const WINDOWS_PRODUCT_PLATFORM: ProductPlatform = "windows-x64";
+const ROOT = resolve(import.meta.dirname, "..", "..");
 const SOURCE_BUILD_FILE = "source-build.json";
 const PRODUCT_BUILD_FILE = "product-build.json";
 const MAX_ZIP_COMMENT_BYTES = 65_535;


### PR DESCRIPTION
run [32846922132](https://github.com/notnotype/neuro-book/actions/runs/32846922132) 与 [32849944091](https://github.com/notnotype/neuro-book/actions/runs/32849944091)：`windows-portable-manager.ts` 存在 cutover 遗留的未定义引用——`verifyPortableExecutables` 调用未导入的 `runCapture`、`packagePortable` 收尾日志使用未定义的 `ROOT`。分别恢复导入与常量定义。`scripts/tsconfig.json` 未纳入该文件致 typecheck 失察，类型缺口以跟进 issue 跟踪。需要新 Draft。