### PR TITLE
fix(release): remove metadata garbage and dangling app-meta label ref

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -106,9 +106,6 @@ jobs:
           owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           echo "app=ghcr.io/${owner}/neuro-book" >> "${GITHUB_OUTPUT}"
 
-          labels: |
-            org.opencontainers.image.revision=${{ inputs.revision }}
-
       - id: app-build
         name: Build and push app image by digest
         uses: docker/build-push-action@v6
@@ -118,7 +115,6 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             NEURO_BOOK_SOURCE_REVISION=${{ inputs.revision }}
-          labels: ${{ steps.app-meta.outputs.labels }}
           outputs: type=image,name=${{ steps.image-names.outputs.app }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=app-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=app-${{ matrix.arch }}


### PR DESCRIPTION
#209 的编辑误把 `docker/metadata-action` 步骤整体替换为 `labels:` 垃圾行（进入 image-names 的 run，CI 报 `labels:: command not found`），并让 app-build 悬挂引用 `steps.app-meta.outputs.labels`。\n\n- 清除 image-names run 内的垃圾行。\n- 移除 app-build 的悬空 labels 行；镜像 `org.opencontainers.image.revision` 由 Dockerfile 的 `NEURO_BOOK_SOURCE_REVISION` build-arg 提供（值即 `inputs.revision`），verify-linux 标签比对成立。\n\nworkflow 层改动，可同 Draft 重派。