### PR TITLE
fix(release): instrument delegated podman path diagnostics

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -1086,6 +1086,11 @@ jobs:
               exit 1
           fi
           command -v docker-compose
+          # 委托通信探针：docker-compose 必须能在 60 秒内连上 podman.sock 完成 version。
+          export DOCKER_HOST="unix:///run/user/$(id -u)/podman/podman.sock"
+          test -S "/run/user/$(id -u)/podman/podman.sock" || { echo "podman.sock 缺失" >&2; exit 1; }
+          timeout 60 docker-compose version || { echo "docker-compose 连 podman.sock 超时/失败" >&2; exit 1; }
+          timeout 60 podman compose version || { echo "podman compose 委托探针失败" >&2; exit 1; }
           manager_version="$(node -p 'require("./packages/neuro-book-manager/package.json").version')"
           candidate_manifest="$PWD/candidate-assets/release-manifest.json"
           # 40 分钟护栏：任何死锁都硬失败并保留现场日志，避免整 job 静默挂到 6 小时。

--- a/scripts/release/verify-public-ghcr.sh
+++ b/scripts/release/verify-public-ghcr.sh
@@ -24,6 +24,7 @@ fi
 
 manager() {
     # 仓库自身也是同名 Bun workspace；必须在空目录运行，确保消费 npm 公开包而不是 Source workspace。
+    echo "[verify] manager> $*" >&2
     (cd "$manager_cwd" && bunx --bun "@notnotype/neuro-book-manager@${manager_version}" "$@")
 }
 
@@ -33,6 +34,7 @@ resolve_state_root() {
 
 compose() {
     [[ -n "$state_root" ]] || { echo "State Root尚未解析。" >&2; return 1; }
+    echo "[verify] compose> $*" >&2
     "$engine" compose --env-file "$state_root/.env" -f "$compose_path" "$@"
 }
 


### PR DESCRIPTION
run 32907756748：委托任务 40 分钟静默挂死（timeout 2400 截断，bunx 装完 manager 包后零输出）。\n\n- verify 步骤：DOCKER_HOST 显式指向 podman.sock，先做 60 秒限时的 docker-compose/podman compose 连通探针，失败即报错退出。\n- verify-public-ghcr.sh：manager/compose 调用输出 `[verify]` stderr 标记，挂死点可定位。\n\n需要新 Draft（revision 内容变更）。