### PR TITLE
fix(release): validate release manifest via contracts package

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -435,9 +435,8 @@ jobs:
             --manager-version "${manager_version}" \
             --ghcr-ref "${APP_IMAGE_NAME}@${GHCR_DIGEST}" \
             --ghcr-digest "${GHCR_DIGEST}"
-          MANAGER_ROOT="${manager_root}" bun -e 'const schema = await import(`${process.env.MANAGER_ROOT}/package/dist/schema.mjs`); const manifest = await Bun.file(`${process.env.NEURO_BOOK_RELEASE_DIR}/release-manifest.json`).json(); schema.parseReleaseManifest(manifest);'
-      - name: Upload candidate release bundle
-        uses: actions/upload-artifact@v4
+          bun -e 'const schema = await import("./packages/neuro-book-contracts/src/release.ts"); const manifest = await Bun.file(`${process.env.NEURO_BOOK_RELEASE_DIR}/release-manifest.json`).json(); schema.parseReleaseManifest(manifest); console.log("release-manifest.json 通过 contracts 解析校验");'
+      - uses: actions/upload-artifact@v4
         with:
           name: release-candidate
           path: |

--- a/packages/neuro-book/package.json
+++ b/packages/neuro-book/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notnotype/neuro-book",
-  "version": "0.9.7-canary.20260825.074349Z.d2dc543a",
+  "version": "0.9.7-canary.20260825.133042Z.22764ac9",
   "description": "A local AI workspace for long-form novel writing, integrating a file-based workspace, Markdown Studio, story structure management, and multi-agent writing workflows.",
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
run [32853804520](https://github.com/notnotype/neuro-book/actions/runs/32853804520)：assemble 的 `Build release manifest` 步骤仍从 packed manager `dist/schema.mjs` 导入 `parseReleaseManifest`，cutover 后该导出已移入 contracts 包，eval 报 `is not a function`。改从 workspace 内 contracts 源导入（bun 原生 TS）。product-windows 本轮已绿。