### PR TITLE
fix(release): pin verify-windows Bun to 1.3.14

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -892,6 +892,8 @@ jobs:
         with:
           ref: ${{ inputs.revision }}
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
       - run: bun scripts/release/install-dependencies.ts --linker hoisted
       - uses: actions/download-artifact@v4
         with:

--- a/packages/neuro-book/package.json
+++ b/packages/neuro-book/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notnotype/neuro-book",
-  "version": "0.9.7-canary.20260825.133042Z.22764ac9",
+  "version": "0.9.7-canary.20260825.150859Z.9095d2b2",
   "description": "A local AI workspace for long-form novel writing, integrating a file-based workspace, Markdown Studio, story structure management, and multi-agent writing workflows.",
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
run [32864012941](https://github.com/notnotype/neuro-book/actions/runs/32864012941)：verify-windows 依赖恢复在 bun 1.4.0（Windows）再现确定性 `EEXIST: failed copying files from cache to destination`。与 product-windows（#196）同型钉 `bun-version: 1.3.14`。workflow 层改动，可同 Draft 重派。