### PR TITLE
Fix/tui blessed runtime assets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -372,6 +372,7 @@
         "neuro-book": "dist/neuro-book.mjs",
       },
       "dependencies": {
+        "blessed": "^0.1.81",
         "proper-lockfile": "^4.1.2",
         "semver": "^7.8.5",
         "yaml": "^2.8.2",
@@ -385,7 +386,6 @@
         "@types/bun": "^1.3.14",
         "@types/node": "^25.6.0",
         "@types/semver": "^7.7.1",
-        "blessed": "^0.1.81",
         "commander": "^14.0.2",
         "fflate": "^0.8.3",
         "typebox": "^1.1.38",

--- a/packages/neuro-book-manager/package.json
+++ b/packages/neuro-book-manager/package.json
@@ -64,7 +64,6 @@
         "@types/bun": "^1.3.14",
         "@types/node": "^25.6.0",
         "@types/semver": "^7.7.1",
-        "blessed": "^0.1.81",
         "commander": "^14.0.2",
         "fflate": "^0.8.3",
         "typebox": "^1.1.38",
@@ -76,6 +75,7 @@
         "access": "public"
     },
     "dependencies": {
+        "blessed": "^0.1.81",
         "proper-lockfile": "^4.1.2",
         "semver": "^7.8.5",
         "yaml": "^2.8.2"

--- a/packages/neuro-book-manager/scripts/build.mjs
+++ b/packages/neuro-book-manager/scripts/build.mjs
@@ -1,33 +1,112 @@
-import {copyFile, mkdir, rm} from "node:fs/promises";
-import {resolve} from "node:path";
+import {copyFile, mkdir, readFile, rm} from "node:fs/promises";
+import {createRequire} from "node:module";
+import {dirname, resolve} from "node:path";
 
 const packageRoot = resolve(import.meta.dir, "..");
 const outdir = resolve(packageRoot, "dist");
+export const blessedTerminfoNames = ["linux", "windows-ansi", "xterm", "xterm-256color"];
 
-await rm(outdir, {recursive: true, force: true});
-await mkdir(outdir, {recursive: true});
-const result = await Bun.build({
-    entrypoints: [
-        resolve(packageRoot, "src", "neuro-book.ts"),
-        resolve(packageRoot, "src", "schema.ts"),
-        resolve(packageRoot, "src", "runtime-projection.ts"),
-        resolve(packageRoot, "src", "desktop-installation-entry.ts"),
-        resolve(packageRoot, "src", "desktop-uac-client-entry.ts"),
-        resolve(packageRoot, "src", "product-runtime-verifier-entry.ts"),
-        resolve(packageRoot, "src", "installation-entry.ts"),
-        resolve(packageRoot, "src", "portable.ts"),
-    ],
-    outdir,
-    target: "bun",
-    format: "esm",
-    naming: "[name].mjs",
-    external: ["blessed", "yaml", "semver"],
-    minify: true,
-});
-if (!result.success) {
-    for (const log of result.logs) {
-        console.error(log);
-    }
-    process.exit(1);
+export async function createBlessedRuntimePlugin(packageJsonPath) {
+    const requireFromPackage = createRequire(packageJsonPath);
+    const blessedPackageRoot = dirname(requireFromPackage.resolve("blessed/package.json"));
+    const blessedTputPath = requireFromPackage.resolve("blessed/lib/tput.js");
+    const blessedTerminfoBase64 = Object.fromEntries(await Promise.all(blessedTerminfoNames.map(async (name) => [
+        name,
+        (await readFile(resolve(blessedPackageRoot, "usr", name))).toString("base64"),
+    ])));
+    const blessedTerminfoSource = `Tput.prototype._useVt102Cap = function() {
+  return this.injectTermcap('vt102');
+};
+
+Tput.prototype._useXtermCap = function() {
+  return this.injectTermcap(__dirname + '/../usr/xterm.termcap');
+};
+
+Tput.prototype._useXtermInfo = function() {
+  return this.injectTerminfo(__dirname + '/../usr/xterm');
+};
+
+Tput.prototype._useInternalInfo = function(name) {
+  name = path.basename(name);
+  return this.injectTerminfo(__dirname + '/../usr/' + name);
+};
+
+Tput.prototype._useInternalCap = function(name) {
+  name = path.basename(name);
+  return this.injectTermcap(__dirname + '/../usr/' + name + '.termcap');
+};`;
+    const blessedTerminfoReplacement = `const embeddedTerminfo = Object.fromEntries(Object.entries(${JSON.stringify(blessedTerminfoBase64)})
+  .map(function(entry) { return [entry[0], Buffer.from(entry[1], "base64")]; }));
+
+Tput.prototype._useVt102Cap = function() {
+  return this.injectTermcap("vt102");
+};
+
+Tput.prototype._useXtermCap = function() {
+  return this._useXtermInfo();
+};
+
+Tput.prototype._useXtermInfo = function() {
+  return this._useInternalInfo("xterm");
+};
+
+Tput.prototype._useInternalInfo = function(name) {
+  name = path.basename(name);
+  if (!embeddedTerminfo[name]) throw new Error("Embedded terminfo not found: " + name);
+  return this.inject(this.compile(this.parseTerminfo(embeddedTerminfo[name], name)));
+};
+
+Tput.prototype._useInternalCap = function(name) {
+  throw new Error("Embedded termcap not found: " + path.basename(name));
+};`;
+    return {
+        name: "manager-blessed-runtime-assets",
+        setup(build) {
+            build.onLoad({filter: /[\\/]blessed[\\/]lib[\\/]tput\.js$/u}, async (args) => {
+                if (resolve(args.path) !== resolve(blessedTputPath)) return undefined;
+                const source = await readFile(args.path, "utf8");
+                const first = source.indexOf(blessedTerminfoSource);
+                if (first < 0 || source.indexOf(blessedTerminfoSource, first + 1) >= 0) {
+                    throw new Error("blessed terminfo fallback源码与Manager构建合同不一致。");
+                }
+                return {
+                    contents: source.replace(blessedTerminfoSource, blessedTerminfoReplacement),
+                    loader: "js",
+                };
+            });
+        },
+    };
 }
-await copyFile(resolve(packageRoot, "..", "..", "LICENSE"), resolve(outdir, "LICENSE"));
+
+export async function buildManager() {
+    await rm(outdir, {recursive: true, force: true});
+    await mkdir(outdir, {recursive: true});
+    const result = await Bun.build({
+        entrypoints: [
+            resolve(packageRoot, "src", "neuro-book.ts"),
+            resolve(packageRoot, "src", "schema.ts"),
+            resolve(packageRoot, "src", "runtime-projection.ts"),
+            resolve(packageRoot, "src", "desktop-installation-entry.ts"),
+            resolve(packageRoot, "src", "desktop-uac-client-entry.ts"),
+            resolve(packageRoot, "src", "product-runtime-verifier-entry.ts"),
+            resolve(packageRoot, "src", "installation-entry.ts"),
+            resolve(packageRoot, "src", "portable.ts"),
+        ],
+        outdir,
+        target: "bun",
+        format: "esm",
+        naming: "[name].mjs",
+        plugins: [await createBlessedRuntimePlugin(resolve(packageRoot, "package.json"))],
+        external: ["yaml", "semver"],
+        minify: true,
+    });
+    if (!result.success) {
+        for (const log of result.logs) {
+            console.error(log);
+        }
+        process.exit(1);
+    }
+    await copyFile(resolve(packageRoot, "..", "..", "LICENSE"), resolve(outdir, "LICENSE"));
+}
+
+if (import.meta.main) await buildManager();

--- a/packages/neuro-book-manager/scripts/build.mjs
+++ b/packages/neuro-book-manager/scripts/build.mjs
@@ -21,7 +21,7 @@ const result = await Bun.build({
     target: "bun",
     format: "esm",
     naming: "[name].mjs",
-    external: ["yaml", "semver"],
+    external: ["blessed", "yaml", "semver"],
     minify: true,
 });
 if (!result.success) {

--- a/packages/neuro-book-manager/scripts/pack-check.mjs
+++ b/packages/neuro-book-manager/scripts/pack-check.mjs
@@ -1,9 +1,11 @@
-import {mkdir, mkdtemp, readFile, readdir, rm, writeFile} from "node:fs/promises";
+import {cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile} from "node:fs/promises";
 import {dirname, isAbsolute, join, relative, resolve, sep} from "node:path";
-import {pathToFileURL} from "node:url";
+import {createRequire} from "node:module";
 import {resolveAgentCacheRoot} from "@notnotype/neuro-book-test-support/paths";
+import {blessedTerminfoNames, createBlessedRuntimePlugin} from "./build.mjs";
 
 const packageRoot = resolve(import.meta.dir, "..");
+const repositoryRoot = resolve(packageRoot, "..", "..");
 // 仅使用系统受控 cache；pack 产物可回收，不污染仓库 `.agent/tmp`。
 const managedTmpRoot = resolveAgentCacheRoot("manager-pack");
 await mkdir(managedTmpRoot, {recursive: true});
@@ -39,35 +41,49 @@ try {
         .scanImports(managerSource)
         .filter((record) => record.kind === "import-statement")
         .map((record) => record.path);
-    const blessedWidgetImports = ["box", "list", "prompt", "question", "screen"]
-        .map((widget) => `blessed/lib/widgets/${widget}.js`);
-    for (const widgetImport of blessedWidgetImports) {
-        if (!managerImports.includes(widgetImport)) {
-            throw new Error(`packed Manager必须从安装依赖加载静态widget：${widgetImport}`);
+    const blessedWidgetImports = managerImports.filter((specifier) => specifier === "blessed" || specifier.startsWith("blessed/"));
+    if (blessedWidgetImports.length > 0) {
+        throw new Error(`packed Manager必须内联blessed运行时：${blessedWidgetImports.join(", ")}`);
+    }
+    const requireFromInstalledManager = createRequire(join(installedPackageRoot, "package.json"));
+    const blessedPackage = requireFromInstalledManager.resolve("blessed/package.json");
+    const blessedRoot = dirname(blessedPackage);
+    for (const moduleId of ["blessed/lib/tput.js", "blessed/lib/widgets/screen.js"]) {
+        const modulePath = requireFromInstalledManager.resolve(moduleId);
+        if (!isPathInside(blessedRoot, modulePath)) {
+            throw new Error(`${moduleId}未从已安装blessed依赖解析：${modulePath}`);
         }
     }
-    const blessedScreen = await Bun.resolve("blessed/lib/widgets/screen.js", installedPackageRoot);
-    const blessedPackage = await Bun.resolve("blessed/package.json", installedPackageRoot);
-    const blessedRoot = dirname(blessedPackage);
-    if (!isPathInside(blessedRoot, blessedScreen)) {
-        throw new Error(`blessed screen未从已安装依赖解析：${blessedScreen}`);
+    const blessedAssets = blessedTerminfoNames;
+    for (const asset of blessedAssets) {
+        const base64 = (await readFile(join(blessedRoot, "usr", asset))).toString("base64");
+        if (!managerSource.includes(base64)) {
+            throw new Error(`packed Manager缺少内嵌blessed资源：${asset}`);
+        }
     }
-    await readFile(join(blessedRoot, "usr", "xterm"));
-    const blessedSmoke = join(temporaryRoot, "blessed-smoke.mjs");
-    await writeFile(blessedSmoke, `
-import {PassThrough} from "node:stream";
-import Screen from ${JSON.stringify(pathToFileURL(blessedScreen).href)};
-
-const input = new PassThrough();
-const output = new PassThrough();
-Object.assign(output, {columns: 80, rows: 24});
-const screen = new Screen({input, output, terminal: "neuro-book-missing-terminfo"});
-if (screen.tput.terminal !== "xterm") {
-    throw new Error("blessed did not load its packaged xterm fallback");
-}
-screen.destroy();
-`, "utf8");
-    await run(["bun", blessedSmoke], temporaryRoot);
+    for (const buildPath of [repositoryRoot, blessedRoot]) {
+        if (containsPath(managerSource, buildPath)) {
+            throw new Error(`packed Manager包含构建机绝对路径：${buildPath}`);
+        }
+    }
+    await verifyBlessedRuntime(temporaryRoot, installedPackageRoot);
+    const standaloneRoot = await mkdtemp(join(managedTmpRoot, "standalone-"));
+    try {
+        const standaloneNodeModules = join(standaloneRoot, "node_modules");
+        await mkdir(standaloneNodeModules, {recursive: true});
+        for (const dependency of ["semver", "yaml"]) {
+            const dependencyPackage = requireFromInstalledManager.resolve(`${dependency}/package.json`);
+            await cp(dirname(dependencyPackage), join(standaloneNodeModules, dependency), {recursive: true});
+        }
+        const standaloneManager = join(standaloneRoot, "neuro-book.mjs");
+        await cp(managerEntry, standaloneManager);
+        const standaloneVersion = await runCapture(["bun", "--no-install", "--no-env-file", standaloneManager, "--version"], standaloneRoot);
+        if (standaloneVersion.trim() !== packageJson.version) {
+            throw new Error(`单文件Manager --version输出错误：${standaloneVersion.trim()}`);
+        }
+    } finally {
+        await rm(standaloneRoot, {recursive: true, force: true});
+    }
     const managerVersion = await runCapture([
         "bun",
         managerEntry,
@@ -143,6 +159,63 @@ async function runCapture(command, cwd, env = process.env) {
     ]);
     if (exitCode !== 0) throw new Error(`${command.join(" ")} 退出码 ${exitCode}：${stderr || stdout}`);
     return stdout;
+}
+
+async function verifyBlessedRuntime(temporaryRoot, installedPackageRoot) {
+    const entrypoint = join(temporaryRoot, "blessed-runtime-check.mjs");
+    const outfile = join(temporaryRoot, "blessed-runtime-check.bundle.mjs");
+    await writeFile(entrypoint, `import {PassThrough} from "node:stream";
+import Tput from "blessed/lib/tput.js";
+import Screen from "blessed/lib/widgets/screen.js";
+
+const missingTerminfo = process.platform === "win32" ? "Z:/neuro-book-missing/terminfo" : "/neuro-book-missing/terminfo";
+const expected = new Map([
+    ["linux", "linux"],
+    ["windows-ansi", "ansi"],
+    ["xterm", "xterm"],
+    ["xterm-256color", "xterm-256color"],
+]);
+for (const [terminal, canonical] of expected) {
+    const tput = new Tput({terminal, terminfoFile: missingTerminfo});
+    if (tput.terminal !== canonical || tput.info.name !== canonical) {
+        throw new Error(terminal + " resolved as " + tput.terminal + ":" + tput.info.name);
+    }
+}
+const termcap = new Tput({terminal: "xterm-256color", terminfoFile: missingTerminfo, termcap: true});
+if (termcap.terminal !== "xterm" || termcap.info.name !== "xterm") {
+    throw new Error("termcap fallback resolved as " + termcap.terminal + ":" + termcap.info.name);
+}
+const input = new PassThrough();
+const output = new PassThrough();
+Object.assign(output, {columns: 80, rows: 24});
+const screen = new Screen({input, output, terminal: "neuro-book-missing-terminfo"});
+try {
+    if (screen.tput.terminal !== "xterm" || screen.tput.info.name !== "xterm") {
+        throw new Error("Screen fallback resolved as " + screen.tput.terminal + ":" + screen.tput.info.name);
+    }
+} finally {
+    screen.destroy();
+}
+`, "utf8");
+    const result = await Bun.build({
+        entrypoints: [entrypoint],
+        outdir: temporaryRoot,
+        naming: "blessed-runtime-check.bundle.mjs",
+        target: "bun",
+        format: "esm",
+        minify: true,
+        plugins: [await createBlessedRuntimePlugin(join(installedPackageRoot, "package.json"))],
+    });
+    if (!result.success) {
+        throw new Error(`blessed runtime smoke构建失败：${result.logs.map(String).join("\n")}`);
+    }
+    await run(["bun", "--no-install", "--no-env-file", outfile], temporaryRoot);
+}
+
+function containsPath(source, path) {
+    const normalized = path.replaceAll("\\", "/");
+    const escaped = JSON.stringify(path).slice(1, -1);
+    return source.includes(path) || source.includes(normalized) || source.includes(escaped);
 }
 
 function isPathInside(parent, child) {

--- a/packages/neuro-book-manager/scripts/pack-check.mjs
+++ b/packages/neuro-book-manager/scripts/pack-check.mjs
@@ -1,5 +1,6 @@
 import {mkdir, mkdtemp, readFile, readdir, rm, writeFile} from "node:fs/promises";
-import {join, resolve} from "node:path";
+import {dirname, isAbsolute, join, relative, resolve, sep} from "node:path";
+import {pathToFileURL} from "node:url";
 import {resolveAgentCacheRoot} from "@notnotype/neuro-book-test-support/paths";
 
 const packageRoot = resolve(import.meta.dir, "..");
@@ -15,7 +16,8 @@ try {
     const archive = join(temporaryRoot, archiveName);
     await writeFile(join(temporaryRoot, "package.json"), "{\"private\":true}\n", "utf8");
     await run(["bun", "add", archive, "--cwd", temporaryRoot], temporaryRoot);
-    const packageJson = JSON.parse(await readFile(join(temporaryRoot, "node_modules", "@notnotype", "neuro-book-manager", "package.json"), "utf8"));
+    const installedPackageRoot = join(temporaryRoot, "node_modules", "@notnotype", "neuro-book-manager");
+    const packageJson = JSON.parse(await readFile(join(installedPackageRoot, "package.json"), "utf8"));
     const forbidden = ["nuxt", "vue", "prisma", "@tiptap/core"];
     for (const name of forbidden) {
         if (packageJson.dependencies?.[name] || packageJson.devDependencies?.[name]) {
@@ -28,9 +30,47 @@ try {
     if (packageJson.dependencies?.["@notnotype/neuro-book-contracts"]) {
         throw new Error("Manager npm包不应携带私有Contracts production dependency；实现必须内联进单文件bundle。");
     }
+    if (!packageJson.dependencies?.blessed) {
+        throw new Error("Manager npm包必须声明blessed runtime dependency。");
+    }
+    const managerEntry = join(installedPackageRoot, "dist", "neuro-book.mjs");
+    const managerSource = (await readFile(managerEntry, "utf8")).replace(/^#![^\n]*\n/u, "");
+    const managerImports = new Bun.Transpiler({loader: "js"})
+        .scanImports(managerSource)
+        .filter((record) => record.kind === "import-statement")
+        .map((record) => record.path);
+    const blessedWidgetImports = ["box", "list", "prompt", "question", "screen"]
+        .map((widget) => `blessed/lib/widgets/${widget}.js`);
+    for (const widgetImport of blessedWidgetImports) {
+        if (!managerImports.includes(widgetImport)) {
+            throw new Error(`packed Manager必须从安装依赖加载静态widget：${widgetImport}`);
+        }
+    }
+    const blessedScreen = await Bun.resolve("blessed/lib/widgets/screen.js", installedPackageRoot);
+    const blessedPackage = await Bun.resolve("blessed/package.json", installedPackageRoot);
+    const blessedRoot = dirname(blessedPackage);
+    if (!isPathInside(blessedRoot, blessedScreen)) {
+        throw new Error(`blessed screen未从已安装依赖解析：${blessedScreen}`);
+    }
+    await readFile(join(blessedRoot, "usr", "xterm"));
+    const blessedSmoke = join(temporaryRoot, "blessed-smoke.mjs");
+    await writeFile(blessedSmoke, `
+import {PassThrough} from "node:stream";
+import Screen from ${JSON.stringify(pathToFileURL(blessedScreen).href)};
+
+const input = new PassThrough();
+const output = new PassThrough();
+Object.assign(output, {columns: 80, rows: 24});
+const screen = new Screen({input, output, terminal: "neuro-book-missing-terminfo"});
+if (screen.tput.terminal !== "xterm") {
+    throw new Error("blessed did not load its packaged xterm fallback");
+}
+screen.destroy();
+`, "utf8");
+    await run(["bun", blessedSmoke], temporaryRoot);
     const managerVersion = await runCapture([
         "bun",
-        join(temporaryRoot, "node_modules", "@notnotype", "neuro-book-manager", "dist", "neuro-book.mjs"),
+        managerEntry,
         "--version",
     ], temporaryRoot);
     if (managerVersion.trim() !== packageJson.version) {
@@ -103,4 +143,9 @@ async function runCapture(command, cwd, env = process.env) {
     ]);
     if (exitCode !== 0) throw new Error(`${command.join(" ")} 退出码 ${exitCode}：${stderr || stdout}`);
     return stdout;
+}
+
+function isPathInside(parent, child) {
+    const remainder = relative(parent, child);
+    return remainder === "" || !isAbsolute(remainder) && remainder !== ".." && !remainder.startsWith(`..${sep}`);
 }


### PR DESCRIPTION
### 关联Issues|Related issue
#223 
### 解决的问题 / Problem
通过 bunx --bun @notnotype/neuro-book-manager@canary 安装的 Manager 在打开 neuro-book manage 实例管理 TUI 时，Blessed 会尝试读取发布构建机上的绝对路径：
/home/runner/work/neuro-book/neuro-book/node_modules/blessed/usr/xterm
该路径在用户环境不存在，导致 ENOENT；随后 Blessed 初始化不完整，又出现 this.program.isAlt 的次生异常。
### 本次范围 / Scope
包含 / In scope:
- 将 blessed 从 Manager 开发依赖改为运行时依赖。
- 让 Bun 构建将 blessed 保持为外部依赖，而非内联进单文件 bundle。
- 在真实 npm tarball 安装边界验证 Blessed widget import、usr/xterm 资源及 Screen 的 xterm fallback。
不包含 / Out of scope:
- 不修改 Blessed 源码、内部路径解析或 TUI 功能。
- 不修改 Manager CLI 参数、安装流程、实例数据或用户状态。
- 不发布新的 canary 版本、不修改版本号或 RELEASE.md。
- 不修改其他未跟踪的 Agent 文档文件。
用户可见结果与实现 / User-visible result and implementation
用户在包含本修复的新 Manager canary 发布后，可通过：
bunx --bun @notnotype/neuro-book-manager@canary manage
正常打开实例管理 TUI，不再依赖 GitHub Actions 构建机上的 Blessed terminfo 路径。
实现上，Manager bundle 保留对 blessed/lib/widgets/*.js 的外部 ESM import；npm 安装时会安装真实的 blessed 包，因此其运行时 terminfo 资源从安装目录的 node_modules/blessed/usr/xterm 解析。pack:check 现在会在全新 tarball 安装目录中验证该发布合同。
### 验证 / Verification
实际执行的完整命令和结果 / Exact commands and results:
bun install --frozen-lockfile --linker hoisted
PASS
- 安装锁定依赖并执行 neuro-agent-harness build。

bun run --cwd packages/neuro-book-manager typecheck
PASS
- TypeScript 无错误。

bun run --cwd packages/neuro-book-manager test
PASS
- Test Files: 40 passed | 2 skipped
- Tests: 311 passed | 28 skipped

bun run --cwd packages/neuro-book-manager pack:check
PASS
- 构建 Manager。
- 创建 npm tarball。
- 在受控临时目录安装 tarball。
- 验证 blessed 为 runtime dependency。
- 验证五个 Blessed widget 保持外部 import。
- 验证已安装 blessed/usr/xterm 存在。
- 使用不存在的终端类型创建并销毁真实 Blessed Screen，确认回退到 packaged xterm。
- 通过既有 CLI 打包 smoke。

git diff --check
PASS
未运行的检查及原因 / Checks not run and why:
- 未运行真实 bunx --bun @notnotype/neuro-book-manager@canary manage：修复尚未发布为新的 canary；pack:check 已在真实 tarball 安装目录覆盖同一 Blessed 资源解析与 Screen 初始化路径。
- 未运行浏览器验证：本 PR 只涉及终端 TUI 的发布依赖与打包合同。
- 未运行完整 monorepo 测试：改动限定在 Manager 的打包与发布边界，已运行该包完整测试和 pack gate。
### 界面证据 / UI evidence
未提供截图或录屏。本 PR 不修改浏览器界面；终端 TUI 的关键初始化路径已由真实 tarball 安装后的 Blessed Screen smoke 覆盖。由于新 canary 尚未发布，未对公网 bunx 包执行人工 TUI 验收。
### 文档与记录 / Documentation and records
- 已更新或确认不需要更新用户文档 / User documentation updated or not needed  
不需要：用户命令和操作方式不变，仅修复已发布包的资源解析。
- 已更新或确认不需要更新 Task walkthrough / Task walkthrough updated or not needed  
不需要：本次为独立、聚焦的发布打包修复，PR 记录和验证输出足以说明变更。
- 已更新或确认不需要更新 Reference、ADR 与 PROJECT-STATUS.md / Reference, ADR, and PROJECT-STATUS.md updated or not needed  
不需要：不改变长期架构决策、运行期 Reference 或项目状态。
- 已链接受影响的具体 Spec 和 capability，或说明本 PR 为什么不改变行为合同 / Affected Spec and capability linked, or rationale provided for no behavior-contract change  
不需要更新产品 Spec：不改变产品能力、数据、接口或用户流程合同；仅修复 Manager npm 发布物对第三方运行时资源的解析。
- 本 PR 不修改版本号或 RELEASE.md，除非维护者明确要求 / This PR does not change the version or RELEASE.md unless requested by a maintainer
### 风险与边界 / Risks and boundaries
- 数据结构或迁移 / Data shape or migration: 无。未修改 Manifest、Operation Journal、实例配置或用户数据。
- 配置、安装或发布 / Configuration, installation, or release: Manager npm 包会新增一个正式运行时依赖 blessed。这是修复 TUI 所需资源可用性的预期发布载荷变化；tarball 安装检查覆盖该依赖和 usr/xterm 文件。
- 安全与隐私 / Security and privacy: 无新增网络权限、凭据读取、用户数据访问或日志内容。
- 已知限制与后续事项 / Known limitations and follow-ups: 当前已发布的 canary 不会自动修复；需在维护者发布包含本 PR 的新 canary 后，使用 bunx ...@canary manage 做最终用户环境确认。
提交者确认 / Contributor confirmation
- 一个连贯目标之外没有夹带其它改动 / This PR contains no unrelated changes outside one coherent goal
- 我已审查并能解释全部改动，包括开发 Agent 生成的内容 / I reviewed and can explain every change, including coding-agent output
- 验证结果真实，聚焦测试没有被描述成全量测试 / Verification is accurate and focused tests are not presented as the full suite
- 日志、截图和 fixture 不含密钥、小说正文、私人会话或未授权内容 / Logs, screenshots, and fixtures contain no secrets, manuscripts, private sessions, or unlicensed material