### PR TITLE
fix(release): pin image revision label to inputs and fix verify-windows Bun

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -106,10 +106,8 @@ jobs:
           owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           echo "app=ghcr.io/${owner}/neuro-book" >> "${GITHUB_OUTPUT}"
 
-      - id: app-meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ steps.image-names.outputs.app }}
+          labels: |
+            org.opencontainers.image.revision=${{ inputs.revision }}
 
       - id: app-build
         name: Build and push app image by digest
@@ -586,6 +584,8 @@ jobs:
         with:
           ref: ${{ inputs.revision }}
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
       - run: bun scripts/release/install-dependencies.ts --linker hoisted
       - uses: actions/download-artifact@v4
         with:
@@ -892,8 +892,6 @@ jobs:
         with:
           ref: ${{ inputs.revision }}
       - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
       - run: bun scripts/release/install-dependencies.ts --linker hoisted
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
run [32870170142](https://github.com/notnotype/neuro-book/actions/runs/32870170142)：\n- verify-linux 标签比对失败：metadata-action 默认 `org.opencontainers.image.revision` 取 `github.sha`（派发 ref 头），与 `inputs.revision` 分离；显式覆盖为 inputs.revision。\n- verify-windows 仍跑 bun 1.4.0（#208 的钉版误落在 verify-public-payload）；移正归属。\n\nworkflow 层改动，revision 不变可同 Draft 重派。