### PR TITLE
fix(governance): reject linked work paths

### DIFF
--- a/.agents/works/README.md
+++ b/.agents/works/README.md
@@ -18,6 +18,7 @@
 - Task 目录在所属 Work 内使用 `t`、两位非零序号和 kebab-case 名称，例如 `t01-task-title`。
 - Task README 使用 `schema: nbook.task/v2`，`taskId` 与目录一致，并指定唯一正式 `role`：`pm`、`leader`、`tasker` 或 `reviewer`。
 - Task 不保存 `actionIssueId`、`agentWorkflow`、`kind`、`worktreeId` 或 `branchId`。Task 正文可记录目标、范围、产物和验证，供协作参考；治理门禁只校验身份、容器和 role。
+- `.agents`、`.agents/works`、Work、`tasks` 与 Task 五级 current 路径必须由真实目录项组成；symlink/junction 不形成 Work/Task identity，`governance:check` 与 `governance:context` 都明确拒绝。
 
 ## 创建与执行
 

--- a/scripts/ci/agent-governance-contract.ts
+++ b/scripts/ci/agent-governance-contract.ts
@@ -335,6 +335,18 @@ const WORKS_ROOT = ".agents/works";
 const WORK_ID_PATTERN = /^w(?!00000)[0-9]{5}-[a-z0-9]+(?:-[a-z0-9]+)*$/u;
 const WORK_TASK_ID_PATTERN = /^t(?!00)[0-9]{2}-[a-z0-9]+(?:-[a-z0-9]+)*$/u;
 const WORK_ISSUE_ID_PATTERN = /^i[1-9][0-9]*$/u;
+function physicalDirectoryFailure(relativePath: string): string {
+    return `Work/Task 目录项必须是物理目录：${relativePath}`;
+}
+
+function firstNonPhysicalDirectory(repoRoot: string, relativePaths: readonly string[]): string | null {
+    for (const relativePath of relativePaths) {
+        const stats = lstatSync(resolve(repoRoot, relativePath), {throwIfNoEntry: false});
+        if (stats && (!stats.isDirectory() || stats.isSymbolicLink())) return relativePath;
+    }
+    return null;
+}
+
 function packageTaskOwnerRoots(repoRoot: string): string[] {
     const roots = [ROOT_TASK_OWNER_ROOT, APPLICATION_TASK_OWNER_ROOT];
     const packagesRoot = resolve(repoRoot, "packages");
@@ -383,13 +395,28 @@ function validateWorkReadme(repoRoot: string, workId: string, relativePath: stri
 }
 
 function readWorkTaskIds(repoRoot: string, workRoot: string, failures: string[]): string[] | null {
-    const tasksRoot = resolve(repoRoot, workRoot, "tasks");
-    if (!existsSync(tasksRoot) || !lstatSync(tasksRoot).isDirectory()) {
+    const tasksRelativeRoot = `${workRoot}/tasks`;
+    const nonPhysicalPath = firstNonPhysicalDirectory(repoRoot, [tasksRelativeRoot]);
+    if (nonPhysicalPath) {
+        failures.push(physicalDirectoryFailure(nonPhysicalPath));
+        return null;
+    }
+    if (!hasDirectory(repoRoot, tasksRelativeRoot)) {
         failures.push(`Work 缺少 tasks 目录：${workRoot}`);
         return null;
     }
-    const taskIds = readdirSync(tasksRoot, {withFileTypes: true}).filter((entry) => entry.isDirectory()).map((entry) => entry.name);
-    if (taskIds.length === 0) {
+    const taskIds: string[] = [];
+    let hasDeclaredTask = false;
+    for (const entry of readdirSync(resolve(repoRoot, tasksRelativeRoot), {withFileTypes: true})) {
+        if (entry.isDirectory() && !entry.isSymbolicLink()) {
+            taskIds.push(entry.name);
+            hasDeclaredTask = true;
+        } else if (WORK_TASK_ID_PATTERN.test(entry.name)) {
+            failures.push(physicalDirectoryFailure(`${tasksRelativeRoot}/${entry.name}`));
+            hasDeclaredTask = true;
+        }
+    }
+    if (!hasDeclaredTask) {
         failures.push(`Work 必须至少包含一个 Task：${workRoot}`);
         return null;
     }
@@ -416,14 +443,18 @@ function validateWorkTask(repoRoot: string, taskId: string, relativePath: string
 /** 校验当前 Work 容器；Task 正文只作执行参考，不作为机器门禁。 */
 export function verifyWorkContracts(repoRoot: string): string[] {
     const failures: string[] = [];
+    const nonPhysicalRoot = firstNonPhysicalDirectory(repoRoot, [".agents", WORKS_ROOT]);
+    if (nonPhysicalRoot) return [physicalDirectoryFailure(nonPhysicalRoot)];
     const worksRoot = resolve(repoRoot, WORKS_ROOT);
     if (!existsSync(worksRoot)) return failures;
-    if (!lstatSync(worksRoot).isDirectory()) return [`Work 根路径不是目录：${WORKS_ROOT}`];
 
-    const workEntries = readdirSync(worksRoot, {withFileTypes: true}).filter((entry) => entry.isDirectory());
-    for (const workEntry of workEntries) {
+    for (const workEntry of readdirSync(worksRoot, {withFileTypes: true})) {
         const workId = workEntry.name;
         const workRoot = `${WORKS_ROOT}/${workId}`;
+        if (!workEntry.isDirectory() || workEntry.isSymbolicLink()) {
+            if (WORK_ID_PATTERN.test(workId)) failures.push(physicalDirectoryFailure(workRoot));
+            continue;
+        }
         if (!WORK_ID_PATTERN.test(workId)) {
             failures.push(`Work 标识格式无效：${workId}`);
             continue;
@@ -723,6 +754,8 @@ export function resolveWorkReadmePath(repoRoot: string, workId: string): {path: 
         return {path: null, failures};
     }
     const workRoot = `${WORKS_ROOT}/${workId}`;
+    const nonPhysicalPath = firstNonPhysicalDirectory(repoRoot, [".agents", WORKS_ROOT, workRoot]);
+    if (nonPhysicalPath) return {path: null, failures: [physicalDirectoryFailure(nonPhysicalPath)]};
     const relativePath = `${workRoot}/README.md`;
     const path = hasFile(repoRoot, relativePath) ? resolve(repoRoot, relativePath) : null;
     if (!path) {
@@ -742,7 +775,13 @@ export function resolveWorkTaskReadmePath(repoRoot: string, workId: string, task
         failures.push(`Task 标识格式无效：${taskId}`);
         return {workPath: work.path, taskPath: null, taskRole: null, failures};
     }
-    const relativePath = `${WORKS_ROOT}/${workId}/tasks/${taskId}/README.md`;
+    const taskRoot = `${WORKS_ROOT}/${workId}/tasks/${taskId}`;
+    const nonPhysicalPath = firstNonPhysicalDirectory(repoRoot, [taskRoot]);
+    if (nonPhysicalPath) {
+        failures.push(physicalDirectoryFailure(nonPhysicalPath));
+        return {workPath: work.path, taskPath: null, taskRole: null, failures};
+    }
+    const relativePath = `${taskRoot}/README.md`;
     const taskPath = hasFile(repoRoot, relativePath) ? resolve(repoRoot, relativePath) : null;
     if (!taskPath) {
         failures.push(`Task README 不存在：${workId}/${taskId}`);

--- a/scripts/ci/agent-governance-contract.ts
+++ b/scripts/ci/agent-governance-contract.ts
@@ -408,11 +408,14 @@ function readWorkTaskIds(repoRoot: string, workRoot: string, failures: string[])
     const taskIds: string[] = [];
     let hasDeclaredTask = false;
     for (const entry of readdirSync(resolve(repoRoot, tasksRelativeRoot), {withFileTypes: true})) {
-        if (entry.isDirectory() && !entry.isSymbolicLink()) {
-            taskIds.push(entry.name);
+        const taskRoot = `${tasksRelativeRoot}/${entry.name}`;
+        if (WORK_TASK_ID_PATTERN.test(entry.name)) {
             hasDeclaredTask = true;
-        } else if (WORK_TASK_ID_PATTERN.test(entry.name)) {
-            failures.push(physicalDirectoryFailure(`${tasksRelativeRoot}/${entry.name}`));
+            const nonPhysicalTask = firstNonPhysicalDirectory(repoRoot, [taskRoot]);
+            if (nonPhysicalTask) failures.push(physicalDirectoryFailure(nonPhysicalTask));
+            else taskIds.push(entry.name);
+        } else if (entry.isDirectory() && !entry.isSymbolicLink()) {
+            taskIds.push(entry.name);
             hasDeclaredTask = true;
         }
     }
@@ -451,12 +454,14 @@ export function verifyWorkContracts(repoRoot: string): string[] {
     for (const workEntry of readdirSync(worksRoot, {withFileTypes: true})) {
         const workId = workEntry.name;
         const workRoot = `${WORKS_ROOT}/${workId}`;
-        if (!workEntry.isDirectory() || workEntry.isSymbolicLink()) {
-            if (WORK_ID_PATTERN.test(workId)) failures.push(physicalDirectoryFailure(workRoot));
-            continue;
-        }
-        if (!WORK_ID_PATTERN.test(workId)) {
-            failures.push(`Work 标识格式无效：${workId}`);
+        if (WORK_ID_PATTERN.test(workId)) {
+            const nonPhysicalWork = firstNonPhysicalDirectory(repoRoot, [workRoot]);
+            if (nonPhysicalWork) {
+                failures.push(physicalDirectoryFailure(nonPhysicalWork));
+                continue;
+            }
+        } else {
+            if (workEntry.isDirectory() && !workEntry.isSymbolicLink()) failures.push(`Work 标识格式无效：${workId}`);
             continue;
         }
         const readmePath = `${workRoot}/README.md`;

--- a/scripts/ci/agent-governance.test.ts
+++ b/scripts/ci/agent-governance.test.ts
@@ -1,6 +1,6 @@
 import {createHash} from "node:crypto";
 import {execFile as execFileCallback} from "node:child_process";
-import {mkdir, readFile, realpath, rm, writeFile} from "node:fs/promises";
+import {mkdir, readFile, realpath, rm, symlink, writeFile} from "node:fs/promises";
 import {dirname, join} from "node:path";
 import {promisify} from "node:util";
 import {afterEach, describe, expect, it} from "vitest";
@@ -136,6 +136,25 @@ describe("Work 与 Task 当前容器门禁", () => {
         await writeText(repoRoot, ".agents/works/w00001-role/tasks/t01-task/README.md", "---\nschema: nbook.task/v2\ntaskId: t01-task\nrole: developer\n---\n\n# Task\n");
 
         expect(verifyWorkContracts(repoRoot)).toContain("Work Task role 无效：.agents/works/w00001-role/tasks/t01-task/README.md");
+    });
+
+    it.each(["agent-root", "works-root", "work", "tasks-root", "task"] as const)("治理检查拒绝 current 路径 symlink 或 junction：%s", async (kind) => {
+        const fixture = await createLinkedWorkFixture(kind);
+
+        expect(verifyWorkContracts(fixture.root)).toEqual([fixture.failure]);
+    });
+
+    it.each(["agent-root", "works-root", "work", "tasks-root", "task"] as const)("agent-context 拒绝 current 路径 symlink 或 junction：%s", async (kind) => {
+        const fixture = await createLinkedWorkFixture(kind);
+
+        const result = await runAgentContextCli(fixture.taskId, fixture.root, fixture.workId);
+        expect(result.status).not.toBe(0);
+        expect(result.failures).toEqual([fixture.failure]);
+        expect(result.report?.workReadme).toBe(fixture.workReadme);
+        expect(result.report?.taskReadme).toBeNull();
+        expect(result.report?.role).toBeNull();
+        expect(result.report?.taskRole).toBeNull();
+        expect(result.report?.roleContract).toBeNull();
     });
 
     it("旧根中的 v2 Task 由 legacy 校验拒收", async () => {
@@ -2332,6 +2351,7 @@ type AgentContextReport = {
     role?: string | null;
     requestedRole?: string | null;
     taskRole?: string | null;
+    roleContract?: string | null;
 };
 
 async function runAgentContextCli(taskId: string, repoRoot = repositoryRoot, workId?: string, role?: string): Promise<{status: number; failures: string[]; report?: AgentContextReport}> {
@@ -2457,6 +2477,68 @@ async function createLocalOnlyMigrationFixture(): Promise<string> {
     await writeText(root, ".agents/tasks/legacy-index.json", `${JSON.stringify(index)}\n`);
     await writeText(root, ".agents/tasks/.migration-complete", `${JSON.stringify(marker)}\n`);
     return root;
+}
+
+type LinkedWorkKind = "agent-root" | "works-root" | "work" | "tasks-root" | "task";
+
+async function createLinkedWorkFixture(kind: LinkedWorkKind): Promise<{
+    root: string;
+    workId: string;
+    taskId: string;
+    workReadme: string | null;
+    failure: string;
+}> {
+    const root = await createTestTmpRoot(`governance-linked-work-${kind}`, `governance-linked-work-${kind}-test`);
+    const externalRoot = await createTestTmpRoot(`governance-linked-work-${kind}-external`, `governance-linked-work-${kind}-external-test`);
+    fixtureRoots.push(root, externalRoot);
+    const workId = "w00001-linked-work";
+    const linkedTaskId = "t01-linked";
+    const realTaskId = "t02-real";
+    const workRoot = `.agents/works/${workId}`;
+    const externalWorkRoot = join(externalRoot, workRoot);
+    const workReadme = `---\nschema: nbook.work/v1\nworkId: ${workId}\nissueId: null\n---\n\n# Linked Work\n`;
+    const linkedTaskReadme = `---\nschema: nbook.task/v2\ntaskId: ${linkedTaskId}\nrole: tasker\n---\n\n# Linked Task\n`;
+    const realTaskReadme = `---\nschema: nbook.task/v2\ntaskId: ${realTaskId}\nrole: tasker\n---\n\n# Real Task\n`;
+    await writeText(externalRoot, `${workRoot}/README.md`, workReadme);
+    await writeText(externalRoot, `${workRoot}/tasks/${linkedTaskId}/README.md`, linkedTaskReadme);
+    await writeText(externalRoot, `${workRoot}/tasks/${realTaskId}/README.md`, realTaskReadme);
+    await writeText(root, "README.md", "# Fixture\n");
+
+    if (kind === "works-root") await writeText(root, ".agents/.keep", "\n");
+    if (kind === "work") await writeText(root, ".agents/works/.keep", "\n");
+    if (kind === "tasks-root" || kind === "task") await writeText(root, `${workRoot}/README.md`, workReadme);
+    if (kind === "task") await writeText(root, `${workRoot}/tasks/${realTaskId}/README.md`, realTaskReadme);
+    await initializeGitFixture(root);
+
+    const linkType = process.platform === "win32" ? "junction" : "dir";
+    const link = async (target: string, relativePath: string): Promise<void> => {
+        await symlink(target, join(root, relativePath), linkType);
+    };
+    let linkedPath: string;
+    if (kind === "agent-root") {
+        linkedPath = ".agents";
+        await link(join(externalRoot, ".agents"), linkedPath);
+    } else if (kind === "works-root") {
+        linkedPath = ".agents/works";
+        await link(join(externalRoot, ".agents/works"), linkedPath);
+    } else if (kind === "work") {
+        linkedPath = workRoot;
+        await link(externalWorkRoot, linkedPath);
+    } else if (kind === "tasks-root") {
+        linkedPath = `${workRoot}/tasks`;
+        await link(join(externalWorkRoot, "tasks"), linkedPath);
+    } else {
+        linkedPath = `${workRoot}/tasks/${linkedTaskId}`;
+        await link(join(externalWorkRoot, "tasks", linkedTaskId), linkedPath);
+    }
+
+    return {
+        root,
+        workId,
+        taskId: kind === "task" ? realTaskId : linkedTaskId,
+        workReadme: kind === "tasks-root" || kind === "task" ? join(root, workRoot, "README.md") : null,
+        failure: `Work/Task 目录项必须是物理目录：${linkedPath}`,
+    };
 }
 
 function hashBytes(bytes: Uint8Array): string {


### PR DESCRIPTION
## 问题

独立审查发现 P2：current Work/Task 的显式 resolver 会沿父目录 symlink/junction 读取仓库外但形状合法的 README，而全仓治理扫描会静默跳过同一目录项，导致 provenance 与 containment 不一致。

## 修复

- 对 `.agents`、`.agents/works`、Work、`tasks`、Task 五级 current 路径统一执行同步物理目录检查
- `verifyWorkContracts()` 与 `governance:context` 共用同一失败合同：`Work/Task 目录项必须是物理目录：<path>`
- Work/Task 子项枚举只用 `Dirent` 发现名称；每个合法 ID 候选都对精确路径执行 `lstat`，不依赖 Windows junction 的 `Dirent` 分类
- symlink/junction 不作为 Work/Task identity；不使用 realpath alias，不增加 schema、索引、状态机或新 CLI
- 五级 Windows junction / POSIX directory symlink 真实 fixture 覆盖全仓检查与 CLI；Task case 证明链接 sibling 会阻断整个 Work

## 验证

- RED：新增聚焦回归实现前 `10 failed`
- GREEN：聚焦回归 `10/10` 通过
- blocker 补充后聚焦回归再次 `10/10` 通过
- 完整治理测试：`159/159` 通过，无新增 skip
- `bun x tsc --noEmit -p scripts/tsconfig.json`：0 errors
- `bun run governance:check`：`failures: []`、`warnings: []`
- `bun run docs:check`：`checkedFiles: 5302`、`failures: []`
- `git diff --check`：退出 0
- Issue #193 与 #191 两个真实 `governance:context` smoke 均退出 0，返回 worktree 内 README、canonical `tasker` role 与空 failures

Reviewer 本身只读审查、未运行测试；以上均为修复后实际执行证据。

## 边界

本修复覆盖 Node `lstat` 可识别的 POSIX directory symlink、dangling symlink 与 Windows directory junction；不宣称检测所有 Windows 通用 reparse 类型。