### PR TITLE
fix(release): single socket owner for delegated podman verification

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -1074,23 +1074,21 @@ jobs:
               exit 1
           fi
           command -v docker-compose
-          # 同一步骤内拉起 podman API service（官方委托合同：DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock）。
-          # 启动前移除可能的 stale socket 文件，保证本 service 是唯一监听者。
-          mkdir -p "${XDG_RUNTIME_DIR}/podman"
-          rm -f "${XDG_RUNTIME_DIR}/podman/podman.sock"
-          nohup podman system service --time=0 "unix://${XDG_RUNTIME_DIR}/podman/podman.sock" \
+          # 本次专属 socket 路径：全新路径无任何历史 owner（systemd unit 或
+          # 旧 service 的 unlink 竞态均不存在），本 service 是唯一监听者。
+          PODMAN_API_SOCK="${RUNNER_TEMP}/podman-api.sock"
+          rm -f "${PODMAN_API_SOCK}"
+          nohup podman system service --time=0 "unix://${PODMAN_API_SOCK}" \
               > "${RUNNER_TEMP}/podman-system-service.log" 2>&1 &
           for attempt in $(seq 1 20); do
-              test -S "${XDG_RUNTIME_DIR}/podman/podman.sock" && break
+              test -S "${PODMAN_API_SOCK}" && break
               sleep 1
           done
-          test -S "${XDG_RUNTIME_DIR}/podman/podman.sock" || { echo "podman.sock 未就绪" >&2; exit 1; }
-          export DOCKER_HOST="unix://${XDG_RUNTIME_DIR}/podman/podman.sock"
+          test -S "${PODMAN_API_SOCK}" || { echo "podman.sock 未就绪" >&2; exit 1; }
+          export DOCKER_HOST="unix://${PODMAN_API_SOCK}"
           # 真连接探针：/_ping 必须在 60 秒内返回 OK（version 不触 daemon，不能作为依据）。
-          timeout 60 curl --silent --show-error --fail --unix-socket "${XDG_RUNTIME_DIR}/podman/podman.sock" "http://d/_ping" \
+          timeout 60 curl --silent --show-error --fail --unix-socket "${PODMAN_API_SOCK}" "http://d/_ping" \
               || { echo "podman service _ping 探针失败" >&2; exit 1; }
-          timeout 60 podman info > /dev/null || { echo "podman info 探针失败" >&2; exit 1; }
-          timeout 60 podman compose version || { echo "podman compose 委托探针失败" >&2; exit 1; }
           manager_version="$(node -p 'require("./packages/neuro-book-manager/package.json").version')"
           candidate_manifest="$PWD/candidate-assets/release-manifest.json"
           # 40 分钟护栏：任何死锁都硬失败并保留现场日志，避免整 job 静默挂到 6 小时。

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -1059,18 +1059,6 @@ jobs:
               echo "隔离失败：podman-compose 不允许存在于 PATH。" >&2
               exit 1
           fi
-          systemctl --user enable --now podman.socket || true
-          # runner 无持久 user systemd 会话时 socket 可能只建文件无监听者，
-          # docker-compose 委托 connect 会永久阻塞；显式拉起 service 并验证 socket。
-          nohup podman system service --time=0 "unix:///run/user/$(id -u)/podman/podman.sock" \
-              > "${RUNNER_TEMP}/podman-system-service.log" 2>&1 &
-          for attempt in $(seq 1 20); do
-              if podman system service --time=0 --help >/dev/null 2>&1 && test -S "/run/user/$(id -u)/podman/podman.sock"; then break; fi
-              sleep 1
-          done
-          test -S "/run/user/$(id -u)/podman/podman.sock" || { echo "podman.sock 未就绪" >&2; exit 1; }
-          podman info
-          podman compose version
           # 持久化 sanitized PATH：逐行写入（每行一个目录条目，不能写整串 PATH=...），
           # 并显式剔除 masked 根前缀，防止任何后续步骤意外纳入。
           printf '%s\n' "$(printf '%s' "$PATH" | tr ':' '\n' | grep -v "^$PODMAN_COMPOSE_MASKED_ROOT")" >> "$GITHUB_PATH"
@@ -1086,10 +1074,22 @@ jobs:
               exit 1
           fi
           command -v docker-compose
-          # 委托通信探针：docker-compose 必须能在 60 秒内连上 podman.sock 完成 version。
-          export DOCKER_HOST="unix:///run/user/$(id -u)/podman/podman.sock"
-          test -S "/run/user/$(id -u)/podman/podman.sock" || { echo "podman.sock 缺失" >&2; exit 1; }
-          timeout 60 docker-compose version || { echo "docker-compose 连 podman.sock 超时/失败" >&2; exit 1; }
+          # 同一步骤内拉起 podman API service（官方委托合同：DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock）。
+          # 启动前移除可能的 stale socket 文件，保证本 service 是唯一监听者。
+          mkdir -p "${XDG_RUNTIME_DIR}/podman"
+          rm -f "${XDG_RUNTIME_DIR}/podman/podman.sock"
+          nohup podman system service --time=0 "unix://${XDG_RUNTIME_DIR}/podman/podman.sock" \
+              > "${RUNNER_TEMP}/podman-system-service.log" 2>&1 &
+          for attempt in $(seq 1 20); do
+              test -S "${XDG_RUNTIME_DIR}/podman/podman.sock" && break
+              sleep 1
+          done
+          test -S "${XDG_RUNTIME_DIR}/podman/podman.sock" || { echo "podman.sock 未就绪" >&2; exit 1; }
+          export DOCKER_HOST="unix://${XDG_RUNTIME_DIR}/podman/podman.sock"
+          # 真连接探针：/_ping 必须在 60 秒内返回 OK（version 不触 daemon，不能作为依据）。
+          timeout 60 curl --silent --show-error --fail --unix-socket "${XDG_RUNTIME_DIR}/podman/podman.sock" "http://d/_ping" \
+              || { echo "podman service _ping 探针失败" >&2; exit 1; }
+          timeout 60 podman info > /dev/null || { echo "podman info 探针失败" >&2; exit 1; }
           timeout 60 podman compose version || { echo "podman compose 委托探针失败" >&2; exit 1; }
           manager_version="$(node -p 'require("./packages/neuro-book-manager/package.json").version')"
           candidate_manifest="$PWD/candidate-assets/release-manifest.json"

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -1089,6 +1089,11 @@ jobs:
           # 真连接探针：/_ping 必须在 60 秒内返回 OK（version 不触 daemon，不能作为依据）。
           timeout 60 curl --silent --show-error --fail --unix-socket "${PODMAN_API_SOCK}" "http://d/_ping" \
               || { echo "podman service _ping 探针失败" >&2; exit 1; }
+          # Compose API 探针：Manager 委托的是 docker-compose 客户端，必须用
+          # 同一客户端对同一 socket 打一次真 API（ps 连 daemon 列项目）。
+          printf 'services: {}\n' > "${RUNNER_TEMP}/podman-api-probe.yaml"
+          timeout 60 docker-compose -f "${RUNNER_TEMP}/podman-api-probe.yaml" ps --all \
+              || { echo "docker-compose 经 podman.sock 的 Compose API 探针失败" >&2; exit 1; }
           manager_version="$(node -p 'require("./packages/neuro-book-manager/package.json").version')"
           candidate_manifest="$PWD/candidate-assets/release-manifest.json"
           # 40 分钟护栏：任何死锁都硬失败并保留现场日志，避免整 job 静默挂到 6 小时。


### PR DESCRIPTION
取证（run [32916292480](https://github.com/notnotype/neuro-book/actions/runs/32916292480)）：探针全绿后 `manager install` 的首个委托 compose 调用静默挂死 40 分钟——上一步拉起的 `podman system service` 在步骤边界被 GHA 杀掉，docker-compose 连接死 socket 永久阻塞；install 步残留的 `systemctl podman.socket` 还会与手工 service 形成 socket 双 owner（unlink 只删路径不杀 listener）。\n\n- install 步：删除 systemctl podman.socket 残留。\n- verify 步：改用本次专属 `${RUNNER_TEMP}/podman-api.sock`（全新路径零历史 owner），service endpoint/`test -S`/`DOCKER_HOST`/curl 统一；`\_ping` 真连接探针。\n\n需要新 Draft。