### PR TITLE
fix(release): build Manager bundle in verify-windows job

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -583,6 +583,8 @@ jobs:
         with:
           bun-version: 1.3.14
       - run: bun scripts/release/install-dependencies.ts --linker hoisted
+      - name: Build Manager bundle for restart verifier
+        run: bun run manager:build
       - uses: actions/download-artifact@v4
         with:
           name: release-candidate


### PR DESCRIPTION
run [32875000828](https://github.com/notnotype/neuro-book/actions/runs/32875000828)：`verify-windows` 的 restart 校验从 workspace 导入 `@notnotype/neuro-book-manager/installation`，该 job 未构建 manager dist → `Cannot find module`。与 product-windows（#201）同型在依赖安装后加 `bun run manager:build`。workflow 层改动，可同 Draft 重派。