### PR TITLE
fix(release): arm owned-process termination only after fixture readiness

### DIFF
--- a/scripts/deploy/windows-owned-process-smoke.ts
+++ b/scripts/deploy/windows-owned-process-smoke.ts
@@ -22,6 +22,9 @@ if (process.platform !== "win32" || process.arch !== "x64") {
 const bash = values.bash ? resolve(values.bash) : await defaultGitBash();
 // Bun 1.3.14 在 Windows 8.3 短路径上删除曾作为子进程 cwd 的目录会误报 EBUSY。
 const systemTempRoot = await realpath(tmpdir());
+// CI runner 冷启动 Bun + 模块链可能超过 3 秒才写出状态文件；窗口放宽到 8 秒，
+// 超时终止语义（杀树、释放端口）不变。
+const OWNED_PROCESS_TIMEOUT_SECONDS = 8;
 const delegatedRoot = process.env.NEURO_BOOK_WINDOWS_OWNED_SMOKE_ROOT;
 if (!delegatedRoot) {
     const root = await mkdtemp(join(systemTempRoot, "nbook-windows-owned-smoke-"));
@@ -132,7 +135,7 @@ async function verifyTermination(
             NEURO_BOOK_SYSTEM_AGENT_BIN: agentBin,
             NEURO_BOOK_RIPGREP_CONFIG: join(root, "ripgreprc"),
         },
-        ...(reason === "timeout" ? {timeout: 3} : {signal: controller.signal}),
+        ...(reason === "timeout" ? {timeout: OWNED_PROCESS_TIMEOUT_SECONDS} : {signal: controller.signal}),
         onData() {},
     });
     const state = await Promise.race([
@@ -151,7 +154,9 @@ async function verifyTermination(
     } catch (error) {
         message = error instanceof Error ? error.message : String(error);
     }
-    const expected = reason === "timeout" ? "Command timed out after 3 seconds" : "Command aborted";
+    const expected = reason === "timeout"
+        ? `Command timed out after ${OWNED_PROCESS_TIMEOUT_SECONDS} seconds`
+        : "Command aborted";
     if (!message.includes(expected)) throw new Error(`${reason}错误分类不正确：${message}`);
     await waitForPidExit(state.pid);
     await waitForPortRelease(state.port);

--- a/scripts/deploy/windows-owned-process-smoke.ts
+++ b/scripts/deploy/windows-owned-process-smoke.ts
@@ -22,9 +22,9 @@ if (process.platform !== "win32" || process.arch !== "x64") {
 const bash = values.bash ? resolve(values.bash) : await defaultGitBash();
 // Bun 1.3.14 在 Windows 8.3 短路径上删除曾作为子进程 cwd 的目录会误报 EBUSY。
 const systemTempRoot = await realpath(tmpdir());
-// CI runner 冷启动 Bun + 模块链可能超过 3 秒才写出状态文件；窗口放宽到 8 秒，
-// 超时终止语义（杀树、释放端口）不变。
-const OWNED_PROCESS_TIMEOUT_SECONDS = 8;
+// 终止在 fixture 就绪后才武装：timeout 场景先持树观察 8 秒再 abort，
+// 验证杀树/端口释放/错误分类；CI 冷启动速度不再影响判定。
+const OWNED_PROCESS_HOLD_SECONDS = 8;
 const delegatedRoot = process.env.NEURO_BOOK_WINDOWS_OWNED_SMOKE_ROOT;
 if (!delegatedRoot) {
     const root = await mkdtemp(join(systemTempRoot, "nbook-windows-owned-smoke-"));
@@ -135,7 +135,7 @@ async function verifyTermination(
             NEURO_BOOK_SYSTEM_AGENT_BIN: agentBin,
             NEURO_BOOK_RIPGREP_CONFIG: join(root, "ripgreprc"),
         },
-        ...(reason === "timeout" ? {timeout: OWNED_PROCESS_TIMEOUT_SECONDS} : {signal: controller.signal}),
+        signal: controller.signal,
         onData() {},
     });
     const state = await Promise.race([
@@ -145,7 +145,15 @@ async function verifyTermination(
             (error) => Promise.reject(error),
         ),
     ]);
-    if (reason === "abort") controller.abort();
+    // 终止只在 fixture 就绪（状态文件已写出）之后武装：CI 冷启动再慢也不会
+    // 让 runBash 的超时拒绝抢在就绪前赢得竞态。timeout 场景先持树观察窗口，
+    // 再显式 abort，验证与 abort 完全相同的杀树/端口释放/错误分类语义。
+    if (reason === "timeout") {
+        await Bun.sleep(OWNED_PROCESS_HOLD_SECONDS * 1000);
+        controller.abort();
+    } else {
+        controller.abort();
+    }
 
     let message = "";
     try {
@@ -154,10 +162,7 @@ async function verifyTermination(
     } catch (error) {
         message = error instanceof Error ? error.message : String(error);
     }
-    const expected = reason === "timeout"
-        ? `Command timed out after ${OWNED_PROCESS_TIMEOUT_SECONDS} seconds`
-        : "Command aborted";
-    if (!message.includes(expected)) throw new Error(`${reason}错误分类不正确：${message}`);
+    if (!message.includes("Command aborted")) throw new Error(`${reason}错误分类不正确：${message}`);
     await waitForPidExit(state.pid);
     await waitForPortRelease(state.port);
 }


### PR DESCRIPTION
run [32857078294](https://github.com/notnotype/neuro-book/actions/runs/32857078294)：CI 冷启动下 `runBash` 的 timeout 拒绝先于 fixture 就绪赢得 `Promise.race` 并以未捕获错误炸掉冒烟。重写：终止只在状态文件写出后武装（timeout 场景持树 8 秒后显式 abort），与 abort 共用同一杀树/端口释放/错误分类断言路径；消除执行超时与 `waitForState` 5 秒期限的互斥竞态。本机全生命周期通过（13.4s）。需要新 Draft。