### PR TITLE
fix: isolate Product Runtime from broken stdio

### DIFF
--- a/.agents/works/w00012-issue-228-product-runtime-stdio-epipe/README.md
+++ b/.agents/works/w00012-issue-228-product-runtime-stdio-epipe/README.md
@@ -1,0 +1,23 @@
+---
+schema: nbook.work/v1
+workId: w00012-issue-228-product-runtime-stdio-epipe
+issueId: i228
+---
+
+# Issue 228 Product Runtime stdio 断管防护
+
+修复 Product Runtime 在父 shell 或 supervisor 关闭 stdout/stderr 后因 consola、console 或 launcher stdio 写入触发 EPIPE，导致 Product 退出并连带 World Engine 请求失败的问题。保留 State Root JSONL 日志、HTTP 服务、shutdown 与 acceptance lease 生命周期；不修改 World Engine schema/slices、esbuild 或 proper-lockfile 算法。
+
+## 交付边界
+
+- 生产日志 reporter 不依赖不稳定的外部 stdout/stderr，日志主出口为 State Root JSONL。
+- `console.warn/error`、`AppFileLogger.write()` 与 `fatalSync()` 的日志失败不递归、不把 EPIPE 变成业务进程退出。
+- Product launcher、command wrapper 和 acceptance runner 使用明确的受控 stdio 生命周期，保留 SIGINT/SIGTERM 转发。
+- 增加 Windows/Bun Product 回归，覆盖父输出管道关闭后的 `/api/app/version`、World Engine API、shutdown、lease release/reacquire 与竞争 `ELOCKED`。
+
+## 非目标
+
+- 不修改 World Engine schema/slices 业务逻辑。
+- 不升级或替换 esbuild。
+- 不修改 `proper-lockfile` 算法、`stale`/`update` 参数或 exFAT 租约判定。
+- 不调用真实 Provider/Model，不执行远端 Issue/Project/PR 写入、push、合并、发布或部署。

--- a/.agents/works/w00012-issue-228-product-runtime-stdio-epipe/tasks/t01-product-runtime-stdio-epipe/README.md
+++ b/.agents/works/w00012-issue-228-product-runtime-stdio-epipe/tasks/t01-product-runtime-stdio-epipe/README.md
@@ -1,0 +1,26 @@
+---
+schema: nbook.task/v2
+taskId: t01-product-runtime-stdio-epipe
+role: tasker
+---
+
+# 修复 Product Runtime stdio 断管
+
+## 目标
+
+修复 Issue #228：当 Product 父进程的 stdout/stderr 被关闭、替换或断开时，Product 继续监听并提供 API；日志写入失败不得递归写管道或让业务进程退出。
+
+## 修改范围
+
+1. 沿用现有 `AppFileLogger` 和 State Root JSONL 所有权，补齐 async/sync 写失败与 EPIPE 处理，并保证 `consola` reporter、`console.warn/error` 和异常监听不把日志错误重新抛回业务路径。
+2. 调整 Product start command、product command wrapper 和 acceptance runner 的 child stdio 与信号生命周期；统一从显式环境解析绝对 Application/State/Cache 根，不改变已有启动命令和退出合同。
+3. 在现有 Product/Bun/Windows 测试入口增加真实子进程回归：断开父输出后 `/api/app/version`、World Engine `schema`/`slices`、shutdown、lease release/reacquire 和第二实例 `ELOCKED`。
+4. 不旁路 Runtime Image verifier，不修改 World Engine 领域逻辑、esbuild、proper-lockfile 算法或真实 Provider/Model。
+
+## 验证
+
+由 Leader 先运行新增复现使其在旧实现失败，再运行日志/launcher 聚焦测试、Product rebuild、Windows Portable smoke 和受影响完整测试；所有临时根使用测试支持包或系统 Temp，并记录未能在当前环境执行的门禁。
+
+## 边界
+
+不执行远端 Issue/Project/PR 写入、push、合并、发布、部署、浏览器人工验收、真实 Provider/Model 或数据删除。实现阶段跳过格式化、lint、全量测试和构建，由 Leader 统一验证。

--- a/packages/neuro-book/server/app-logs/logger.test.ts
+++ b/packages/neuro-book/server/app-logs/logger.test.ts
@@ -10,7 +10,8 @@ import {
     sanitizeAppLogValue,
     serializeAppLogError,
 } from "nbook/server/app-logs/logger";
-import { testHostPath } from "@notnotype/neuro-book-test-support/test-path";
+import {testHostPath} from "@notnotype/neuro-book-test-support/test-path";
+import {afterEach, describe, expect, it, vi} from "vitest";
 
 const cleanupRoots: string[] = [];
 
@@ -134,6 +135,25 @@ describe("app logs logger", () => {
             event: "process.uncaughtException",
         });
         expect(entry.error).toMatchObject({message: "fatal token=[REDACTED]"});
+    });
+
+    it("日志写入失败时不会把诊断递归写回断开的 stderr", async () => {
+        const root = await tempLogRoot();
+        const blockedLogPath = path.join(root, "blocked-log");
+        await fs.writeFile(blockedLogPath, "not a directory", "utf8");
+        const epipe = Object.assign(new Error("broken pipe"), {code: "EPIPE"});
+        const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => {
+            throw epipe;
+        });
+        const logger = new AppFileLogger({
+            env: {NEURO_BOOK_LOG_DIR: blockedLogPath} as NodeJS.ProcessEnv,
+        });
+
+        expect(() => logger.fatalSync("process.uncaughtException", undefined, epipe)).not.toThrow();
+        await expect(logger.warn("app.logs.writeFailed")).resolves.toBeUndefined();
+        await expect(logger.flush()).resolves.toBeUndefined();
+        expect(stderrWrite).not.toHaveBeenCalled();
+        stderrWrite.mockRestore();
     });
 
     it("rotates server-current and prunes old server logs", async () => {

--- a/packages/neuro-book/server/app-logs/logger.ts
+++ b/packages/neuro-book/server/app-logs/logger.ts
@@ -213,8 +213,8 @@ export class AppFileLogger {
     fatalSync(event: string, data?: unknown, error?: unknown, message?: string): void {
         try {
             this.appendLineSync(this.formatLine("fatal", event, data, error, message));
-        } catch (writeError) {
-            process.stderr.write(`[app-logs] fatal sync write failed: ${writeError instanceof Error ? writeError.message : String(writeError)}\n`);
+        } catch {
+            // 日志出口本身不可用时必须静默收口；再次写 stderr 会在断管时递归触发 EPIPE。
         }
     }
 
@@ -235,9 +235,7 @@ export class AppFileLogger {
 
     private write(level: AppLogLevel, event: string, data?: unknown, error?: unknown, message?: string): Promise<void> {
         const line = this.formatLine(level, event, data, error, message);
-        const task = this.queue.then(() => this.appendLine(line)).catch((writeError) => {
-            process.stderr.write(`[app-logs] write failed: ${writeError instanceof Error ? writeError.message : String(writeError)}\n`);
-        });
+        const task = this.queue.then(() => this.appendLine(line)).catch(() => undefined);
         this.queue = task.then(() => undefined, () => undefined);
         return task;
     }

--- a/packages/neuro-book/server/plugins/app-logs.test.ts
+++ b/packages/neuro-book/server/plugins/app-logs.test.ts
@@ -1,0 +1,58 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    addReporter: vi.fn(),
+    setReporters: vi.fn(),
+    info: vi.fn(async () => undefined),
+    warn: vi.fn(async () => undefined),
+    error: vi.fn(async () => undefined),
+}));
+
+vi.mock("consola", () => ({
+    consola: {
+        addReporter: mocks.addReporter,
+        setReporters: mocks.setReporters,
+    },
+}));
+vi.mock("nbook/server/app-logs/logger", () => ({
+    appLogger: {
+        info: mocks.info,
+        warn: mocks.warn,
+        error: mocks.error,
+        fatalSync: vi.fn(),
+        logDirectory: "C:/state/logs",
+        currentFilePath: "C:/state/logs/server-current.jsonl",
+    },
+}));
+
+describe("app logs production bridge", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.stubGlobal("defineNitroPlugin", (plugin: unknown) => plugin);
+        vi.stubEnv("NODE_ENV", "production");
+        delete (globalThis as typeof globalThis & {__nbookAppLogsInstalled?: boolean}).__nbookAppLogsInstalled;
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it("production 只安装 JSONL reporter 且不调用原始 console", async () => {
+        const originalWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+        const originalError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+        const plugin = (await import("nbook/server/plugins/app-logs")).default;
+        plugin();
+
+        expect(mocks.setReporters).toHaveBeenCalledOnce();
+        expect(mocks.addReporter).not.toHaveBeenCalled();
+        console.warn("断管警告");
+        console.error("断管错误");
+        await Promise.resolve();
+        expect(originalWarn).not.toHaveBeenCalled();
+        expect(originalError).not.toHaveBeenCalled();
+        expect(mocks.warn).toHaveBeenCalledWith("console.warn", {args: ["断管警告"]}, "断管警告");
+        expect(mocks.error).toHaveBeenCalledWith("console.error", {args: ["断管错误"]}, undefined, "断管错误");
+    });
+});

--- a/packages/neuro-book/server/plugins/app-logs.ts
+++ b/packages/neuro-book/server/plugins/app-logs.ts
@@ -21,26 +21,36 @@ export default defineNitroPlugin(() => {
     }
     globalState.__nbookAppLogsInstalled = true;
 
-    consola.addReporter({
+    const reporter = {
         log(logObject: ConsolaLogObject) {
             const level = resolveConsolaLevel(logObject);
-            void appLogger[level]("consola", {
+            void safeLog(() => appLogger[level]("consola", {
                 type: logObject.type,
                 tag: logObject.tag,
                 args: logObject.args ?? [],
-            });
+            }));
         },
-    });
+    };
+    if (process.env.NODE_ENV === "production") {
+        // Product 的父 stdout/stderr 可能随 supervisor 生命周期关闭；JSONL 是唯一稳定出口。
+        consola.setReporters([reporter]);
+    } else {
+        consola.addReporter(reporter);
+    }
 
     const originalWarn = console.warn.bind(console);
     const originalError = console.error.bind(console);
     console.warn = (...args: unknown[]) => {
-        originalWarn(...args);
-        void appLogger.warn("console.warn", {args}, formatConsoleArgs(args));
+        if (process.env.NODE_ENV !== "production") {
+            originalWarn(...args);
+        }
+        void safeLog(() => appLogger.warn("console.warn", {args}, formatConsoleArgs(args)));
     };
     console.error = (...args: unknown[]) => {
-        originalError(...args);
-        void appLogger.error("console.error", {args}, firstErrorArg(args), formatConsoleArgs(args));
+        if (process.env.NODE_ENV !== "production") {
+            originalError(...args);
+        }
+        void safeLog(() => appLogger.error("console.error", {args}, firstErrorArg(args), formatConsoleArgs(args)));
     };
 
     process.on("unhandledRejection", (reason) => {
@@ -53,12 +63,16 @@ export default defineNitroPlugin(() => {
         appLogger.fatalSync("process.uncaughtException", undefined, error, "Uncaught exception");
     });
 
-    void appLogger.info("app.logs.ready", {
+    void safeLog(() => appLogger.info("app.logs.ready", {
         directory: appLogger.logDirectory,
         currentFile: appLogger.currentFilePath,
         nodeEnv: process.env.NODE_ENV ?? null,
-    });
+    }));
 });
+
+async function safeLog(task: () => Promise<void>): Promise<void> {
+    await Promise.resolve().then(task).catch(() => undefined);
+}
 
 function resolveConsolaLevel(logObject: ConsolaLogObject): "debug" | "info" | "warn" | "error" {
     if (logObject.type === "error" || logObject.type === "fatal") {

--- a/packages/neuro-book/server/runtime/product-command.ts
+++ b/packages/neuro-book/server/runtime/product-command.ts
@@ -20,10 +20,11 @@ async function main(): Promise<void> {
     }
     const imageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
     delete process.env.NODE_PATH;
-    const applicationRoot = process.env.NEURO_BOOK_APPLICATION_ROOT?.trim();
-    if (!applicationRoot) {
+    const applicationRootInput = process.env.NEURO_BOOK_APPLICATION_ROOT?.trim();
+    if (!applicationRootInput) {
         throw new Error("Product Runtime command 缺少 NEURO_BOOK_APPLICATION_ROOT；必须由 Manager、Desktop Envelope 或 CLI wrapper 显式注入。");
     }
+    const applicationRoot = resolve(applicationRootInput);
     const receiptAuthorization = productRuntimeReceiptAuthorizationFromEnvironment(process.env);
     if (receiptAuthorization) {
         await verifyAuthorizedProductRuntimeReceiptControlPlane(imageRoot, applicationRoot, receiptAuthorization);
@@ -37,12 +38,16 @@ async function main(): Promise<void> {
         NEURO_BOOK_APPLICATION_ROOT: applicationRoot,
         NEURO_BOOK_PRODUCT_IMAGE_ROOT: imageRoot,
     };
+    for (const key of ["NEURO_BOOK_STATE_ROOT", "NEURO_BOOK_CACHE_ROOT", "NEURO_BOOK_LOG_DIR"] as const) {
+        const configured = childEnvironment[key]?.trim();
+        if (configured) childEnvironment[key] = resolve(applicationRoot, configured);
+    }
     delete childEnvironment.NODE_PATH;
     if (mode === "check" && id === "all") {
         if (args.length > 0) throw new Error("Product Runtime check all 不接受额外参数。");
         for (const invocation of resolveProductRuntimeChecks(contract)) {
             const entry = resolve(imageRoot, ...invocation.entry.split("/"));
-            const code = await run(entry, invocation.fixedArgs, applicationRoot, childEnvironment);
+            const code = await run(entry, invocation.fixedArgs, applicationRoot, childEnvironment, "inherit");
             if (code !== 0) {
                 process.exitCode = code;
                 return;
@@ -56,17 +61,23 @@ async function main(): Promise<void> {
         : resolveProductRuntimeCheck(contract, id, args);
     const entry = resolve(imageRoot, ...invocation.entry.split("/"));
     const cwd = productRuntimeCwd(mode, id, applicationRoot, process.cwd());
-    const code = await run(entry, invocation.fixedArgs, cwd, childEnvironment);
+    const code = await run(entry, invocation.fixedArgs, cwd, childEnvironment, mode === "command" && id === "start" ? "ignore" : "inherit");
     process.exitCode = code;
 }
 
 /** 使用当前受控 Bun 运行入口，并原样转发 stdio 与退出码。 */
-async function run(entry: string, args: string[], cwd: string, env: NodeJS.ProcessEnv): Promise<number> {
+async function run(
+    entry: string,
+    args: string[],
+    cwd: string,
+    env: NodeJS.ProcessEnv,
+    stdio: "inherit" | "ignore",
+): Promise<number> {
     return await new Promise((resolvePromise, rejectPromise) => {
         const child = spawn(process.execPath, [...PRODUCT_BUN_RUNTIME_ARGS, entry, ...args], {
             cwd,
             env,
-            stdio: "inherit",
+            stdio,
             windowsHide: true,
         });
         const forward = (signal: NodeJS.Signals): void => {

--- a/packages/neuro-book/server/runtime/product-start-command.mjs
+++ b/packages/neuro-book/server/runtime/product-start-command.mjs
@@ -46,7 +46,7 @@ await runInternal(productImageRoot, applicationRoot, productEnv, "prepare-system
 const child = spawn(process.execPath, [...PRODUCT_BUN_RUNTIME_ARGS, entry, ...process.argv.slice(2)], {
     cwd: applicationRoot,
     env: productEnv,
-    stdio: "inherit",
+    stdio: "ignore",
     windowsHide: false,
 });
 let shutdownSignal;
@@ -72,11 +72,12 @@ async function runInternal(imageRoot, applicationRoot, env, id) {
     ], {
         cwd: applicationRoot,
         env,
+        // start 是长驻服务；启动前内部命令也不能继承可能已断开的 supervisor 管道。
+        stdio: "ignore",
     });
 }
 
-child.on("error", (error) => {
-    console.error(error);
+child.on("error", () => {
     process.exit(1);
 });
 
@@ -189,7 +190,7 @@ function run(command, args, options = {}) {
         const child = spawn(command, args, {
             cwd: options.cwd,
             env: options.env ?? process.env,
-            stdio: "inherit",
+            stdio: options.stdio ?? "inherit",
             windowsHide: true,
         });
         child.on("error", rejectPromise);

--- a/scripts/build/product-runtime-contract.test.ts
+++ b/scripts/build/product-runtime-contract.test.ts
@@ -31,4 +31,14 @@ describe("Product 临时验收实例合同", () => {
         expect(start).not.toContain("productRuntimeReady");
         expect(start).toContain("repositoryRoot: applicationRoot");
     });
+
+    it("Product 启动链路不把长驻服务绑定到父 stdout/stderr", async () => {
+        const start = await readFile(resolve(applicationRoot, "server", "runtime", "product-start-command.mjs"), "utf8");
+        const command = await readFile(resolve(applicationRoot, "server", "runtime", "product-command.ts"), "utf8");
+        const runtime = await readFile(resolve("scripts", "deploy", "product-runtime.mjs"), "utf8");
+        expect(start).toContain('stdio: "ignore"');
+        expect(start).toContain('// start 是长驻服务；启动前内部命令也不能继承可能已断开的 supervisor 管道。');
+        expect(command).toContain('mode === "command" && id === "start" ? "ignore" : "inherit"');
+        expect(runtime).toContain('stdio: commandId === "start" ? "ignore" : "inherit"');
+    });
 });

--- a/scripts/deploy/product-runtime.mjs
+++ b/scripts/deploy/product-runtime.mjs
@@ -83,14 +83,14 @@ async function runAcceptedCommand(commandId, args) {
         throw new Error("Product 验收实例 owner 与 Runtime Image identity 不一致。");
     }
 
-    const stateRoot = process.env.NEURO_BOOK_STATE_ROOT?.trim() || "state";
-    if (!process.env.NEURO_BOOK_STATE_ROOT) {
-        await mkdir(resolve(stageRoot, stateRoot), {recursive: true});
+    const configuredStateRoot = process.env.NEURO_BOOK_STATE_ROOT?.trim();
+    const stateRoot = configuredStateRoot ? resolve(stageRoot, configuredStateRoot) : resolve(stageRoot, "state");
+    if (!configuredStateRoot) {
+        await mkdir(stateRoot, {recursive: true});
     }
     await withAcceptanceLease(stageRoot, async () => {
-        const cacheRoot = process.env.NEURO_BOOK_CACHE_ROOT?.trim()
-            ? resolve(process.env.NEURO_BOOK_CACHE_ROOT)
-            : resolve(stageRoot, stateRoot, "cache");
+        const configuredCacheRoot = process.env.NEURO_BOOK_CACHE_ROOT?.trim();
+        const cacheRoot = configuredCacheRoot ? resolve(stageRoot, configuredCacheRoot) : resolve(stateRoot, "cache");
         assertContained(resolve(stageRoot, stateRoot), cacheRoot, "Product Cache Root");
         const excludedRoots = [
             resolve(stageRoot, ".output"),
@@ -114,6 +114,7 @@ async function runAcceptedCommand(commandId, args) {
                 NEURO_BOOK_CACHE_ROOT: cacheRoot,
                 BUN: process.execPath,
             },
+            stdio: commandId === "start" ? "ignore" : "inherit",
         });
         await openVerifiedImage(resolve(stageRoot, ".output"), owner);
         const afterApplicationDigest = await applicationTreeDigest(stageRoot, excludedRoots);
@@ -417,7 +418,7 @@ function run(commandName, args, options) {
         const child = spawn(commandName, args, {
             cwd: options.cwd,
             env: options.env,
-            stdio: "inherit",
+            stdio: options.stdio ?? "inherit",
             windowsHide: false,
         });
         const forwardSignals = ["SIGINT", "SIGTERM"];

--- a/scripts/deploy/product-start.test.ts
+++ b/scripts/deploy/product-start.test.ts
@@ -2,7 +2,7 @@ import {once} from "node:events";
 import {spawn, type ChildProcess} from "node:child_process";
 import {createServer} from "node:http";
 import {existsSync} from "node:fs";
-import {cp, mkdtemp, rm} from "node:fs/promises";
+import {cp, mkdir, mkdtemp, readFile, rm, writeFile} from "node:fs/promises";
 import {randomUUID} from "node:crypto";
 import {join, resolve} from "node:path";
 import {testHostPath} from "@notnotype/neuro-book-test-support/test-path";
@@ -61,6 +61,44 @@ describe("Product start生命周期", () => {
             expect(launcher.exitCode).toBe(0);
         } finally {
             if (launcher.exitCode === null && launcher.signalCode === null) launcher.kill("SIGKILL");
+        }
+    }, 300_000);
+    it("父 stdout/stderr 断开后仍保持 HTTP ready 并可正常 shutdown", async () => {
+        const root = await mkdtemp(testHostPath("nbook-product-stdio-disconnect-"));
+        roots.push(root);
+        const outputRoot = join(root, ".output");
+        const stateRoot = join(root, "state");
+        const productCommandEntry = await createVerifiedProductImage(root, outputRoot);
+        const port = await freeLoopbackPort();
+        const commandEnvironment = createProductEnvironment(root, stateRoot, outputRoot, port);
+        await mkdirStateConfig(stateRoot);
+        await runProductCommand(productCommandEntry, commandEnvironment, "command", "migrate-database");
+        await runProductCommand(productCommandEntry, commandEnvironment, "command", "migrate-application-state", "--apply", "--run-id", "product-stdio-disconnect");
+
+        await runProductCommand(productCommandEntry, commandEnvironment, "command", "workspace", "project", "create", "product-stdio-disconnect", "--title", "Product Stdio Disconnect", "--json");
+
+        const launcher = launchProductWithClosedOutput(productCommandEntry, root, stateRoot, outputRoot, port, "product-stdio-disconnect-shutdown");
+        try {
+            const version = await waitForVersion(port, launcher, () => "");
+            expect(version.versionLabel).toMatch(/^v/u);
+            await assertWorldEngineReadPaths(port, "product-stdio-disconnect");
+            const shutdown = await fetch(`http://127.0.0.1:${port}${PRODUCT_SHUTDOWN_PATH}`, {
+                method: "POST",
+                headers: {authorization: "Bearer product-stdio-disconnect-shutdown"},
+                signal: AbortSignal.timeout(5_000),
+            });
+            expect(shutdown.status).toBe(202);
+            await waitForExit(launcher, () => "");
+            expect(launcher.exitCode).toBe(0);
+            const logText = await readFile(resolve(stateRoot, "logs", "server-current.jsonl"), "utf8");
+            expect(logText).toContain('"event":"app.logs.ready"');
+            expect(logText).not.toContain("EPIPE");
+            expect(logText).not.toContain("process.uncaughtException");
+        } finally {
+            if (launcher.exitCode === null && launcher.signalCode === null) {
+                launcher.kill("SIGKILL");
+                await waitForExit(launcher, () => "").catch(() => undefined);
+            }
         }
     }, 300_000);
 
@@ -138,6 +176,10 @@ function createProductEnvironment(root: string, stateRoot: string, outputRoot: s
         NUXT_SESSION_PASSWORD: "product-start-smoke-session-password",
     };
 }
+async function mkdirStateConfig(stateRoot: string): Promise<void> {
+    await mkdir(stateRoot, {recursive: true});
+    await writeFile(join(stateRoot, "config.yaml"), "auth:\n  enabled: false\n", "utf8");
+}
 
 async function runProductCommand(commandEntry: string, environment: NodeJS.ProcessEnv, mode: "command" | "check", id: string, ...args: string[]): Promise<void> {
     const bunExecutable = process.versions.bun ? process.execPath : process.env.BUN || "bun";
@@ -171,6 +213,27 @@ function launchProduct(
         },
         stdio: ["ignore", "ignore", "pipe"],
     });
+}
+function launchProductWithClosedOutput(
+    commandEntry: string,
+    applicationRoot: string,
+    stateRoot: string,
+    outputRoot: string,
+    port: number,
+    shutdownToken: string,
+): ChildProcess {
+    const bunExecutable = process.versions.bun ? process.execPath : process.env.BUN || "bun";
+    const child = spawn(bunExecutable, [...PRODUCT_BUN_RUNTIME_ARGS, commandEntry, "command", "start"], {
+        cwd: applicationRoot,
+        env: {
+            ...createProductEnvironment(applicationRoot, stateRoot, outputRoot, port),
+            [PRODUCT_SHUTDOWN_TOKEN_ENVIRONMENT]: shutdownToken,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout?.destroy();
+    child.stderr?.destroy();
+    return child;
 }
 async function expectInstalledRuntimeAssets(stateRoot: string): Promise<void> {
     for (const relativePath of [
@@ -227,6 +290,23 @@ async function waitForExit(child: ChildProcess, stderr: () => string): Promise<v
         once(child, "exit").then(() => undefined),
         new Promise<never>((_resolvePromise, rejectPromise) => setTimeout(() => rejectPromise(new Error(`Product launcher 退出超时：${stderr()}`)), 30_000)),
     ]);
+}
+async function assertWorldEngineReadPaths(port: number, projectRoot: string): Promise<void> {
+    const open = await fetch(`http://127.0.0.1:${port}/api/projects/open`, {
+        method: "POST",
+        headers: {"content-type": "application/json"},
+        body: JSON.stringify({projectRoot}),
+        signal: AbortSignal.timeout(10_000),
+    });
+    expect(open.status).toBe(200);
+    await open.arrayBuffer();
+    for (const path of ["schema", "subjects", "slices"] as const) {
+        const response = await fetch(`http://127.0.0.1:${port}/api/projects/world-engine/${path}?projectRoot=${encodeURIComponent(projectRoot)}`, {
+            signal: AbortSignal.timeout(10_000),
+        });
+        expect(response.status).toBe(200);
+        await response.arrayBuffer();
+    }
 }
 
 function isVersionResponse(value: unknown): value is {versionLabel: string} {

--- a/scripts/release/verify-windows-product.ts
+++ b/scripts/release/verify-windows-product.ts
@@ -142,12 +142,14 @@ export async function verifyWindowsProduct(
             ["command", "create-admin", "product-smoke-admin", "--password-stdin"],
             adminPassword,
         );
+        await command(["command", "workspace", "project", "create", "product-smoke", "--title", "Product Smoke", "--json"]);
 
         const launched = launchProduct(bunRuntime, bootstrap, productRoot, environment);
         product = launched.product;
         logs = launched.logs;
         const baseUrl = `http://127.0.0.1:${port}`;
         const version = await waitForVersion(product, `${baseUrl}/api/app/version`, 90_000);
+        await assertHttpWorldEngineReadPaths(baseUrl, "product-smoke");
         await assertHttpProfileCompile(baseUrl, stateRoot);
 
         const wrongToken = await fetch(`${baseUrl}${contract.shutdown.path}`, {
@@ -175,7 +177,6 @@ export async function verifyWindowsProduct(
         }
         await assertPortClosed(`${baseUrl}/api/app/version`);
 
-        await command(["command", "workspace", "project", "create", "product-smoke", "--title", "Product Smoke", "--json"]);
         const projectWorkspaceRoot = join(stateRoot, "workspace", "product-smoke");
         const nodeRoot = join(projectWorkspaceRoot, "manuscript", "smoke-chapter");
         await commandAt(projectWorkspaceRoot, "command", "workspace", "node", "new", "manuscript/smoke-chapter", "--type", "chapter", "--title", "Smoke Chapter");
@@ -198,6 +199,9 @@ export async function verifyWindowsProduct(
                 "migrate-application-state",
                 ...WINDOWS_PRODUCT_RELEASE_CHECKS,
                 "create-admin",
+                "world-engine-http-schema",
+                "world-engine-http-subjects",
+                "world-engine-http-slices",
                 "http-profile-compile-with-hostile-node-path",
                 "invalid-shutdown-token",
                 "authenticated-shutdown",
@@ -222,8 +226,29 @@ export async function verifyWindowsProduct(
         await rm(rootNodeModules, {recursive: true, force: true});
     }
 }
+/** 通过公开 HTTP 入口验证 Product World Engine 的 schema、subjects、slices 仍可用。 */
+async function assertHttpWorldEngineReadPaths(baseUrl: string, projectRoot: string): Promise<void> {
+    const open = await fetch(`${baseUrl}/api/projects/open`, {
+        method: "POST",
+        headers: {"content-type": "application/json"},
+        body: JSON.stringify({projectRoot}),
+        signal: AbortSignal.timeout(10_000),
+    });
+    if (!open.ok) {
+        throw new Error(`Product Project open 失败：status=${open.status} body=${await open.text()}`);
+    }
+    await open.arrayBuffer();
+    for (const path of ["schema", "subjects", "slices"] as const) {
+        const response = await fetch(`${baseUrl}/api/projects/world-engine/${path}?projectRoot=${encodeURIComponent(projectRoot)}`, {
+            signal: AbortSignal.timeout(10_000),
+        });
+        if (!response.ok) {
+            throw new Error(`Product World Engine ${path} 失败：status=${response.status} body=${await response.text()}`);
+        }
+        await response.arrayBuffer();
+    }
+}
 
-/** 通过公开 HTTP 入口验证 Product 只使用镜像内预编译 Profile worker。 */
 async function assertHttpProfileCompile(baseUrl: string, stateRoot: string): Promise<void> {
     const fileName = "release/http-worker.profile.tsx";
     const profileRoot = join(stateRoot, "workspace", ".nbook", "agent", "profiles");


### PR DESCRIPTION
## 关联 Issue / Related issue

Closes #228

## 解决的问题 / Problem

Windows/Bun Product Runtime 的父 shell 或 supervisor 关闭、替换或断开 stdout/stderr 后，consola、console 或 launcher fallback 可能触发 EPIPE，导致 Product 退出并连带 HTTP 与 World Engine 请求失败。

## 本次范围 / Scope

包含 / In scope:

- 将 production 日志主出口固定为 State Root JSONL，避免依赖父 stdout/stderr 生命周期。
- 让日志写入失败、console bridge 失败和 fatal 日志失败安全收口，不递归写入断开的 stderr。
- 让长驻 Product start 及启动前内部步骤使用 `stdio: "ignore"`；一次性 command/check 保留 `stdio: "inherit"`。
- 保留 SIGINT/SIGTERM 转发、退出码、lease、owner、pointer、cleanup 和 containment 语义。
- 增加 Windows/Bun Product 断管及 HTTP/World Engine/shutdown 回归验证。

不包含 / Out of scope:

- World Engine schema/slices 业务逻辑。
- esbuild、proper-lockfile 算法、Issue #123/#225、真实 Provider/Model。
- Release Manifest 伪造，以及远端发布、部署或依赖升级。

## 用户可见结果与实现 / User-visible result and implementation

父 stdout/stderr 管道断开后，Product 仍可启动并提供 HTTP 服务；诊断日志继续写入 State Root JSONL。Product launcher 与 command wrapper 在长驻服务边界隔离不稳定的外部 stdio，同时保留一次性命令的可见输出和既有信号/退出语义。

## 验证 / Verification

实际执行的完整命令和结果 / Exact commands and results:

```text
bun run --cwd packages/neuro-book test -- server/app-logs/logger.test.ts server/plugins/app-logs.test.ts server/runtime/paths/runtime-paths.test.ts server/runtime/installation-paths.test.ts
4 个文件、16 个测试通过

bun x vitest run --config scripts/vitest.config.ts scripts/deploy/product-runtime-cleanup.test.ts
1 个文件、5 个测试通过

bun x vitest run --config scripts/vitest.config.ts scripts/build/proper-lockfile-patch.test.ts --testNamePattern="竞争者在持有期间收到 ELOCKED"
1 个测试通过，12 个跳过

bun run --cwd packages/neuro-book runtime:typecheck
通过

bun run --cwd packages/neuro-book nuxt:build
通过；runtime-image.json 确认 dirty: false

真实 Windows Product verifier
通过；覆盖 Product commands/checks、World Engine HTTP schema/subjects/slices、hostile NODE_PATH、shutdown、端口释放、workspace node、State Root move/delete

真实 Windows Portable restart verifier
通过；覆盖 Manager/Product 启动、浏览器 HTTP smoke、登录、shutdown、端口释放、lease release/reacquire

bun x vitest run --config scripts/vitest.config.ts scripts/release/windows-portable-manager.test.ts
未运行到测试用例；Manager 生成物导入时报既有错误 TypeError: Q9 is not a function，已单独登记 Issue #229
```

未运行的检查及原因 / Checks not run and why:

- 完整 `scripts:typecheck`：仓库既有生成物/类型错误，不属于本 PR 改动。
- 正式 `verify-windows-portable.ts`：本地缺少完整五平台 Release Manifest 和全部 Product archive，未伪造发布身份；真实 Portable restart verifier 已通过。

## 界面证据 / UI evidence

无前端改动。浏览器 HTTP smoke 已在真实 Windows Portable Product 上通过。

## 文档与记录 / Documentation and records

- [x] 已确认本次不需要更新用户文档。
- [x] 已更新或确认不需要更新 Task walkthrough。
- [x] 已确认不需要更新 Reference、ADR 与 `PROJECT-STATUS.md`。
- [x] 已链接 Issue #228；本 PR 不改变 World Engine 行为合同。
- [x] 本 PR 不修改版本号或 `RELEASE.md`。

## 风险与边界 / Risks and boundaries

- 数据结构或迁移 / Data shape or migration: 不改变数据结构；使用既有 migration/preflight 流程。
- 配置、安装或发布 / Configuration, installation, or release: 仅调整 Product Runtime 的 stdio 生命周期；正式 Portable provenance 受独立 Issue #229 的 Manager bundle 导入错误影响。
- 安全与隐私 / Security and privacy: 不新增凭据、外部 Provider 或数据出口；继续使用既有 identity、containment 和认证 shutdown 校验。
- 已知限制与后续事项 / Known limitations and follow-ups: Issue #229 跟踪 `@notnotype/neuro-book-manager/installation` clean minified bundle 的 `TypeError: Q9 is not a function`。

## 提交者确认 / Contributor confirmation

- [x] 一个连贯目标之外没有夹带其它改动。
- [x] 我已审查并能解释全部改动，包括开发 Agent 生成的内容。
- [x] 验证结果真实，聚焦测试没有被描述成全量测试。
- [x] 日志、截图和 fixture 不含密钥、小说正文、私人会话或未授权内容。